### PR TITLE
mdoc: Resolves issue in fx mode with overridden members.

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -4,6 +4,6 @@ namespace Mono.Documentation
 	public static class Consts
 	{
 		// this is only a placeholder
-		public static string MonoVersion = "5.0.0.7";
+		public static string MonoVersion = "5.0.0.8";
 	}
 }

--- a/mdoc/Mono.Documentation/Frameworks/FrameworkEntry.cs
+++ b/mdoc/Mono.Documentation/Frameworks/FrameworkEntry.cs
@@ -10,9 +10,20 @@ namespace Mono.Documentation
 	{
 		SortedSet<FrameworkTypeEntry> types = new SortedSet<FrameworkTypeEntry> ();
 
+		List<FrameworkEntry> allframeworks;
+
+		public FrameworkEntry (List<FrameworkEntry> frameworks)
+		{
+			allframeworks = frameworks;
+			if (allframeworks == null)
+				allframeworks = new List<FrameworkEntry> (0);
+		}
+
 		public string Name { get; set; }
 
 		public ISet<FrameworkTypeEntry> Types { get { return this.types; } }
+
+		public IEnumerable<FrameworkEntry> Frameworks { get { return this.allframeworks; } }
 
 		public static readonly FrameworkEntry Empty = new EmptyFrameworkEntry () { Name = "Empty" };
 
@@ -32,6 +43,7 @@ namespace Mono.Documentation
 
 		class EmptyFrameworkEntry : FrameworkEntry
 		{
+			public EmptyFrameworkEntry () : base (null) { }
 			public override FrameworkTypeEntry ProcessType (TypeDefinition type) { return FrameworkTypeEntry.Empty; }
 		}
 	}

--- a/mdoc/Mono.Documentation/Frameworks/FrameworkIndex.cs
+++ b/mdoc/Mono.Documentation/Frameworks/FrameworkIndex.cs
@@ -40,7 +40,7 @@ namespace Mono.Documentation
 
 			var entry = frameworks.FirstOrDefault (f => f.Name.Equals (shortPath));
 			if (entry == null) {
-				entry = new FrameworkEntry { Name = shortPath };
+				entry = new FrameworkEntry (frameworks) { Name = shortPath };
 				frameworks.Add (entry);
 			}
 			return entry;

--- a/mdoc/Mono.Documentation/Frameworks/FrameworkTypeEntry.cs
+++ b/mdoc/Mono.Documentation/Frameworks/FrameworkTypeEntry.cs
@@ -10,7 +10,7 @@ namespace Mono.Documentation
 		SortedSet<string> members = new SortedSet<string> ();
 		SortedSet<string> memberscsharpsig = new SortedSet<string> ();
 
-		CSharpFullMemberFormatter formatter = new CSharpFullMemberFormatter ();
+		ILMemberFormatter formatter = new ILMemberFormatter ();
 
 		FrameworkEntry fx;
 

--- a/mdoc/Mono.Documentation/Frameworks/FrameworkTypeEntry.cs
+++ b/mdoc/Mono.Documentation/Frameworks/FrameworkTypeEntry.cs
@@ -8,6 +8,10 @@ namespace Mono.Documentation
 	class FrameworkTypeEntry : IComparable<FrameworkTypeEntry>
 	{
 		SortedSet<string> members = new SortedSet<string> ();
+		SortedSet<string> memberscsharpsig = new SortedSet<string> ();
+
+		CSharpFullMemberFormatter formatter = new CSharpFullMemberFormatter ();
+
 		FrameworkEntry fx;
 
 		public static FrameworkTypeEntry Empty = new EmptyTypeEntry (FrameworkEntry.Empty) { Name = "Empty" };
@@ -37,6 +41,14 @@ namespace Mono.Documentation
 			}
 			else 
 				members.Add (member.FullName);
+
+			// this is for lookup purposes
+			memberscsharpsig.Add(formatter.GetDeclaration (member));
+		}
+
+		public bool ContainsCSharpSig (string sig)
+		{
+			return memberscsharpsig.Contains (sig);
 		}
 
 		public override string ToString () => $"{this.Name} in {this.fx.Name}";
@@ -47,6 +59,13 @@ namespace Mono.Documentation
 			if (this.Name == null) return 1;
 
 			return string.Compare (this.Name, other.Name, StringComparison.CurrentCulture);
+		}
+
+		public override bool Equals (object obj)
+		{
+			FrameworkTypeEntry other = obj as FrameworkTypeEntry;
+			if (other == null) return false;
+			return this.Name.Equals (other.Name);
 		}
 
 		class EmptyTypeEntry : FrameworkTypeEntry

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -1220,6 +1220,20 @@ class MDocUpdater : MDocCommand
 			
 			// Deleted (or signature changed)
 			if (oldmember2 == null) {
+				if (!string.IsNullOrWhiteSpace (FrameworksPath)) {
+					// verify that this member wasn't seen in another framework and is indeed valid
+					var sigFromXml = oldmember
+						.GetElementsByTagName ("MemberSignature")
+						.Cast<XmlElement> ()
+						.FirstOrDefault (x => x.GetAttribute ("Language").Equals ("C#"));
+
+					if (sigFromXml != null) {
+						var sigvalue = sigFromXml.GetAttribute ("Value");
+						if (typeEntry.Framework.Frameworks.Any (fx => fx.Types.Any (t => t.Equals(typeEntry) && t.ContainsCSharpSig (sigvalue))))
+							continue;
+					}
+				}
+
 				if (!no_assembly_versions && UpdateAssemblyVersions (oldmember, type.Module.Assembly, new string[]{ GetAssemblyVersion (type.Module.Assembly) }, false))
 					continue;
 

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -1225,7 +1225,7 @@ class MDocUpdater : MDocCommand
 					var sigFromXml = oldmember
 						.GetElementsByTagName ("MemberSignature")
 						.Cast<XmlElement> ()
-						.FirstOrDefault (x => x.GetAttribute ("Language").Equals ("C#"));
+						.FirstOrDefault (x => x.GetAttribute ("Language").Equals ("ILAsm"));
 
 					if (sigFromXml != null) {
 						var sigvalue = sigFromXml.GetAttribute ("Value");

--- a/mdoc/Test/DocTest-framework-inheritance.cs
+++ b/mdoc/Test/DocTest-framework-inheritance.cs
@@ -1,6 +1,15 @@
 namespace MyNamespace {
-	public abstract class MyBaseClassOne {}
-    public abstract class MyBaseClassTwo {}
+    public abstract class MyBaseClassOne 
+    {
+        public virtual string AllVirtual {get;}
+        public abstract void AllAbstract();
+    }
+    public abstract class MyBaseClassTwo 
+    {
+        public string TwoMember {get;}
+        public virtual string AllVirtual {get;}
+        public abstract void AllAbstract();
+    }
 
     public class MyClass
     #if FXONE
@@ -9,5 +18,11 @@ namespace MyNamespace {
     #if FXTWO
         : MyBaseClassTwo
     #endif
-    {}
+    {
+        public override void AllAbstract() {}
+
+    #if FXONE
+        public override string AllVirtual { get { return ""; } }
+    #endif
+    }
 }

--- a/mdoc/Test/en.expected-frameworks-inheritance/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/FrameworksIndex/One.xml
@@ -3,12 +3,19 @@
   <Namespace Name="MyNamespace">
     <Type Name="MyNamespace.MyBaseClassOne" Id="T:MyNamespace.MyBaseClassOne">
       <Member Id="M:MyNamespace.MyBaseClassOne.#ctor" />
+      <Member Id="M:MyNamespace.MyBaseClassOne.AllAbstract" />
+      <Member Id="P:MyNamespace.MyBaseClassOne.AllVirtual" />
     </Type>
     <Type Name="MyNamespace.MyBaseClassTwo" Id="T:MyNamespace.MyBaseClassTwo">
       <Member Id="M:MyNamespace.MyBaseClassTwo.#ctor" />
+      <Member Id="M:MyNamespace.MyBaseClassTwo.AllAbstract" />
+      <Member Id="P:MyNamespace.MyBaseClassTwo.AllVirtual" />
+      <Member Id="P:MyNamespace.MyBaseClassTwo.TwoMember" />
     </Type>
     <Type Name="MyNamespace.MyClass" Id="T:MyNamespace.MyClass">
       <Member Id="M:MyNamespace.MyClass.#ctor" />
+      <Member Id="M:MyNamespace.MyClass.AllAbstract" />
+      <Member Id="P:MyNamespace.MyClass.AllVirtual" />
     </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-frameworks-inheritance/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/FrameworksIndex/Two.xml
@@ -3,12 +3,18 @@
   <Namespace Name="MyNamespace">
     <Type Name="MyNamespace.MyBaseClassOne" Id="T:MyNamespace.MyBaseClassOne">
       <Member Id="M:MyNamespace.MyBaseClassOne.#ctor" />
+      <Member Id="M:MyNamespace.MyBaseClassOne.AllAbstract" />
+      <Member Id="P:MyNamespace.MyBaseClassOne.AllVirtual" />
     </Type>
     <Type Name="MyNamespace.MyBaseClassTwo" Id="T:MyNamespace.MyBaseClassTwo">
       <Member Id="M:MyNamespace.MyBaseClassTwo.#ctor" />
+      <Member Id="M:MyNamespace.MyBaseClassTwo.AllAbstract" />
+      <Member Id="P:MyNamespace.MyBaseClassTwo.AllVirtual" />
+      <Member Id="P:MyNamespace.MyBaseClassTwo.TwoMember" />
     </Type>
     <Type Name="MyNamespace.MyClass" Id="T:MyNamespace.MyClass">
       <Member Id="M:MyNamespace.MyClass.#ctor" />
+      <Member Id="M:MyNamespace.MyClass.AllAbstract" />
     </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyBaseClassOne.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyBaseClassOne.xml
@@ -36,5 +36,47 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="AllAbstract">
+      <MemberSignature Language="C#" Value="public abstract void AllAbstract ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void AllAbstract() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AllVirtual">
+      <MemberSignature Language="C#" Value="public virtual string AllVirtual { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string AllVirtual" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>

--- a/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyBaseClassTwo.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyBaseClassTwo.xml
@@ -36,5 +36,68 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="AllAbstract">
+      <MemberSignature Language="C#" Value="public abstract void AllAbstract ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void AllAbstract() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AllVirtual">
+      <MemberSignature Language="C#" Value="public virtual string AllVirtual { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string AllVirtual" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TwoMember">
+      <MemberSignature Language="C#" Value="public string TwoMember { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string TwoMember" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>

--- a/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/MyNamespace/MyClass.xml
@@ -37,5 +37,43 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="AllAbstract">
+      <MemberSignature Language="C#" Value="public override void AllAbstract ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig virtual instance void AllAbstract() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AllVirtual">
+      <MemberSignature Language="C#" Value="public override string AllVirtual { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string AllVirtual" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-framework-inheritance-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
   </Members>
 </Type>


### PR DESCRIPTION
When a type overrides a member in one framework, but does not in another framework
processed after the first, the Member node was being removed, even though the entry
remained in teh first framework index file. This Resolves #39