### PR TITLE
mdoc: Extension method comparison improved.

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -4,6 +4,6 @@ namespace Mono.Documentation
 	public static class Consts
 	{
 		// this is only a placeholder
-		public static string MonoVersion = "5.0.0.8";
+		public static string MonoVersion = "5.0.0.9";
 	}
 }

--- a/mdoc/Mono.Documentation/Frameworks/AssemblySet.cs
+++ b/mdoc/Mono.Documentation/Frameworks/AssemblySet.cs
@@ -35,8 +35,12 @@ namespace Mono.Documentation
 
 			foreach (var searchPath in resolverSearchPaths.Union(assemblyDirectories))
 				assemblySearchPaths.Add (searchPath);
-			
-			foreach (var searchPath in assemblySearchPaths)
+
+			char oppositeSeparator = Path.DirectorySeparatorChar == '/' ? '\\' : '/';
+			Func<string, string> sanitize = p => 
+				p.Replace (oppositeSeparator, Path.DirectorySeparatorChar);
+
+			foreach (var searchPath in assemblySearchPaths.Select(sanitize))
 				resolver.AddSearchDirectory (searchPath);
 		}
 

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -327,7 +327,8 @@ class MDocUpdater : MDocCommand
 								SearchPaths = f.Elements("assemblySearchPath")
 					                           .Select(a => Path.Combine(frameworksDir, a.Value))
 					                           .ToArray()
-							  });
+							  })
+							  .Where (f => Directory.Exists (f.Path));
 
 			var sets = fxd.Select (d => new AssemblySet (
 				d.Name,
@@ -2067,13 +2068,14 @@ class MDocUpdater : MDocCommand
 		RemoveExcept (member.SelectSingleNode ("Docs"), ValidExtensionDocMembers);
 		WriteElementText (member, "MemberType", "ExtensionMethod");
 		XmlElement link = member.OwnerDocument.CreateElement ("Link");
-		link.SetAttribute ("Type", slashdocFormatter.GetName (me.DeclaringType));
-		link.SetAttribute ("Member", slashdocFormatter.GetDeclaration (me));
+		var linktype = slashdocFormatter.GetName (me.DeclaringType);
+		var linkmember = slashdocFormatter.GetDeclaration (me);
+		link.SetAttribute ("Type", linktype);
+		link.SetAttribute ("Member", linkmember);
 		member.AppendChild (link);
 		AddTargets (em, info);
 
-		var sig = em.SelectSingleNode ("Member/MemberSignature[@Language='C#']/@Value");
-		if (!IsMultiAssembly || (IsMultiAssembly && sig != null && !extensionMethods.Any (ex => ex.SelectSingleNode ("Member/MemberSignature[@Language='C#']/@Value").Value == sig.Value))) {
+		if (!IsMultiAssembly || (IsMultiAssembly && !extensionMethods.Any (ex => ex.SelectSingleNode ("Member/Link/@Type").Value == linktype && ex.SelectSingleNode ("Member/Link/@Member").Value == linkmember))) {
 			extensionMethods.Add (em);
 		}
 	}


### PR DESCRIPTION
This fixes an issue where an extension method in multiple frameworks might have a slightly different signature,
due to a different parameter name, resulting in an InvalidOperationException because a duplicate extension
was added to the index file.

Additionally, this improves robustness of assembly search paths.

Related to  to #27.