### PR TITLE
Support for differing inheritance chains in multiple frameworks

### DIFF
--- a/mdoc/.gitignore
+++ b/mdoc/.gitignore
@@ -2,6 +2,6 @@
 /Test/html.*/
 /Test/DocTest.*
 /Test/*.dll*
-/Test/FrameworkTestData/
+/Test/FrameworkTestData*
 /.v2.txt
 /.v0.txt

--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -4,6 +4,6 @@ namespace Mono.Documentation
 	public static class Consts
 	{
 		// this is only a placeholder
-		public static string MonoVersion = "5.0.0.6";
+		public static string MonoVersion = "5.0.0.7";
 	}
 }

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -102,6 +102,12 @@ Test/DocTest.dll:
 Test/DocTest-InternalInterface.dll: 
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-InternalInterface.cs
 
+Test/DocTest-framework-inheritance-one.dll:
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-framework-inheritance.cs /define:FXONE
+
+Test/DocTest-framework-inheritance-two.dll:
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-framework-inheritance.cs /define:FXTWO
+
 Test/DocTest.dll-v1: 
 	-rm -f Test/DocTest.cs
 	cp Test/DocTest-v1.cs Test/DocTest.cs
@@ -129,10 +135,24 @@ Test/FrameworkTestData: Test/DocTest-addNonGeneric.dll Test/DocTest-DropNS-class
 	cp Test/DocTest-DropNS-classic-secondary.dll Test/FrameworkTestData/Two/
 	$(MONO) $(PROGRAM) fx-bootstrap Test/FrameworkTestData
 
+Test/FrameworkTestData-fx-inheritance: Test/DocTest-framework-inheritance-one.dll Test/DocTest-framework-inheritance-two.dll
+	rm -rf Test/FrameworkTestData-fx-inheritance
+	mkdir Test/FrameworkTestData-fx-inheritance
+	mkdir Test/FrameworkTestData-fx-inheritance/One
+	mkdir Test/FrameworkTestData-fx-inheritance/Two
+	cp Test/DocTest-framework-inheritance-one.dll Test/FrameworkTestData-fx-inheritance/One/
+	cp Test/DocTest-framework-inheritance-two.dll Test/FrameworkTestData-fx-inheritance/Two/
+	$(MONO) $(PROGRAM) fx-bootstrap Test/FrameworkTestData-fx-inheritance
+
 check-monodocer-frameworks: Test/FrameworkTestData
 	-rm -Rf Test/en.actual
 	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/FrameworkTestData
 	$(DIFF) Test/en.expected-frameworks Test/en.actual
+
+check-monodocer-frameworks-inheritance: Test/FrameworkTestData-fx-inheritance
+	-rm -Rf Test/en.actual
+	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/FrameworkTestData-fx-inheritance
+	$(DIFF) Test/en.expected-frameworks-inheritance Test/en.actual
 
 check-monodocer-docid: Test/FrameworkTestData
 	-rm -Rf Test/en.actual
@@ -419,6 +439,7 @@ check-doc-tools: check-monodocer-since \
 	check-monodocer-dropns-multi \
 	check-monodocer-dropns-multi-withexisting \
 	check-monodocer-frameworks \
+	check-monodocer-frameworks-inheritance \
 	check-monodocer-docid
 
 check-doc-tools-update: check-monodocer-since-update \

--- a/mdoc/Mono.Documentation/Frameworks/FrameworkTypeEntry.cs
+++ b/mdoc/Mono.Documentation/Frameworks/FrameworkTypeEntry.cs
@@ -20,6 +20,7 @@ namespace Mono.Documentation
 		public string Id { get; set; }
 		public string Name { get; set; }
 		public string Namespace { get; set; }
+		public FrameworkEntry Framework { get { return fx; } }
 
 		public ISet<string> Members {
 			get {

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -1191,7 +1191,7 @@ class MDocUpdater : MDocCommand
 		StringToXmlNodeMap seenmembers = new StringToXmlNodeMap ();
 
 		// Update type metadata
-		UpdateType(basefile.DocumentElement, type);
+		UpdateType(basefile.DocumentElement, type, typeEntry);
 
 		// Update existing members.  Delete member nodes that no longer should be there,
 		// and remember what members are already documented so we don't add them again.
@@ -1561,7 +1561,7 @@ class MDocUpdater : MDocCommand
 	
 	// STUBBING/UPDATING FUNCTIONS
 	
-	public void UpdateType (XmlElement root, TypeDefinition type)
+	public void UpdateType (XmlElement root, TypeDefinition type, FrameworkTypeEntry typeEntry)
 	{
 		root.SetAttribute("Name", GetDocTypeName (type));
 		root.SetAttribute("FullName", GetDocTypeFullName (type));
@@ -1625,7 +1625,27 @@ class MDocUpdater : MDocCommand
 			
 			string basetypename = GetDocTypeFullName (type.BaseType);
 			if (basetypename == "System.MulticastDelegate") basetypename = "System.Delegate";
-			WriteElementText(root, "Base/BaseTypeName", basetypename);
+
+			if (string.IsNullOrWhiteSpace (FrameworksPath))
+				WriteElementText (root, "Base/BaseTypeName", basetypename);
+			else {
+				// Check for the possibility of an alternate inheritance chain in different frameworks
+				var typeElements = basenode.GetElementsByTagName ("BaseTypeName");
+
+				if (typeElements.Count == 0) // no existing elements, just add
+					WriteElementText (root, "Base/BaseTypeName", basetypename);
+				else {
+					// There's already a BaseTypeName, see if it matches
+					if (typeElements[0].InnerText != basetypename) {
+						// Add a framework alternate if one doesn't already exist
+						var existing = typeElements.Cast<XmlNode> ().Where (n => n.InnerText == basetypename);
+						if (!existing.Any ()) {
+							var newNode = WriteElementText (basenode, "BaseTypeName", basetypename, forceNewElement:true);
+							WriteElementAttribute (basenode, newNode, "FrameworkAlternate", typeEntry.Framework.Name);
+						}
+					}
+				}
+			}
 			
 			// Document how this type instantiates the generic parameters of its base type
 			TypeReference origBase = type.BaseType.GetElementType ();

--- a/mdoc/Test/DocTest-framework-inheritance.cs
+++ b/mdoc/Test/DocTest-framework-inheritance.cs
@@ -1,0 +1,13 @@
+namespace MyNamespace {
+	public abstract class MyBaseClassOne {}
+    public abstract class MyBaseClassTwo {}
+
+    public class MyClass
+    #if FXONE
+        : MyBaseClassOne
+    #endif
+    #if FXTWO
+        : MyBaseClassTwo
+    #endif
+    {}
+}

--- a/mdoc/Test/en.expected-frameworks-inheritance/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/FrameworksIndex/One.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework Name="One">
+  <Namespace Name="MyNamespace">
+    <Type Name="MyNamespace.MyBaseClassOne" Id="T:MyNamespace.MyBaseClassOne">
+      <Member Id="M:MyNamespace.MyBaseClassOne.#ctor" />
+    </Type>
+    <Type Name="MyNamespace.MyBaseClassTwo" Id="T:MyNamespace.MyBaseClassTwo">
+      <Member Id="M:MyNamespace.MyBaseClassTwo.#ctor" />
+    </Type>
+    <Type Name="MyNamespace.MyClass" Id="T:MyNamespace.MyClass">
+      <Member Id="M:MyNamespace.MyClass.#ctor" />
+    </Type>
+  </Namespace>
+</Framework>

--- a/mdoc/Test/en.expected-frameworks-inheritance/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/FrameworksIndex/Two.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework Name="Two">
+  <Namespace Name="MyNamespace">
+    <Type Name="MyNamespace.MyBaseClassOne" Id="T:MyNamespace.MyBaseClassOne">
+      <Member Id="M:MyNamespace.MyBaseClassOne.#ctor" />
+    </Type>
+    <Type Name="MyNamespace.MyBaseClassTwo" Id="T:MyNamespace.MyBaseClassTwo">
+      <Member Id="M:MyNamespace.MyBaseClassTwo.#ctor" />
+    </Type>
+    <Type Name="MyNamespace.MyClass" Id="T:MyNamespace.MyClass">
+      <Member Id="M:MyNamespace.MyClass.#ctor" />
+    </Type>
+  </Namespace>
+</Framework>

--- a/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyBaseClassOne.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyBaseClassOne.xml
@@ -1,0 +1,40 @@
+<Type Name="MyBaseClassOne" FullName="MyNamespace.MyBaseClassOne">
+  <TypeSignature Language="C#" Value="public abstract class MyBaseClassOne" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract beforefieldinit MyBaseClassOne extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="protected MyBaseClassOne ();" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyBaseClassTwo.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyBaseClassTwo.xml
@@ -1,0 +1,40 @@
+<Type Name="MyBaseClassTwo" FullName="MyNamespace.MyBaseClassTwo">
+  <TypeSignature Language="C#" Value="public abstract class MyBaseClassTwo" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract beforefieldinit MyBaseClassTwo extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="protected MyBaseClassTwo ();" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyClass.xml
@@ -1,0 +1,41 @@
+<Type Name="MyClass" FullName="MyNamespace.MyClass">
+  <TypeSignature Language="C#" Value="public class MyClass : MyNamespace.MyBaseClassTwo" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyClass extends MyNamespace.MyBaseClassTwo" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>MyNamespace.MyBaseClassOne</BaseTypeName>
+    <BaseTypeName FrameworkAlternate="Two">MyNamespace.MyBaseClassTwo</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-frameworks-inheritance/index.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/index.xml
@@ -1,0 +1,34 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="DocTest-framework-inheritance-one" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+    <Assembly Name="DocTest-framework-inheritance-two" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="MyNamespace">
+      <Type Name="MyBaseClassOne" Kind="Class" />
+      <Type Name="MyBaseClassTwo" Kind="Class" />
+      <Type Name="MyClass" Kind="Class" />
+    </Namespace>
+  </Types>
+  <Title>Untitled</Title>
+</Overview>

--- a/mdoc/Test/en.expected-frameworks-inheritance/ns-MyNamespace.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/ns-MyNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>


### PR DESCRIPTION
When a class has a different inheritance chain in two different frameworks, the changes in this PR will support that by adding a `FrameworkAlternate` parameter to the `BaseTypeName` node for the alternate parameter.

```xml
  <Base>
    <BaseTypeName>MyNamespace.MyBaseClassOne</BaseTypeName>
    <BaseTypeName FrameworkAlternate="Two">MyNamespace.MyBaseClassTwo</BaseTypeName>
  </Base>
```

Per Issue #16 