### PR TITLE
mdoc: special characters in attributes are now filtered.

### DIFF
--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -2511,6 +2511,41 @@ class MDocUpdater : MDocCommand
 		"System.Runtime.CompilerServices.DynamicAttribute",
 	};
 
+	private IEnumerable<char> FilterSpecialChars (string value)
+	{
+		foreach (char c in value) {
+			switch (c) {
+				case '\0':
+					yield return '\\';
+					yield return '0';
+					break;
+				case '\t':
+					yield return '\\';
+					yield return 't';
+					break;
+				case '\n':
+					yield return '\\';
+					yield return 'n';
+					break;
+				case '\r':
+					yield return '\\';
+					yield return 'r';
+					break;
+				case '\f':
+					yield return '\\';
+					yield return 'f';
+					break;
+				case '\b':
+					yield return '\\';
+					yield return 'b';
+					break;
+				default:
+					yield return c;
+					break;
+			}
+		}
+	}
+
 	private void MakeAttributes (XmlElement root, IEnumerable<string> attributes, TypeReference t=null)
 	{
 		if (!attributes.Any ()) {
@@ -2524,11 +2559,12 @@ class MDocUpdater : MDocCommand
 		else if (e == null)
 			e = root.OwnerDocument.CreateElement("Attributes");
 		
+
 		foreach (string attribute in attributes) {
 			XmlElement ae = root.OwnerDocument.CreateElement("Attribute");
 			e.AppendChild(ae);
-			
-			WriteElementText(ae, "AttributeName", attribute);
+			var value = new String (FilterSpecialChars (attribute).ToArray ());
+			WriteElementText(ae, "AttributeName", value);
 		}
 		
 		if (e.ParentNode == null)

--- a/mdoc/Test/DocTest-InternalInterface.cs
+++ b/mdoc/Test/DocTest-InternalInterface.cs
@@ -7,6 +7,7 @@ namespace MyNamespace {
 	}
 
 	public class MyClass : MyInternalInterface {
+		[System.ComponentModel.DefaultValue ('\0')]
 		public string Bar {get;set;}
 		public void BarMeth () {} // part of the interface, but publicly implemented
 

--- a/mdoc/Test/en.expected-internal-interface/MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-internal-interface/MyNamespace/MyClass.xml
@@ -34,6 +34,11 @@
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.ComponentModel.DefaultValue('\0')</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.String</ReturnType>
       </ReturnValue>


### PR DESCRIPTION
Fixes #32, which was an issue with the ascii null character. It caused the resulting XML to be
malformed. So instead of being written as `&#x0;`, it will now be written as `\0`. All the characters being filtered in attributes are:

- \0
- \t
- \n
- \r
- \f
- \b