### PR TITLE
mdoc: Support for VB Explicitly Implemented Interface members

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -4,6 +4,6 @@ namespace Mono.Documentation
 	public static class Consts
 	{
 		// this is only a placeholder
-		public static string MonoVersion = "5.0.0.9";
+		public static string MonoVersion = "5.0.0.10";
 	}
 }

--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,6 +3,6 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.0.0.11";
+		public static string MonoVersion = "5.0.0.12";
 	}
 }

--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,6 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		// this is only a placeholder
-		public static string MonoVersion = "5.0.0.10";
+		public static string MonoVersion = "5.0.0.11";
 	}
 }

--- a/mdoc/Mono.Documentation/Frameworks/FrameworkTypeEntry.cs
+++ b/mdoc/Mono.Documentation/Frameworks/FrameworkTypeEntry.cs
@@ -43,7 +43,10 @@ namespace Mono.Documentation
 				members.Add (member.FullName);
 
 			// this is for lookup purposes
-			memberscsharpsig.Add(formatter.GetDeclaration (member));
+			try {
+				memberscsharpsig.Add(formatter.GetDeclaration(member));
+			}
+			catch {}
 		}
 
 		public bool ContainsCSharpSig (string sig)

--- a/mdoc/Mono.Documentation/Frameworks/FrameworkTypeEntry.cs
+++ b/mdoc/Mono.Documentation/Frameworks/FrameworkTypeEntry.cs
@@ -10,7 +10,7 @@ namespace Mono.Documentation
 		SortedSet<string> members = new SortedSet<string> ();
 		SortedSet<string> memberscsharpsig = new SortedSet<string> ();
 
-		ILMemberFormatter formatter = new ILMemberFormatter ();
+		ILFullMemberFormatter formatter = new ILFullMemberFormatter ();
 
 		FrameworkEntry fx;
 

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -334,24 +334,25 @@ class MDocUpdater : MDocCommand
 			var sets = fxd.Select (d => new AssemblySet (
 				d.Name,
 				Directory.GetFiles (d.Path, "*.dll"),
-				this.globalSearchPaths.Union(d.SearchPaths)
+				this.globalSearchPaths.Union (d.SearchPaths)
 			));
 			this.assemblies.AddRange (sets);
-			assemblyPaths.AddRange(sets.SelectMany (s => s.AssemblyPaths));
+			assemblyPaths.AddRange (sets.SelectMany (s => s.AssemblyPaths));
 
 			// Create a cache of all frameworks, so we can look up 
 			// members that may exist only other frameworks before deleting them
 			Console.Write ("Creating frameworks cache: ");
 			FrameworkIndex cacheIndex = new FrameworkIndex (FrameworksPath);
+			string[] prefixesToAvoid = { "get_", "set_", "add_", "remove_", "raise_" };
 			foreach (var assemblySet in this.assemblies) {
 				using (assemblySet) {
 					Console.Write (".");
 					foreach (var assembly in assemblySet.Assemblies) {
 						var a = cacheIndex.StartProcessingAssembly(assembly);
-						foreach (var type in assembly.GetTypes()) {
-							var t = a.ProcessType(type);
-							foreach (var member in type.GetMembers())
-								t.ProcessMember(member);
+						foreach (var type in assembly.GetTypes ()) {
+							var t = a.ProcessType (type);
+							foreach (var member in type.GetMembers ().Where (m => !prefixesToAvoid.Any (pre => m.Name.StartsWith (pre))))
+								t.ProcessMember (member);
 						}
 					}
 				}


### PR DESCRIPTION
Since VB.NET can explicitly implement a member without using the same
naming convention as you might use in C#, it was causing some issues with
mdoc matching xml member nodes to reflected types. In particular, the cases
supported with this patch are:

- interface type and member name concatenated. e.g. `IListAdd`
- same as above, but when the interface doesn’t match the interface where the member is defined. e.g. `ICollection` inherits `IEnumerable`. So `System.Collections.IEnumerable.GetEnumerator` is expressed in some types as `ICollectionGetEnumerator`
- same name as the interface member e.g. `Microsoft.VisualBasic.Compability.VB6.BaseControlArray$System.ComponentModel.ISupportInitialize.BeginInit`

Related #44