### PR TITLE
mdoc: Failing to load an assembly is no longer a fatal error.

### DIFF
--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -272,6 +272,13 @@ check-monodocer-delete:
 	$(MONO) $(PROGRAM) --debug update -fno-assembly-versions --delete --exceptions=all -o Test/en.actual Test/DocTest.dll
 	$(DIFF) Test/en.expected.delete Test/en.actual
 
+check-monodocer-ignore-invalid-assemblies: Test/DocTest-addNonGeneric.dll Test/DocTest-addNonGeneric-v2.dll
+	-rm -Rf Test/en.actual
+	touch Test/notActuallyA.dll
+	$(MONO) $(PROGRAM) --debug update -o Test/en.actual Test/DocTest-addNonGeneric.dll Test/notActuallyA.dll
+	$(MONO) $(PROGRAM) --debug update -o Test/en.actual Test/DocTest-addNonGeneric-v2.dll Test/notActuallyA.dll
+	$(DIFF) Test/en.expected-addNonGeneric Test/en.actual
+
 check-monodocer-importslashdoc-update: 
 	find Test/en.expected.importslashdoc -name \*.xml -exec rm "{}" \;
 	$(MAKE) Test/DocTest.dll-v1 TEST_CSCFLAGS=-doc:Test/DocTest.xml
@@ -377,6 +384,8 @@ check-doc-tools: check-monodocer-since \
 	check-monodocer-dropns-classic-withsecondary \
 	check-monodocer-dropns-delete \
 	check-monodocer-internal-interface \
+	check-monodocer-addNonGeneric \
+	check-monodocer-ignore-invalid-assemblies \
 	check-monodocer-enumerations \
 	check-monodocer-dropns-multi \
 	check-monodocer-dropns-multi-withexisting

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -320,8 +320,11 @@ class MDocUpdater : MDocCommand
 		if (srcPath == null)
 			throw new InvalidOperationException("The --out option is required.");
 		
-		this.assemblies = assemblies.Select (a => LoadAssembly (a)).ToList ();
-
+		this.assemblies = assemblies.Select (a => LoadAssembly (a)).Where(a => a != null).ToList ();
+		
+		if (assemblies.Count == 0)
+			Error ("No valid assemblies specified.");
+			
 		// Store types that have been forwarded to avoid duplicate generation
 		GatherForwardedTypes ();
 
@@ -408,10 +411,10 @@ class MDocUpdater : MDocCommand
 		AssemblyDefinition assembly = null;
 		try {
 			assembly = AssemblyDefinition.ReadAssembly (name, new ReaderParameters { AssemblyResolver = assemblyResolver });
-		} catch (System.IO.FileNotFoundException) { }
-
-		if (assembly == null)
-			throw new InvalidOperationException("Assembly " + name + " not found.");
+		} 
+		catch (Exception ex) {
+			Warning ($"Unable to load assembly '{name}': {ex.Message}");
+		}
 
 		return assembly;
 	}

--- a/mdoc/Test/en.expected-addNonGeneric/MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-addNonGeneric/MyNamespace/MyClass.xml
@@ -1,0 +1,73 @@
+<Type Name="MyClass" FullName="MyNamespace.MyClass">
+  <TypeSignature Language="C#" Value="public class MyClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyClass extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-addNonGeneric</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-addNonGeneric-v2</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SomeMethod">
+      <MemberSignature Language="C#" Value="public string SomeMethod ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance string SomeMethod() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SomeMethod&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public string SomeMethod&lt;T&gt; ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance string SomeMethod&lt;T&gt;() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters />
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-addNonGeneric/index.xml
+++ b/mdoc/Test/en.expected-addNonGeneric/index.xml
@@ -1,0 +1,22 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="DocTest-addNonGeneric-v2" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="MyNamespace">
+      <Type Name="MyClass" Kind="Class" />
+    </Namespace>
+  </Types>
+  <Title>DocTest-addNonGeneric</Title>
+</Overview>

--- a/mdoc/Test/en.expected-addNonGeneric/ns-MyNamespace.xml
+++ b/mdoc/Test/en.expected-addNonGeneric/ns-MyNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>


### PR DESCRIPTION
In some cases, for example when running in "frameworks" mode (ie. https://github.com/mono/api-doc-tools/pull/18), you might have non-managed .dlls in the directory. This change allows mdoc to simply write the fact that it couldn't load the assembly, and continue doing work.
Resolves #7
Provices a temporary workaround for #8, #9