### PR TITLE
mdoc: Added MemberGroup as valid element

### DIFF
--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -152,6 +152,13 @@ check-monodocer-addNonGeneric:
 	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-addNonGeneric-v2.dll
 	$(DIFF) Test/en.expected-addNonGeneric Test/en.actual
 
+check-monodocer-membergroup: Test/DocTest-addNonGeneric-v2.dll Test/DocTest-addNonGeneric.dll
+	-rm -Rf Test/en.actual
+	cp -r Test/en.expected-membergroup Test/en.actual
+	$(MONO) $(PROGRAM) update --debug --exceptions=all -o Test/en.actual Test/DocTest-addNonGeneric-v2.dll
+	$(DIFF) Test/en.expected-membergroup Test/en.actual
+	$(MONO) $(PROGRAM) validate -f ecma Test/en.actual
+
 check-monodocer-dropns-classic: 
 	# tests the simplest --dropns case, a single class where the root namespace was dropped.
 	-rm -Rf Test/en.actual
@@ -414,6 +421,7 @@ check-doc-tools: check-monodocer-since \
 	check-monodocer-dropns-delete \
 	check-monodocer-internal-interface \
 	check-monodocer-addNonGeneric \
+	check-monodocer-membergroup \
 	check-monodocer-ignore-invalid-assemblies \
 	check-monodocer-enumerations \
 	check-monodocer-dropns-multi \

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -1466,6 +1466,17 @@ class MDocUpdater : MDocCommand
 			if ((r = xMemberName.CompareTo (yMemberName)) != 0)
 				return r;
 
+			// Handle MemberGroup sorting
+			var sc = StringComparison.InvariantCultureIgnoreCase;
+			if (x.Name.Equals ("MemberGroup", sc) || y.Name.Equals ("MemberGroup", sc)) {
+				if (x.Name.Equals ("MemberGroup", sc) && y.Name.Equals ("Member", sc))
+					return -1;
+				else if (x.Name.Equals ("Member", sc) && y.Name.Equals ("MemberGroup", sc))
+					return 1;
+				else
+					return xMemberName.CompareTo (yMemberName);
+			}
+
 			// if @MemberName matches, then it's either two different types of
 			// members sharing the same name, e.g. field & property, or it's an
 			// overloaded method.
@@ -1519,7 +1530,7 @@ class MDocUpdater : MDocCommand
 	{
 		if (members == null)
 			return;
-		SortXmlNodes (members, members.SelectNodes ("Member"), DefaultMemberComparer);
+		SortXmlNodes (members, members.SelectNodes ("Member|MemberGroup"), DefaultMemberComparer);
 	}
 	
 	private static bool MemberDocsHaveUserContent (XmlNode e)

--- a/mdoc/Resources/monodoc-ecma.xsd
+++ b/mdoc/Resources/monodoc-ecma.xsd
@@ -481,11 +481,22 @@ add masterdoc support?
     </xs:complexType>
   </xs:element>
 
+  <xs:element name="MemberGroup">
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="AssemblyInfo" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="Docs" minOccurs="0" maxOccurs="1" />
+      </xs:choice>
+      <xs:attribute ref="MemberName" />
+    </xs:complexType>
+  </xs:element>
+
   <xs:element name="Members">
     <xs:complexType>
-      <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="MemberGroup" minOccurs="0" maxOccurs="unbounded" />
         <xs:element ref="Member" minOccurs="0" maxOccurs="unbounded" />
-      </xs:sequence>
+      </xs:choice>
     </xs:complexType>
   </xs:element>
 

--- a/mdoc/Test/en.expected-membergroup/MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-membergroup/MyNamespace/MyClass.xml
@@ -1,0 +1,82 @@
+<Type Name="MyClass" FullName="MyNamespace.MyClass">
+  <TypeSignature Language="C#" Value="public class MyClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyClass extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-addNonGeneric</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-addNonGeneric-v2</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <MemberGroup MemberName="SomeMethod">
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Docs>
+        <remarks>To be added.</remarks>
+        <summary>To be added.</summary>
+      </Docs>
+    </MemberGroup>
+    <Member MemberName="SomeMethod">
+      <MemberSignature Language="C#" Value="public string SomeMethod ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance string SomeMethod() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SomeMethod&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public string SomeMethod&lt;T&gt; ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance string SomeMethod&lt;T&gt;() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters />
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-membergroup/index.xml
+++ b/mdoc/Test/en.expected-membergroup/index.xml
@@ -1,0 +1,22 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="DocTest-addNonGeneric-v2" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="MyNamespace">
+      <Type Name="MyClass" Kind="Class" />
+    </Namespace>
+  </Types>
+  <Title>DocTest-addNonGeneric</Title>
+</Overview>

--- a/mdoc/Test/en.expected-membergroup/ns-MyNamespace.xml
+++ b/mdoc/Test/en.expected-membergroup/ns-MyNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>


### PR DESCRIPTION
A MemberGroup can be intermixed amongst the other Member nodes.
It will be sorted to be in front of the other similarly named Members.
It must contain a MemberName attribute, and can have: summary, remarks, and AssemblyInfo nodes.

```xml

    <MemberGroup MemberName="SomeMethod">
      <AssemblyInfo>
        <AssemblyVersion>0.0.0.0</AssemblyVersion>
      </AssemblyInfo>
      <Docs>
        <remarks>To be added.</remarks>
        <summary>To be added.</summary>
      </Docs>
    </MemberGroup>
```

Resolves #35