### PR TITLE
mdoc: no longer skips documenting forwarded types

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,6 +3,6 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.0.0.13";
+		public static string MonoVersion = "5.0.0.14";
 	}
 }

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -921,7 +921,7 @@ class MDocUpdater : MDocCommand
 
 		foreach (TypeDefinition type in docEnum.GetDocumentationTypes (assembly, null)) {
 			string typename = GetTypeFileName(type);
-			if (!IsPublic (type) || typename.IndexOfAny (InvalidFilenameChars) >= 0 || assemblySet.ContainsForwardedType (type.FullName))
+			if (!IsPublic (type) || typename.IndexOfAny (InvalidFilenameChars) >= 0)
 				continue;
 
 			var typeEntry = frameworkEntry.ProcessType (type);


### PR DESCRIPTION
Previously, mdoc simply skipped documenting forwarded types. With this change, forwarded types will still be documented if they exist in the assemblies being documented ... and they will contain the assembly info of the Assembly where the types are declared.