### PR TITLE
Mdoc import support for frameworks mode

### DIFF
--- a/mdoc/.gitignore
+++ b/mdoc/.gitignore
@@ -3,5 +3,7 @@
 /Test/DocTest.*
 /Test/*.dll*
 /Test/FrameworkTestData*
+/Test/fx-import
+Test/DocTest-DropNS-classic.xml
 /.v2.txt
 /.v0.txt

--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,6 +3,6 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.0.0.14";
+		public static string MonoVersion = "5.0.0.17";
 	}
 }

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -63,11 +63,11 @@ Test/DocTest-addNonGeneric-v2.dll:
 
 Test/DocTest-DropNS-classic-secondary.dll:
 	@echo $(value @)
-	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-DropNS-classic-secondary.cs
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-DropNS-classic-secondary.cs -doc:Test/DocTest-DropNS-classic-secondary.xml
 
 Test/DocTest-DropNS-classic.dll:
 	@echo $(value @)
-	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-DropNS-classic.cs
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-DropNS-classic.cs -doc:Test/DocTest-DropNS-classic.xml
 
 Test/DocTest-DropNS-unified.dll:
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-DropNS-unified.cs
@@ -357,6 +357,25 @@ check-monodocer-importecmadoc:
 		-o Test/en.actual Test/DocTest.dll 
 	$(DIFF) Test/en.expected.importecmadoc Test/en.actual
 
+.PHONY: check-monodocer-import-fx
+check-monodocer-import-fx: Test/DocTest.dll-v1 Test/DocTest-DropNS-classic-secondary.dll Test/DocTest-DropNS-classic.dll
+	rm -Rf Test/en.actual
+	rm -Rf Test/fx-import
+	mkdir Test/fx-import
+	mkdir Test/fx-import/one
+	mkdir Test/fx-import/two
+	cp Test/DocTest.dll Test/fx-import/one
+	cp Test/DocTest-DropNS-classic-secondary.dll Test/fx-import/two
+	cp Test/DocTest-DropNS-classic.dll Test/fx-import/two
+	cp Test/DocTest-DropNS-classic-secondary.xml Test/fx-import/TestEcmaDocs2.xml
+	cp Test/DocTest-DropNS-classic.xml Test/fx-import/DocTest-DropNS-classic.xml
+	cp Test/DocTest.xml Test/fx-import/TestEcmaDocs.xml
+	cp Test/CLILibraryTypes.dtd Test/fx-import/
+	cp Test/fx-import-configuration.xml Test/fx-import/frameworks.xml
+	#$(MONO) $(PROGRAM) fx-bootstrap Test/fx-import
+	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/fx-import
+	$(DIFF) Test/en.expected-fx-import Test/en.actual
+
 check-mdoc-export-html-update: 
 	find Test/html.expected -name \*.html -exec rm "{}" \;
 	$(MONO) $(PROGRAM) export-html -o Test/html.expected \
@@ -429,6 +448,7 @@ run-test-update : check-doc-tools-update
 check-doc-tools: check-monodocer-since \
 	check-monodocer-importecmadoc \
 	check-monodocer-importslashdoc \
+	check-monodocer-import-fx \
 	check-monodocer \
 	check-monodocer-delete \
 	check-mdoc-export-html \

--- a/mdoc/Mono.Documentation/Frameworks/FrameworkEntry.cs
+++ b/mdoc/Mono.Documentation/Frameworks/FrameworkEntry.cs
@@ -21,6 +21,8 @@ namespace Mono.Documentation
 
 		public string Name { get; set; }
 
+		public IEnumerable<DocumentationImporter> Importers { get; set; }
+
 		public ISet<FrameworkTypeEntry> Types { get { return this.types; } }
 
 		public IEnumerable<FrameworkEntry> Frameworks { get { return this.allframeworks; } }

--- a/mdoc/Mono.Documentation/Frameworks/FrameworkIndex.cs
+++ b/mdoc/Mono.Documentation/Frameworks/FrameworkIndex.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -26,7 +26,7 @@ namespace Mono.Documentation
 			}
 		}
 
-		public FrameworkEntry StartProcessingAssembly (AssemblyDefinition assembly) 
+        public FrameworkEntry StartProcessingAssembly (AssemblyDefinition assembly, IEnumerable<DocumentationImporter> importers) 
 		{
 			if (string.IsNullOrWhiteSpace (this.path))
 				return FrameworkEntry.Empty;
@@ -40,7 +40,7 @@ namespace Mono.Documentation
 
 			var entry = frameworks.FirstOrDefault (f => f.Name.Equals (shortPath));
 			if (entry == null) {
-				entry = new FrameworkEntry (frameworks) { Name = shortPath };
+				entry = new FrameworkEntry (frameworks) { Name = shortPath, Importers = importers };
 				frameworks.Add (entry);
 			}
 			return entry;

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -318,7 +318,7 @@ class MDocUpdater : MDocCommand
 				configPath = Path.Combine (configPath, "frameworks.xml");
 			else
 				frameworksDir = Path.GetDirectoryName (configPath);
-			
+
 			var fxconfig = XDocument.Load (configPath);
 			var fxd = fxconfig.Root
 			                  .Elements ("Framework")
@@ -327,14 +327,18 @@ class MDocUpdater : MDocCommand
 								Path = Path.Combine(frameworksDir,f.Attribute("Source").Value),
 								SearchPaths = f.Elements("assemblySearchPath")
 					                           .Select(a => Path.Combine(frameworksDir, a.Value))
-					                           .ToArray()
+					                           .ToArray(),
+								Imports = f.Elements("import")
+                                               .Select(a => Path.Combine(frameworksDir, a.Value))
+                                               .ToArray()
 							  })
 							  .Where (f => Directory.Exists (f.Path));
 
 			var sets = fxd.Select (d => new AssemblySet (
 				d.Name,
 				Directory.GetFiles (d.Path, "*.dll"),
-				this.globalSearchPaths.Union (d.SearchPaths)
+				this.globalSearchPaths.Union (d.SearchPaths),
+				d.Imports
 			));
 			this.assemblies.AddRange (sets);
 			assemblyPaths.AddRange (sets.SelectMany (s => s.AssemblyPaths));
@@ -348,7 +352,7 @@ class MDocUpdater : MDocCommand
 				using (assemblySet) {
 					Console.Write (".");
 					foreach (var assembly in assemblySet.Assemblies) {
-						var a = cacheIndex.StartProcessingAssembly(assembly);
+						var a = cacheIndex.StartProcessingAssembly(assembly, assemblySet.Importers);
 						foreach (var type in assembly.GetTypes ()) {
 							var t = a.ProcessType (type);
 							foreach (var member in type.GetMembers ().Where (m => !prefixesToAvoid.Any (pre => m.Name.StartsWith (pre))))
@@ -361,7 +365,7 @@ class MDocUpdater : MDocCommand
 			this.frameworksCache = cacheIndex;
 		}
 		else {
-			this.assemblies.Add (new AssemblySet ("Default", assemblyPaths, this.globalSearchPaths));
+			this.assemblies.Add (new AssemblySet ("Default", assemblyPaths, this.globalSearchPaths, null));
 		}
 
 		if (assemblyPaths == null)
@@ -407,6 +411,13 @@ class MDocUpdater : MDocCommand
 
 	void AddImporter (string path)
 	{
+		var importer = GetImporter (path, supportsEcmaDoc:true);
+		if (importer != null)
+			importers.Add (importer);
+	}
+
+	internal DocumentationImporter GetImporter (string path, bool supportsEcmaDoc)
+	{
 		try {
 			XmlReader r = new XmlTextReader (path);
 			if (r.Read ()) {
@@ -415,12 +426,15 @@ class MDocUpdater : MDocCommand
 						Error ("Unable to read XML file: {0}.", path);
 				}
 				if (r.LocalName == "doc") {
-					importers.Add (new MsxdocDocumentationImporter (path));
+					return new MsxdocDocumentationImporter (path);
 				}
 				else if (r.LocalName == "Libraries") {
+					if (!supportsEcmaDoc)
+						throw new NotSupportedException ($"Ecma documentation not supported in this mode: {path}");
+                        
 					var ecmadocs = new XmlTextReader (path);
 					docEnum = new EcmaDocumentationEnumerator (this, ecmadocs);
-					importers.Add (new EcmaDocumentationImporter (ecmadocs));
+					return new EcmaDocumentationImporter (ecmadocs);
 				}
 				else
 					Error ("Unsupported XML format within {0}.", path);
@@ -430,6 +444,7 @@ class MDocUpdater : MDocCommand
 			Environment.ExitCode = 1;
 			Error ("Could not load XML file: {0}.", e.Message);
 		}
+		return null;
 	}
 
 	static ExceptionLocations ParseExceptionLocations (string s)
@@ -588,7 +603,7 @@ class MDocUpdater : MDocCommand
 			foreach (var assemblySet in this.assemblies) {
 				using (assemblySet) {
 					foreach (AssemblyDefinition assembly in assemblySet.Assemblies) {
-						var frameworkEntry = frameworks.StartProcessingAssembly (assembly);
+						var frameworkEntry = frameworks.StartProcessingAssembly (assembly, assemblySet.Importers);
 
 						foreach (TypeDefinition type in docEnum.GetDocumentationTypes (assembly, typenames)) {
 							var typeEntry = frameworkEntry.ProcessType (type);
@@ -757,7 +772,7 @@ class MDocUpdater : MDocCommand
 			DoUpdateType2("Updating", basefile, type, typeEntry, output, false);
 		} else {
 			// Stub
-			XmlElement td = StubType(type, output);
+			XmlElement td = StubType(type, output, typeEntry.Framework.Importers);
 			if (td == null)
 				return null;
 		}
@@ -917,7 +932,7 @@ class MDocUpdater : MDocCommand
 
 	private void DoUpdateAssembly (AssemblySet assemblySet, AssemblyDefinition assembly, XmlElement index_types, string source, string dest, HashSet<string> goodfiles) 
 	{
-		var frameworkEntry = frameworks.StartProcessingAssembly (assembly);
+        var frameworkEntry = frameworks.StartProcessingAssembly (assembly, assemblySet.Importers);
 
 		foreach (TypeDefinition type in docEnum.GetDocumentationTypes (assembly, null)) {
 			string typename = GetTypeFileName(type);
@@ -1335,7 +1350,7 @@ class MDocUpdater : MDocCommand
 					})
 					.ToArray();
 			foreach (MemberReference m in typemembers) {
-				XmlElement mm = MakeMember(basefile, new DocsNodeInfo (null, m), typeEntry);
+				XmlElement mm = MakeMember(basefile, new DocsNodeInfo (null, m), members, typeEntry);
 				if (mm == null) continue;
 
 				if (MDocUpdater.SwitchingToMagicTypes || MDocUpdater.HasDroppedNamespace (m)) {
@@ -1344,7 +1359,6 @@ class MDocUpdater : MDocCommand
 					mm.AddApiStyle (ApiStyle.Unified);
 				}
 
-				members.AppendChild( mm );
 				Console.WriteLine("Member Added: " + mm.SelectSingleNode("MemberSignature/@Value").InnerText);
 				additions++;
 			}
@@ -1591,7 +1605,7 @@ class MDocUpdater : MDocCommand
 	
 	// CREATE A STUB DOCUMENTATION FILE	
 
-	public XmlElement StubType (TypeDefinition type, string output)
+        public XmlElement StubType (TypeDefinition type, string output, IEnumerable<DocumentationImporter> importers)
 	{
 		string typesig = typeFormatters [0].GetDeclaration (type);
 		if (typesig == null) return null; // not publicly visible
@@ -1600,7 +1614,7 @@ class MDocUpdater : MDocCommand
 		XmlElement root = doc.CreateElement("Type");
 		doc.AppendChild (root);
 
-		var frameworkEntry = frameworks.StartProcessingAssembly (type.Module.Assembly);
+		var frameworkEntry = frameworks.StartProcessingAssembly (type.Module.Assembly, importers);
 		var typeEntry = frameworkEntry.ProcessType (type);
 		DoUpdateType2 ("New Type", doc, type, typeEntry, output, true);
 		
@@ -1754,7 +1768,7 @@ class MDocUpdater : MDocCommand
 		}
 		
 		DocsNodeInfo typeInfo = new DocsNodeInfo (WriteElement(root, "Docs"), type);
-		MakeDocNode (typeInfo);
+		MakeDocNode (typeInfo, typeEntry.Framework.Importers);
 		
 		if (!DocUtils.IsDelegate (type))
 			WriteElement (root, "Members");
@@ -1881,7 +1895,7 @@ class MDocUpdater : MDocCommand
 			WriteElementText(me, "MemberValue", fieldValue);
 		
 		info.Node = WriteElement (me, "Docs");
-		MakeDocNode (info);
+		MakeDocNode (info, typeEntry.Framework.Importers);
 		OrderMemberNodes (me, me.ChildNodes);
 		UpdateExtensionMethods (me, info);
 	}
@@ -2248,10 +2262,10 @@ class MDocUpdater : MDocCommand
 		if (node != null)
 			parent.RemoveChild(node);
 	}
-	
+
 	// DOCUMENTATION HELPER FUNCTIONS
-	
-	private void MakeDocNode (DocsNodeInfo info)
+
+	private void MakeDocNode (DocsNodeInfo info, IEnumerable<DocumentationImporter> setimporters)
 	{
 		List<GenericParameter> genericParams      = info.GenericParameters;
 		IList<ParameterDefinition> parameters  = info.Parameters;
@@ -2304,9 +2318,14 @@ class MDocUpdater : MDocCommand
 			UpdateExceptions (e, info.Member);
 		}
 
-		foreach (DocumentationImporter importer in importers)
+		foreach (DocumentationImporter importer in importers) {
 			importer.ImportDocumentation (info);
-		
+		}
+		if (setimporters != null) {
+			foreach (var i in setimporters)
+				i.ImportDocumentation (info);
+		}
+
 		OrderDocsNodes (e, e.ChildNodes);
 		NormalizeWhitespace(e);
 	}
@@ -2877,7 +2896,7 @@ class MDocUpdater : MDocCommand
 			throw new ArgumentException(mi + " is a " + mi.GetType().FullName);
 	}
 	
-	private XmlElement MakeMember(XmlDocument doc, DocsNodeInfo info, FrameworkTypeEntry typeEntry)
+	private XmlElement MakeMember(XmlDocument doc, DocsNodeInfo info, XmlNode members, FrameworkTypeEntry typeEntry)
 	{
 		MemberReference mi = info.Member;
 		if (mi is TypeDefinition) return null;
@@ -2893,6 +2912,7 @@ class MDocUpdater : MDocCommand
 		if (mi.Name.StartsWith("raise_")) return null;
 		
 		XmlElement me = doc.CreateElement("Member");
+		members.AppendChild (me);
 		me.SetAttribute("MemberName", GetMemberName (mi));
 
 		info.Node = me;

--- a/mdoc/Test/DocTest-DropNS-classic-secondary.cs
+++ b/mdoc/Test/DocTest-DropNS-classic-secondary.cs
@@ -2,8 +2,13 @@ namespace MyFramework.MyOtherNamespace {
 	///<summary>Make sure the namespace in this assembly doesn't get 'dropped'</summary>
 	public class MyOtherClass {
 		public string MyProperty {get;set;}
+		///<summary>Hello</summary>
 		public float Hello(int value) {
 			return 0.0f;
+		}
+		///<summary>Is it me you're looking for</summary>
+		public float Hello(double value) {
+			return (float)value;
 		}
 	}
 }

--- a/mdoc/Test/DocTest-DropNS-classic-secondary.xml
+++ b/mdoc/Test/DocTest-DropNS-classic-secondary.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>DocTest-DropNS-classic-secondary</name>
+    </assembly>
+    <members>
+        <member name="T:MyFramework.MyOtherNamespace.MyOtherClass">
+            <summary>Make sure the namespace in this assembly doesn't get 'dropped'</summary>
+            </member>
+        <member name="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Int32)">
+            <summary>Hello</summary>
+            </member>
+        <member name="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Double)">
+            <summary>Is it me you're looking for</summary>
+            </member>
+    </members>
+</doc>

--- a/mdoc/Test/DocTest-DropNS-classic.cs
+++ b/mdoc/Test/DocTest-DropNS-classic.cs
@@ -1,5 +1,8 @@
 namespace MyFramework.MyNamespace {
+	/// <summary>MyClass summary</summary>
+	/// <remarks>my class remarks</remarks>
 	public class MyClass {
+		/// <summary>MyProperty Summary</summary>
 		public string MyProperty {get;set;}
 		public float Hello(int value) {
 			return 0.0f;

--- a/mdoc/Test/en.expected-docid/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-docid/FrameworksIndex/Two.xml
@@ -3,6 +3,7 @@
   <Namespace Name="MyFramework.MyOtherNamespace">
     <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">
       <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.#ctor" />
+      <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Double)" />
       <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Int32)" />
       <Member Id="P:MyFramework.MyOtherNamespace.MyOtherClass.MyProperty" />
     </Type>

--- a/mdoc/Test/en.expected-docid/MyFramework.MyOtherNamespace/MyOtherClass.xml
+++ b/mdoc/Test/en.expected-docid/MyFramework.MyOtherNamespace/MyOtherClass.xml
@@ -31,6 +31,28 @@
       </Docs>
     </Member>
     <Member MemberName="Hello">
+      <MemberSignature Language="C#" Value="public float Hello (double value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(float64 value) cil managed" />
+      <MemberSignature Language="DocId" Value="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Double)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Hello">
       <MemberSignature Language="C#" Value="public float Hello (int value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
       <MemberSignature Language="DocId" Value="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Int32)" />

--- a/mdoc/Test/en.expected-frameworks/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-frameworks/FrameworksIndex/Two.xml
@@ -3,6 +3,7 @@
   <Namespace Name="MyFramework.MyOtherNamespace">
     <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">
       <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.#ctor" />
+      <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Double)" />
       <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Int32)" />
       <Member Id="P:MyFramework.MyOtherNamespace.MyOtherClass.MyProperty" />
     </Type>

--- a/mdoc/Test/en.expected-frameworks/MyFramework.MyOtherNamespace/MyOtherClass.xml
+++ b/mdoc/Test/en.expected-frameworks/MyFramework.MyOtherNamespace/MyOtherClass.xml
@@ -29,6 +29,27 @@
       </Docs>
     </Member>
     <Member MemberName="Hello">
+      <MemberSignature Language="C#" Value="public float Hello (double value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(float64 value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Hello">
       <MemberSignature Language="C#" Value="public float Hello (int value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
       <MemberType>Method</MemberType>

--- a/mdoc/Test/en.expected-fx-import/FrameworksIndex/one.xml
+++ b/mdoc/Test/en.expected-fx-import/FrameworksIndex/one.xml
@@ -1,0 +1,192 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework Name="one">
+  <Namespace Name="Mono.DocTest">
+    <Type Name="Mono.DocTest.Color" Id="T:Mono.DocTest.Color">
+      <Member Id="F:Mono.DocTest.Color.AnotherGreen" />
+      <Member Id="F:Mono.DocTest.Color.Blue" />
+      <Member Id="F:Mono.DocTest.Color.Green" />
+      <Member Id="F:Mono.DocTest.Color.Red" />
+    </Type>
+    <Type Name="Mono.DocTest.D" Id="T:Mono.DocTest.D" />
+    <Type Name="Mono.DocTest.DocAttribute" Id="T:Mono.DocTest.DocAttribute">
+      <Member Id="F:Mono.DocTest.DocAttribute.Field" />
+      <Member Id="F:Mono.DocTest.DocAttribute.FlagsEnum" />
+      <Member Id="F:Mono.DocTest.DocAttribute.NonFlagsEnum" />
+      <Member Id="M:Mono.DocTest.DocAttribute.#ctor(System.String)" />
+      <Member Id="P:Mono.DocTest.DocAttribute.Property" />
+    </Type>
+    <Type Name="Mono.DocTest.DocValueType" Id="T:Mono.DocTest.DocValueType">
+      <Member Id="F:Mono.DocTest.DocValueType.total" />
+      <Member Id="M:Mono.DocTest.DocValueType.M(System.Int32)" />
+    </Type>
+    <Type Name="Mono.DocTest.IProcess" Id="T:Mono.DocTest.IProcess" />
+    <Type Name="Mono.DocTest.UseLists" Id="T:Mono.DocTest.UseLists">
+      <Member Id="M:Mono.DocTest.UseLists.#ctor" />
+      <Member Id="M:Mono.DocTest.UseLists.GetValues``1(``0)" />
+      <Member Id="M:Mono.DocTest.UseLists.Process(Mono.DocTest.Generic.MyList{System.Int32})" />
+      <Member Id="M:Mono.DocTest.UseLists.Process(System.Collections.Generic.List{System.Int32})" />
+      <Member Id="M:Mono.DocTest.UseLists.Process(System.Collections.Generic.List{System.Predicate{System.Int32}})" />
+      <Member Id="M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}})" />
+      <Member Id="M:Mono.DocTest.UseLists.UseHelper``3(Mono.DocTest.Generic.MyList`1.Helper{``0,``1,``2})" />
+    </Type>
+    <Type Name="Mono.DocTest.Widget" Id="T:Mono.DocTest.Widget">
+      <Member Id="E:Mono.DocTest.Widget.AnEvent" />
+      <Member Id="E:Mono.DocTest.Widget.AnotherEvent" />
+      <Member Id="E:Mono.DocTest.Widget.DynamicE1" />
+      <Member Id="E:Mono.DocTest.Widget.DynamicE2" />
+      <Member Id="F:Mono.DocTest.Widget.array1" />
+      <Member Id="F:Mono.DocTest.Widget.array2" />
+      <Member Id="F:Mono.DocTest.Widget.classCtorError" />
+      <Member Id="F:Mono.DocTest.Widget.defaultColor" />
+      <Member Id="F:Mono.DocTest.Widget.DynamicF" />
+      <Member Id="F:Mono.DocTest.Widget.message" />
+      <Member Id="F:Mono.DocTest.Widget.monthlyAverage" />
+      <Member Id="F:Mono.DocTest.Widget.op_Division" />
+      <Member Id="F:Mono.DocTest.Widget.pCount" />
+      <Member Id="F:Mono.DocTest.Widget.PI" />
+      <Member Id="F:Mono.DocTest.Widget.ppValues" />
+      <Member Id="M:Mono.DocTest.Widget.#ctor" />
+      <Member Id="M:Mono.DocTest.Widget.#ctor(System.Converter{System.String,System.String})" />
+      <Member Id="M:Mono.DocTest.Widget.#ctor(System.String)" />
+      <Member Id="M:Mono.DocTest.Widget.Default(System.Int32,System.Int32)" />
+      <Member Id="M:Mono.DocTest.Widget.Default(System.String,System.Char)" />
+      <Member Id="M:Mono.DocTest.Widget.Dynamic0(System.Object,System.Object)" />
+      <Member Id="M:Mono.DocTest.Widget.Dynamic1(System.Collections.Generic.Dictionary{System.Object,System.String})" />
+      <Member Id="M:Mono.DocTest.Widget.Dynamic2(System.Func{System.String,System.Object})" />
+      <Member Id="M:Mono.DocTest.Widget.Dynamic3(System.Func{System.Func{System.String,System.Object},System.Func{System.Object,System.String}})" />
+      <Member Id="M:Mono.DocTest.Widget.M0" />
+      <Member Id="M:Mono.DocTest.Widget.M1(System.Char,System.Single@,Mono.DocTest.DocValueType@)" />
+      <Member Id="M:Mono.DocTest.Widget.M2(System.Int16[],System.Int32[0:,0:],System.Int64[][])" />
+      <Member Id="M:Mono.DocTest.Widget.M3(System.Int64[][],Mono.DocTest.Widget[0:,0:,0:][])" />
+      <Member Id="M:Mono.DocTest.Widget.M4(System.Char*,Mono.DocTest.Color**)" />
+      <Member Id="M:Mono.DocTest.Widget.M5(System.Void*,System.Double*[0:,0:][])" />
+      <Member Id="M:Mono.DocTest.Widget.M6(System.Int32,System.Object[])" />
+      <Member Id="M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple)" />
+      <Member Id="M:Mono.DocTest.Widget.op_Addition(Mono.DocTest.Widget,Mono.DocTest.Widget)" />
+      <Member Id="M:Mono.DocTest.Widget.op_Explicit(Mono.DocTest.Widget)~System.Int32" />
+      <Member Id="M:Mono.DocTest.Widget.op_Implicit(Mono.DocTest.Widget)~System.Int64" />
+      <Member Id="M:Mono.DocTest.Widget.op_UnaryPlus(Mono.DocTest.Widget)" />
+      <Member Id="P:Mono.DocTest.Widget.DynamicP" />
+      <Member Id="P:Mono.DocTest.Widget.Height" />
+      <Member Id="P:Mono.DocTest.Widget.Item(System.Int32)" />
+      <Member Id="P:Mono.DocTest.Widget.Item(System.String,System.Int32)" />
+      <Member Id="P:Mono.DocTest.Widget.Width" />
+      <Member Id="P:Mono.DocTest.Widget.X" />
+      <Member Id="P:Mono.DocTest.Widget.Y" />
+    </Type>
+  </Namespace>
+  <Namespace Name="Mono.DocTest.Generic">
+    <Type Name="Mono.DocTest.Generic.Extensions" Id="T:Mono.DocTest.Generic.Extensions">
+      <Member Id="M:Mono.DocTest.Generic.Extensions.Bar``1(Mono.DocTest.Generic.IFoo{``0},System.String)" />
+      <Member Id="M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0})" />
+      <Member Id="M:Mono.DocTest.Generic.Extensions.ToDouble(System.Collections.Generic.IEnumerable{System.Int32})" />
+      <Member Id="M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0)" />
+      <Member Id="M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)" />
+    </Type>
+    <Type Name="Mono.DocTest.Generic.Func`2" Id="T:Mono.DocTest.Generic.Func`2" />
+    <Type Name="Mono.DocTest.Generic.GenericBase`1" Id="T:Mono.DocTest.Generic.GenericBase`1">
+      <Member Id="E:Mono.DocTest.Generic.GenericBase`1.ItemChanged" />
+      <Member Id="E:Mono.DocTest.Generic.GenericBase`1.MyEvent" />
+      <Member Id="F:Mono.DocTest.Generic.GenericBase`1.ConstField1" />
+      <Member Id="F:Mono.DocTest.Generic.GenericBase`1.StaticField1" />
+      <Member Id="M:Mono.DocTest.Generic.GenericBase`1.#ctor" />
+      <Member Id="M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0)" />
+      <Member Id="M:Mono.DocTest.Generic.GenericBase`1.op_Explicit(Mono.DocTest.Generic.GenericBase{`0})~`0" />
+    </Type>
+    <Type Name="Mono.DocTest.Generic.IFoo`1" Id="T:Mono.DocTest.Generic.IFoo`1">
+      <Member Id="M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0)" />
+    </Type>
+    <Type Name="Mono.DocTest.Generic.MyList`1" Id="T:Mono.DocTest.Generic.MyList`1">
+      <Member Id="M:Mono.DocTest.Generic.MyList`1.#ctor" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`1.GetEnumerator" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`1.GetHelper``2" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`1.Method``1(`0,``0)" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`1.RefMethod``1(`0@,``0@)" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`1.System#Collections#IEnumerable#GetEnumerator" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`1.Test(`0)" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`1.UseHelper``2(Mono.DocTest.Generic.MyList`1.Helper{`0,``0,``1})" />
+    </Type>
+    <Type Name="Mono.DocTest.Generic.MyList`2" Id="T:Mono.DocTest.Generic.MyList`2">
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.#ctor" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.CopyTo(`0[],System.Int32)" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.Dispose" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.Foo" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.GetEnumerator" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo&lt;A&gt;#Method``1(`0,``0)" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.MoveNext" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.Reset" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection&lt;A&gt;#Add(`0)" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection&lt;A&gt;#Clear" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection&lt;A&gt;#Contains(`0)" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection&lt;A&gt;#Remove(`0)" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerable&lt;A&gt;#GetEnumerator" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerable#GetEnumerator" />
+      <Member Id="P:Mono.DocTest.Generic.MyList`2.Count" />
+      <Member Id="P:Mono.DocTest.Generic.MyList`2.Current" />
+      <Member Id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#ICollection&lt;A&gt;#IsReadOnly" />
+      <Member Id="P:Mono.DocTest.Generic.MyList`2.System#Collections#Generic#IEnumerator&lt;A&gt;#Current" />
+      <Member Id="P:Mono.DocTest.Generic.MyList`2.System#Collections#IEnumerator#Current" />
+    </Type>
+  </Namespace>
+  <Namespace Name="">
+    <Type Name="Mono.DocTest.Generic.GenericBase`1/FooEventArgs" Id="T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs">
+      <Member Id="M:Mono.DocTest.Generic.GenericBase`1.FooEventArgs.#ctor" />
+    </Type>
+    <Type Name="Mono.DocTest.Generic.GenericBase`1/NestedCollection" Id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection">
+      <Member Id="M:Mono.DocTest.Generic.GenericBase`1.NestedCollection.#ctor" />
+    </Type>
+    <Type Name="Mono.DocTest.Generic.GenericBase`1/NestedCollection/Enumerator" Id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator" />
+    <Type Name="Mono.DocTest.Generic.MyList`1/Helper`2" Id="T:Mono.DocTest.Generic.MyList`1.Helper`2">
+      <Member Id="M:Mono.DocTest.Generic.MyList`1.Helper`2.#ctor" />
+      <Member Id="M:Mono.DocTest.Generic.MyList`1.Helper`2.UseT(`0,`1,`2)" />
+    </Type>
+    <Type Name="Mono.DocTest.Widget/Del" Id="T:Mono.DocTest.Widget.Del" />
+    <Type Name="Mono.DocTest.Widget/Direction" Id="T:Mono.DocTest.Widget.Direction">
+      <Member Id="F:Mono.DocTest.Widget.Direction.East" />
+      <Member Id="F:Mono.DocTest.Widget.Direction.North" />
+      <Member Id="F:Mono.DocTest.Widget.Direction.South" />
+      <Member Id="F:Mono.DocTest.Widget.Direction.West" />
+    </Type>
+    <Type Name="Mono.DocTest.Widget/IMenuItem" Id="T:Mono.DocTest.Widget.IMenuItem">
+      <Member Id="M:Mono.DocTest.Widget.IMenuItem.A" />
+      <Member Id="P:Mono.DocTest.Widget.IMenuItem.B" />
+    </Type>
+    <Type Name="Mono.DocTest.Widget/NestedClass" Id="T:Mono.DocTest.Widget.NestedClass">
+      <Member Id="F:Mono.DocTest.Widget.NestedClass.value" />
+      <Member Id="M:Mono.DocTest.Widget.NestedClass.#ctor" />
+      <Member Id="M:Mono.DocTest.Widget.NestedClass.M(System.Int32)" />
+    </Type>
+    <Type Name="Mono.DocTest.Widget/NestedClass/Double" Id="T:Mono.DocTest.Widget.NestedClass.Double">
+      <Member Id="M:Mono.DocTest.Widget.NestedClass.Double.#ctor" />
+    </Type>
+    <Type Name="Mono.DocTest.Widget/NestedClass/Double/Triple" Id="T:Mono.DocTest.Widget.NestedClass.Double.Triple">
+      <Member Id="M:Mono.DocTest.Widget.NestedClass.Double.Triple.#ctor" />
+    </Type>
+    <Type Name="Mono.DocTest.Widget/NestedClass/Double/Triple/Quadruple" Id="T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple">
+      <Member Id="M:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple.#ctor" />
+    </Type>
+    <Type Name="Mono.DocTest.Widget/NestedClass`1" Id="T:Mono.DocTest.Widget.NestedClass`1">
+      <Member Id="F:Mono.DocTest.Widget.NestedClass`1.value" />
+      <Member Id="M:Mono.DocTest.Widget.NestedClass`1.#ctor" />
+      <Member Id="M:Mono.DocTest.Widget.NestedClass`1.M(System.Int32)" />
+    </Type>
+    <Type Name="NoNamespace" Id="T:NoNamespace">
+      <Member Id="M:NoNamespace.#ctor" />
+    </Type>
+    <Type Name="System.Environment/SpecialFolder" Id="T:System.Environment.SpecialFolder" />
+  </Namespace>
+  <Namespace Name="System">
+    <Type Name="System.Action`1" Id="T:System.Action`1" />
+    <Type Name="System.Array" Id="T:System.Array">
+      <Member Id="M:System.Array.#ctor" />
+      <Member Id="M:System.Array.AsReadOnly``1(``0[])" />
+      <Member Id="M:System.Array.ConvertAll``2(``0[],System.Converter{``0,``1})" />
+      <Member Id="M:System.Array.Resize``1(``0[]@,System.Int32)" />
+    </Type>
+    <Type Name="System.AsyncCallback" Id="T:System.AsyncCallback" />
+    <Type Name="System.Environment" Id="T:System.Environment">
+      <Member Id="M:System.Environment.GetFolderPath(System.Environment.SpecialFolder)" />
+      <Member Id="M:System.Environment.IsAligned``1(``0[],System.Int32)" />
+    </Type>
+  </Namespace>
+</Framework>

--- a/mdoc/Test/en.expected-fx-import/FrameworksIndex/two.xml
+++ b/mdoc/Test/en.expected-fx-import/FrameworksIndex/two.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework Name="two">
+  <Namespace Name="MyFramework.MyNamespace">
+    <Type Name="MyFramework.MyNamespace.MyClass" Id="T:MyFramework.MyNamespace.MyClass">
+      <Member Id="M:MyFramework.MyNamespace.MyClass.#ctor" />
+      <Member Id="M:MyFramework.MyNamespace.MyClass.Hello(System.Int32)" />
+      <Member Id="P:MyFramework.MyNamespace.MyClass.MyProperty" />
+      <Member Id="P:MyFramework.MyNamespace.MyClass.OnlyInClassic" />
+    </Type>
+    <Type Name="MyFramework.MyNamespace.MyClassExtensions" Id="T:MyFramework.MyNamespace.MyClassExtensions">
+      <Member Id="M:MyFramework.MyNamespace.MyClassExtensions.AnExtension(MyFramework.MyNamespace.MyClass)" />
+    </Type>
+  </Namespace>
+  <Namespace Name="MyFramework.MyOtherNamespace">
+    <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">
+      <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.#ctor" />
+      <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Double)" />
+      <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Int32)" />
+      <Member Id="P:MyFramework.MyOtherNamespace.MyOtherClass.MyProperty" />
+    </Type>
+  </Namespace>
+</Framework>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/Extensions.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/Extensions.xml
@@ -1,0 +1,165 @@
+<Type Name="Extensions" FullName="Mono.DocTest.Generic.Extensions">
+  <TypeSignature Language="C#" Value="public static class Extensions" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit Extensions extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>extension methods!</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Generic.Extensions</c>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Bar&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static void Bar&lt;T&gt; (this Mono.DocTest.Generic.IFoo&lt;T&gt; self, string s);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Bar&lt;T&gt;(class Mono.DocTest.Generic.IFoo`1&lt;!!T&gt; self, string s) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="self" Type="Mono.DocTest.Generic.IFoo&lt;T&gt;" RefType="this" />
+        <Parameter Name="s" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="self">To be added.</param>
+        <param name="s">To be added.</param>
+        <summary>
+          <see cref="T:Mono.DocTest.Generic.IFoo`1" /> extension method</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Generic.Extensions.Bar``1</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ForEach&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static void ForEach&lt;T&gt; (this System.Collections.Generic.IEnumerable&lt;T&gt; self, Action&lt;T&gt; a);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void ForEach&lt;T&gt;(class System.Collections.Generic.IEnumerable`1&lt;!!T&gt; self, class System.Action`1&lt;!!T&gt; a) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="self" Type="System.Collections.Generic.IEnumerable&lt;T&gt;" RefType="this" />
+        <Parameter Name="a" Type="System.Action&lt;T&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="self">To be added.</param>
+        <param name="a">To be added.</param>
+        <summary>
+          <see cref="T:System.Collections.Generic.IEnumerable`1" /> extension method</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Generic.Extensions.ForEach``1</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ToDouble">
+      <MemberSignature Language="C#" Value="public static System.Collections.Generic.IEnumerable&lt;double&gt; ToDouble (this System.Collections.Generic.IEnumerable&lt;int&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.Generic.IEnumerable`1&lt;float64&gt; ToDouble(class System.Collections.Generic.IEnumerable`1&lt;int32&gt; list) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Double&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="list" Type="System.Collections.Generic.IEnumerable&lt;System.Int32&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="list">To be added.</param>
+        <summary>
+          <see cref="T:System.Collections.Generic.IEnumerable{System.Int32}" /> 
+               extension method.
+             </summary>
+        <returns>To be added.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.Generic.Extensions.ToDouble</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ToDouble&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static double ToDouble&lt;T&gt; (this T val) where T : Mono.DocTest.Generic.IFoo&lt;T&gt;;" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig float64 ToDouble&lt;(class Mono.DocTest.Generic.IFoo`1&lt;!!T&gt;) T&gt;(!!T val) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T">
+          <Constraints>
+            <InterfaceName>Mono.DocTest.Generic.IFoo&lt;T&gt;</InterfaceName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="val" Type="T" RefType="this" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="val">To be added.</param>
+        <summary>
+          <see cref="T:Mono.DocTest.Generic.IFoo`1" /> extension method.
+             </summary>
+        <returns>To be added.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.Generic.Extensions.ToDouble</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ToEnumerable&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static System.Collections.Generic.IEnumerable&lt;T&gt; ToEnumerable&lt;T&gt; (this T self);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.Generic.IEnumerable`1&lt;!!T&gt; ToEnumerable&lt;T&gt;(!!T self) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IEnumerable&lt;T&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="self" Type="T" RefType="this" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="self">To be added.</param>
+        <summary>
+          <c>System.Object</c> extension method</summary>
+        <returns>To be added.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.Generic.Extensions.ToEnumerable``1</c>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/Func`2.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/Func`2.xml
@@ -1,0 +1,65 @@
+<Type Name="Func&lt;TArg,TRet&gt;" FullName="Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;">
+  <TypeSignature Language="C#" Value="public delegate TRet Func&lt;in TArg,out TRet&gt;(TArg a) where TArg : Exception;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed Func`2&lt;(class System.Exception) - TArg, + TRet&gt; extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="TArg">
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("arg!")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <Constraints>
+        <ParameterAttribute>Contravariant</ParameterAttribute>
+        <BaseTypeName>System.Exception</BaseTypeName>
+      </Constraints>
+    </TypeParameter>
+    <TypeParameter Name="TRet">
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("ret!")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <Constraints>
+        <ParameterAttribute>Covariant</ParameterAttribute>
+      </Constraints>
+    </TypeParameter>
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Mono.DocTest.Doc("method")</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Parameters>
+    <Parameter Name="a" Type="TArg">
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("arg-actual")</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Parameter>
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>TRet</ReturnType>
+    <Attributes>
+      <Attribute>
+        <AttributeName>Mono.DocTest.Doc("return", Field=false)</AttributeName>
+      </Attribute>
+    </Attributes>
+  </ReturnValue>
+  <Docs>
+    <typeparam name="TArg">argument type, with attributes!</typeparam>
+    <typeparam name="TRet">return type, with attributes!</typeparam>
+    <param name="a">To be added.</param>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>
+      <c>T:Mono.DocTest.Generic.Func`2</c>.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1+FooEventArgs.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1+FooEventArgs.xml
@@ -1,0 +1,35 @@
+<Type Name="GenericBase&lt;U&gt;+FooEventArgs" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs">
+  <TypeSignature Language="C#" Value="public class GenericBase&lt;U&gt;.FooEventArgs : EventArgs" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit GenericBase`1/FooEventArgs&lt;U&gt; extends System.EventArgs" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="U" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.EventArgs</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>T:Mono.DocTest.Generic.GenericBase`1.FooEventArgs</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FooEventArgs ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
@@ -1,0 +1,20 @@
+<Type Name="GenericBase&lt;U&gt;+NestedCollection+Enumerator" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator">
+  <TypeSignature Language="C#" Value="protected struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
+  <TypeSignature Language="ILAsm" Value=".class nested protected sequential ansi sealed beforefieldinit GenericBase`1/NestedCollection/Enumerator&lt;U&gt; extends System.ValueType" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="U" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.ValueType</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator</remarks>
+  </Docs>
+  <Members />
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1+NestedCollection.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1+NestedCollection.xml
@@ -1,0 +1,35 @@
+<Type Name="GenericBase&lt;U&gt;+NestedCollection" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection">
+  <TypeSignature Language="C#" Value="public class GenericBase&lt;U&gt;.NestedCollection" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit GenericBase`1/NestedCollection&lt;U&gt; extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="U" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>T:Mono.DocTest.Generic.GenericBase`1.NestedCollection</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public NestedCollection ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1.xml
@@ -1,0 +1,160 @@
+<Type Name="GenericBase&lt;U&gt;" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;">
+  <TypeSignature Language="C#" Value="public class GenericBase&lt;U&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit GenericBase`1&lt;U&gt; extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="U" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <typeparam name="U">Insert <c>text</c> here.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Generic.GenericBase`1</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public GenericBase ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="BaseMethod&lt;S&gt;">
+      <MemberSignature Language="C#" Value="public U BaseMethod&lt;S&gt; (S genericParameter);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance !U BaseMethod&lt;S&gt;(!!S genericParameter) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>U</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="S">
+          <Attributes>
+            <Attribute>
+              <AttributeName>Mono.DocTest.Doc("S")</AttributeName>
+            </Attribute>
+          </Attributes>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="genericParameter" Type="S" />
+      </Parameters>
+      <Docs>
+        <typeparam name="S">Insert more <c>text</c> here.</typeparam>
+        <param name="genericParameter">Something</param>
+        <summary>To be added.</summary>
+        <returns>The default value.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.GenericBase`1.BaseMethod``1(``0)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConstField1">
+      <MemberSignature Language="C#" Value="public const int ConstField1;" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal int32 ConstField1" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.GenericBase`1.ConstField1</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ItemChanged">
+      <MemberSignature Language="C#" Value="public event Action&lt;Mono.DocTest.Generic.MyList&lt;U&gt;,Mono.DocTest.Generic.MyList&lt;U&gt;.Helper&lt;U,U&gt;&gt; ItemChanged;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.Action`2&lt;class Mono.DocTest.Generic.MyList`1&lt;!U&gt;, class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!U, !U, !U&gt;&gt; ItemChanged" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Action&lt;Mono.DocTest.Generic.MyList&lt;U&gt;,Mono.DocTest.Generic.MyList&lt;U&gt;+Helper&lt;U,U&gt;&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>E:Mono.DocTest.Generic.GenericBase`1.ItemChanged</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="MyEvent">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Mono.DocTest.Generic.GenericBase&lt;U&gt;.FooEventArgs&gt; MyEvent;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Mono.DocTest.Generic.GenericBase`1/FooEventArgs&lt;!U&gt;&gt; MyEvent" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>E:Mono.DocTest.Generic.GenericBase`1.MyEvent</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Explicit">
+      <MemberSignature Language="C#" Value="public static U op_Explicit (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname !U op_Explicit(class Mono.DocTest.Generic.GenericBase`1&lt;!U&gt; list) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>U</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="list" Type="Mono.DocTest.Generic.GenericBase&lt;U&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="list">Insert description here</param>
+        <summary>To be added.</summary>
+        <returns>The default value for <typeparamref name="U" />.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.GenericBase`1.op_Explicit(Mono.DocTest.GenericBase{`0})~`0</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="StaticField1">
+      <MemberSignature Language="C#" Value="public static readonly Mono.DocTest.Generic.GenericBase&lt;U&gt; StaticField1;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Mono.DocTest.Generic.GenericBase`1&lt;!U&gt; StaticField1" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Generic.GenericBase&lt;U&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.GenericBase`1.StaticField1</c>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/IFoo`1.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/IFoo`1.xml
@@ -1,0 +1,48 @@
+<Type Name="IFoo&lt;T&gt;" FullName="Mono.DocTest.Generic.IFoo&lt;T&gt;">
+  <TypeSignature Language="C#" Value="public interface IFoo&lt;T&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract IFoo`1&lt;T&gt;" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T" />
+  </TypeParameters>
+  <Interfaces />
+  <Docs>
+    <typeparam name="T">T generic param</typeparam>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.IFoo`1</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Method&lt;U&gt;">
+      <MemberSignature Language="C#" Value="public T Method&lt;U&gt; (T t, U u);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance !T Method&lt;U&gt;(!T t, !!U u) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>T</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="t" Type="T" />
+        <Parameter Name="u" Type="U" />
+      </Parameters>
+      <Docs>
+        <typeparam name="U">U generic param</typeparam>
+        <param name="t">To be added.</param>
+        <param name="u">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>
+          <c>T:Mono.DocTest.IFoo`1.Method``1(`0,``0)</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/MyList`1+Helper`2.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/MyList`1+Helper`2.xml
@@ -1,0 +1,65 @@
+<Type Name="MyList&lt;T&gt;+Helper&lt;U,V&gt;" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;">
+  <TypeSignature Language="C#" Value="public class MyList&lt;T&gt;.Helper&lt;U,V&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit MyList`1/Helper`2&lt;T, U, V&gt; extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T" />
+    <TypeParameter Name="U" />
+    <TypeParameter Name="V" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <typeparam name="U">Seriously!</typeparam>
+    <typeparam name="V">Too <c>many</c> docs!</typeparam>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.MyList`1.Helper`2</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Helper ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseT">
+      <MemberSignature Language="C#" Value="public void UseT (T a, U b, V c);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void UseT(!T a, !U b, !V c) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="T" />
+        <Parameter Name="b" Type="U" />
+        <Parameter Name="c" Type="V" />
+      </Parameters>
+      <Docs>
+        <param name="a">Ako</param>
+        <param name="b">bko</param>
+        <param name="c">cko</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`1.Helper`2.UseT(`0,`1,`2)</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/MyList`1.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/MyList`1.xml
@@ -1,0 +1,215 @@
+<Type Name="MyList&lt;T&gt;" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;">
+  <TypeSignature Language="C#" Value="public class MyList&lt;T&gt; : Mono.DocTest.Generic.GenericBase&lt;T&gt;, System.Collections.Generic.IEnumerable&lt;int[]&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyList`1&lt;T&gt; extends Mono.DocTest.Generic.GenericBase`1&lt;!T&gt; implements class System.Collections.Generic.IEnumerable`1&lt;int32[]&gt;, class System.Collections.IEnumerable" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T">
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("Type Parameter!")</AttributeName>
+        </Attribute>
+      </Attributes>
+    </TypeParameter>
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>Mono.DocTest.Generic.GenericBase&lt;T&gt;</BaseTypeName>
+    <BaseTypeArguments>
+      <BaseTypeArgument TypeParamName="U">T</BaseTypeArgument>
+    </BaseTypeArguments>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>System.Collections.Generic.IEnumerable&lt;System.Int32[]&gt;</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <typeparam name="T">I'm Dying Here!</typeparam>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Generic.MyList`1</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyList ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetEnumerator">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.IEnumerator&lt;int[]&gt; GetEnumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class System.Collections.Generic.IEnumerator`1&lt;int32[]&gt; GetEnumerator() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IEnumerator&lt;System.Int32[]&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`1.GetEnumerator</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetHelper&lt;U,V&gt;">
+      <MemberSignature Language="C#" Value="public Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U,V&gt; GetHelper&lt;U,V&gt; ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!T, !!U, !!V&gt; GetHelper&lt;U, V&gt;() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+        <TypeParameter Name="V" />
+      </TypeParameters>
+      <Parameters />
+      <Docs>
+        <typeparam name="U">To be added.</typeparam>
+        <typeparam name="V">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <returns>
+          <see langword="null" />.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.Generic.MyList`1.GetHelper``2</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Method&lt;U&gt;">
+      <MemberSignature Language="C#" Value="public void Method&lt;U&gt; (T t, U u);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Method&lt;U&gt;(!T t, !!U u) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="t" Type="T" />
+        <Parameter Name="u" Type="U" />
+      </Parameters>
+      <Docs>
+        <typeparam name="U">Method generic parameter</typeparam>
+        <param name="t">Class generic type</param>
+        <param name="u">Method generic type</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`1.Method``1(`0,``0)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RefMethod&lt;U&gt;">
+      <MemberSignature Language="C#" Value="public void RefMethod&lt;U&gt; (ref T t, ref U u);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void RefMethod&lt;U&gt;(!T t, !!U u) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="t" Type="T&amp;" RefType="ref" />
+        <Parameter Name="u" Type="U&amp;" RefType="ref" />
+      </Parameters>
+      <Docs>
+        <typeparam name="U">To be added.</typeparam>
+        <param name="t">To be added.</param>
+        <param name="u">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
+      <MemberSignature Language="C#" Value="System.Collections.IEnumerator IEnumerable.GetEnumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.IEnumerator</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`1.System#Collections#GetEnumerator</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Test">
+      <MemberSignature Language="C#" Value="public void Test (T t);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Test(!T t) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="t" Type="T" />
+      </Parameters>
+      <Docs>
+        <param name="t">tko</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`1.Test(`0)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseHelper&lt;U,V&gt;">
+      <MemberSignature Language="C#" Value="public void UseHelper&lt;U,V&gt; (Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U,V&gt; helper);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void UseHelper&lt;U, V&gt;(class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!T, !!U, !!V&gt; helper) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+        <TypeParameter Name="V" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="helper" Type="Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="U">Argh!</typeparam>
+        <typeparam name="V">Foo Argh!</typeparam>
+        <param name="helper">A <see cref="T:Mono.DocTest.Generic.MyList`1.Helper`2" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Generic.MyList`1.UseHelper``2(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2})</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/MyList`2.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/MyList`2.xml
@@ -1,0 +1,421 @@
+<Type Name="MyList&lt;A,B&gt;" FullName="Mono.DocTest.Generic.MyList&lt;A,B&gt;">
+  <TypeSignature Language="C#" Value="public class MyList&lt;A,B&gt; : Mono.DocTest.Generic.GenericBase&lt;System.Collections.Generic.Dictionary&lt;A,B&gt;&gt;, Mono.DocTest.Generic.IFoo&lt;A&gt;, System.Collections.Generic.ICollection&lt;A&gt;, System.Collections.Generic.IEnumerable&lt;A&gt;, System.Collections.Generic.IEnumerator&lt;A&gt; where A : class, IList&lt;B&gt;, new() where B : class, A" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyList`2&lt;class .ctor (class System.Collections.Generic.IList`1&lt;!B&gt;) A, class (!A) B&gt; extends Mono.DocTest.Generic.GenericBase`1&lt;class System.Collections.Generic.Dictionary`2&lt;!A, !B&gt;&gt; implements class Mono.DocTest.Generic.IFoo`1&lt;!A&gt;, class System.Collections.Generic.ICollection`1&lt;!A&gt;, class System.Collections.Generic.IEnumerable`1&lt;!A&gt;, class System.Collections.Generic.IEnumerator`1&lt;!A&gt;, class System.Collections.IEnumerable, class System.Collections.IEnumerator, class System.IDisposable" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="A">
+      <Constraints>
+        <ParameterAttribute>DefaultConstructorConstraint</ParameterAttribute>
+        <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+        <InterfaceName>System.Collections.Generic.IList&lt;B&gt;</InterfaceName>
+      </Constraints>
+    </TypeParameter>
+    <TypeParameter Name="B">
+      <Constraints>
+        <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+        <BaseTypeName>A</BaseTypeName>
+      </Constraints>
+    </TypeParameter>
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>Mono.DocTest.Generic.GenericBase&lt;System.Collections.Generic.Dictionary&lt;A,B&gt;&gt;</BaseTypeName>
+    <BaseTypeArguments>
+      <BaseTypeArgument TypeParamName="U">System.Collections.Generic.Dictionary&lt;A,B&gt;</BaseTypeArgument>
+    </BaseTypeArguments>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Mono.DocTest.Generic.IFoo&lt;A&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>System.Collections.Generic.ICollection&lt;A&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>System.Collections.Generic.IEnumerable&lt;A&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>System.Collections.Generic.IEnumerator&lt;A&gt;</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <typeparam name="A">Ako generic param</typeparam>
+    <typeparam name="B">Bko generic param</typeparam>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.MyList`2</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyList ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CopyTo">
+      <MemberSignature Language="C#" Value="public void CopyTo (A[] array, int arrayIndex);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void CopyTo(!A[] array, int32 arrayIndex) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="array" Type="A[]" />
+        <Parameter Name="arrayIndex" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="array">Where to copy elements to</param>
+        <param name="arrayIndex">Where to start copyingto</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.CopyTo(`0[],System.Int32)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Count">
+      <MemberSignature Language="C#" Value="public int Count { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 Count" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>A <see cref="T:System.Int32" />.</value>
+        <remarks>
+          <c>P:Mono.DocTest.MyList`2.Count</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Current">
+      <MemberSignature Language="C#" Value="public A Current { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance !A Current" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>A</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>The current value.</value>
+        <remarks>
+          <c>P:Mono.DocTest.MyList`2.Current</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Dispose">
+      <MemberSignature Language="C#" Value="public void Dispose ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Dispose() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.Dispose</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Foo">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.KeyValuePair&lt;System.Collections.Generic.IEnumerable&lt;A&gt;,System.Collections.Generic.IEnumerable&lt;B&gt;&gt; Foo ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance valuetype System.Collections.Generic.KeyValuePair`2&lt;class System.Collections.Generic.IEnumerable`1&lt;!A&gt;, class System.Collections.Generic.IEnumerable`1&lt;!B&gt;&gt; Foo() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.KeyValuePair&lt;System.Collections.Generic.IEnumerable&lt;A&gt;,System.Collections.Generic.IEnumerable&lt;B&gt;&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>M:Mono.DocTest.Generic.MyList`2.Foo</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetEnumerator">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.List&lt;A&gt;.Enumerator GetEnumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance valuetype System.Collections.Generic.List`1/Enumerator&lt;!A&gt; GetEnumerator() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.List&lt;A&gt;+Enumerator</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>A <see cref="T:System.Collections.Generic.List{`0}.Enumerator" />.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.GetEnumerator</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt;">
+      <MemberSignature Language="C#" Value="A IFoo&lt;A&gt;.Method&lt;U&gt; (A a, U u);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance !A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt;(!A a, !!U u) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>A</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="a" Type="A" />
+        <Parameter Name="u" Type="U" />
+      </Parameters>
+      <Docs>
+        <typeparam name="U">U generic param on MyList`2</typeparam>
+        <param name="a">To be added.</param>
+        <param name="u">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.Generic.MyList`2.Mono#DocTest#Generic#IFoo{A}#Method``1(`0,``0)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="MoveNext">
+      <MemberSignature Language="C#" Value="public bool MoveNext ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance bool MoveNext() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>
+          <see cref="T:System.Boolean" />
+        </returns>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.MoveNext</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Reset">
+      <MemberSignature Language="C#" Value="public void Reset ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Reset() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.Reset</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Add">
+      <MemberSignature Language="C#" Value="void ICollection&lt;A&gt;.Add (A item);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void System.Collections.Generic.ICollection&lt;A&gt;.Add(!A item) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="A" />
+      </Parameters>
+      <Docs>
+        <param name="item">The item to add.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.System#Collections#Generic#ICollection{A}#Add(`0)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Clear">
+      <MemberSignature Language="C#" Value="void ICollection&lt;A&gt;.Clear ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void System.Collections.Generic.ICollection&lt;A&gt;.Clear() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.System#Collections#Generic#ICollection{A}#Clear</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Contains">
+      <MemberSignature Language="C#" Value="bool ICollection&lt;A&gt;.Contains (A item);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(!A item) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="A" />
+      </Parameters>
+      <Docs>
+        <param name="item">The item to check for</param>
+        <summary>To be added.</summary>
+        <returns>A <see cref="T:System.Boolean" /> instance (<see langword="false" />).</returns>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.System#Collections#Generic#ICollection{A}.Contains(`0)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.IsReadOnly">
+      <MemberSignature Language="C#" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.IsReadOnly { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool System.Collections.Generic.ICollection&lt;A&gt;.IsReadOnly" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>A <see cref="T:System.Boolean" />.</value>
+        <remarks>
+          <c>P:Mono.DocTest.MyList`2.System#Collections#Generic#ICollection{A}#IsReadOnly</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Remove">
+      <MemberSignature Language="C#" Value="bool ICollection&lt;A&gt;.Remove (A item);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(!A item) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="A" />
+      </Parameters>
+      <Docs>
+        <param name="item">the item to remove</param>
+        <summary>To be added.</summary>
+        <returns>Whether the item was removed.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.System#Collections#Generic#ICollection{A}#Remove(`0)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.IEnumerable&lt;A&gt;.GetEnumerator">
+      <MemberSignature Language="C#" Value="System.Collections.Generic.IEnumerator&lt;A&gt; IEnumerable&lt;A&gt;.GetEnumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class System.Collections.Generic.IEnumerator`1&lt;!A&gt; System.Collections.Generic.IEnumerable&lt;A&gt;.GetEnumerator() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IEnumerator&lt;A&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>A <see cref="T:System.Collections.Generic.IEnumerator{`0}" />.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.System#Collections#Generic#IEnumerable{A}#GetEnumerator</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.IEnumerator&lt;A&gt;.Current">
+      <MemberSignature Language="C#" Value="A System.Collections.Generic.IEnumerator&lt;A&gt;.Current { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance !A System.Collections.Generic.IEnumerator&lt;A&gt;.Current" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>A</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>The current value.</value>
+        <remarks>
+          <c>P:Mono.DocTest.MyList`2.Current</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
+      <MemberSignature Language="C#" Value="System.Collections.IEnumerator IEnumerable.GetEnumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.IEnumerator</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.MyList`2.System#Collections#GetEnumerator</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.IEnumerator.Current">
+      <MemberSignature Language="C#" Value="object System.Collections.IEnumerator.Current { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance object System.Collections.IEnumerator.Current" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Color.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Color.xml
@@ -1,0 +1,86 @@
+<Type Name="Color" FullName="Mono.DocTest.Color">
+  <TypeSignature Language="C#" Value="public enum Color" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed Color extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>Possible colors</summary>
+    <remarks>
+      <see cref="T:Mono.DocTest.Color" />.
+               Namespace Test: [<see cref="N:Mono.DocTest" />]
+             </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="AnotherGreen">
+      <MemberSignature Language="C#" Value="AnotherGreen" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Color AnotherGreen = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Blue">
+      <MemberSignature Language="C#" Value="Blue" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Color Blue = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Insert Blue summary here</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Color.Blue</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Green">
+      <MemberSignature Language="C#" Value="Green" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Color Green = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Insert Green summary here</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Color.Green</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Red">
+      <MemberSignature Language="C#" Value="Red" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Color Red = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Insert Red summary here</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Color.Red</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/D.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/D.xml
@@ -1,0 +1,25 @@
+<Type Name="D" FullName="Mono.DocTest.D">
+  <TypeSignature Language="C#" Value="public delegate dynamic D(Func&lt;string,dynamic,object&gt; value);" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed D extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="value" Type="System.Func&lt;System.String,System.Object,System.Object&gt;" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Object</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <param name="value">To be added.</param>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>
+      <c>T:Mono.DocTest.D</c>
+    </remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/DocAttribute.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/DocAttribute.xml
@@ -1,0 +1,133 @@
+<Type Name="DocAttribute" FullName="Mono.DocTest.DocAttribute">
+  <TypeSignature Language="C#" Value="public class DocAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit DocAttribute extends System.Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.AttributeUsage(System.AttributeTargets.All)</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <para>
+               cref=<c>T:Mono.DocTest.DocAttribute</c>.
+              </para>
+      <format type="text/html">
+        <table width="100%">
+          <tr>
+            <td style="color:red">red</td>
+            <td style="color:blue">blue</td>
+            <td style="color:green">green</td>
+          </tr>
+        </table>
+      </format>
+      <code lang="C#" src="../DocTest.cs#DocAttribute Example">[Doc ("documented class")]
+class Example {
+	[Doc ("documented field")] public string field;
+}
+</code>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public DocAttribute (string docs);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string docs) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="docs" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="docs">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>C:Mono.DocTest.DocAttribute(System.String)</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Field">
+      <MemberSignature Language="C#" Value="public bool Field;" />
+      <MemberSignature Language="ILAsm" Value=".field public bool Field" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.DocAttribute.Field</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FlagsEnum">
+      <MemberSignature Language="C#" Value="public ConsoleModifiers FlagsEnum;" />
+      <MemberSignature Language="ILAsm" Value=".field public valuetype System.ConsoleModifiers FlagsEnum" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.ConsoleModifiers</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.DocAttribute.FlagsEnum</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NonFlagsEnum">
+      <MemberSignature Language="C#" Value="public Mono.DocTest.Color NonFlagsEnum;" />
+      <MemberSignature Language="ILAsm" Value=".field public valuetype Mono.DocTest.Color NonFlagsEnum" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.DocAttribute.NonFlagsEnum</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Property">
+      <MemberSignature Language="C#" Value="public Type Property { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Type Property" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Type</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>
+          <c>P:Mono.DocTest.DocAttribute.Property</c>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/DocValueType.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/DocValueType.xml
@@ -1,0 +1,61 @@
+<Type Name="DocValueType" FullName="Mono.DocTest.DocValueType">
+  <TypeSignature Language="C#" Value="public struct DocValueType : Mono.DocTest.IProcess" />
+  <TypeSignature Language="ILAsm" Value=".class public sequential ansi sealed beforefieldinit DocValueType extends System.ValueType implements class Mono.DocTest.IProcess" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.ValueType</BaseTypeName>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Mono.DocTest.IProcess</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <summary>Process interface</summary>
+    <remarks>
+      <c>T:Mono.DocTest.DocValueType</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="M">
+      <MemberSignature Language="C#" Value="public void M (int i);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="i" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="i">A <see cref="T:System.Int32" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <see cref="M:Mono.DocTest.DocValueType.M(System.Int32)" />.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="total">
+      <MemberSignature Language="C#" Value="public int total;" />
+      <MemberSignature Language="ILAsm" Value=".field public int32 total" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.DocValueType.total</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/IProcess.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/IProcess.xml
@@ -1,0 +1,15 @@
+<Type Name="IProcess" FullName="Mono.DocTest.IProcess">
+  <TypeSignature Language="C#" Value="public interface IProcess" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract IProcess" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Interfaces />
+  <Docs>
+    <summary>Process interface</summary>
+    <remarks>
+      <c>T:Mono.DocTest.IProcess</c>.</remarks>
+  </Docs>
+  <Members />
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/UseLists.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/UseLists.xml
@@ -1,0 +1,194 @@
+<Type Name="UseLists" FullName="Mono.DocTest.UseLists">
+  <TypeSignature Language="C#" Value="public class UseLists" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit UseLists extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.UseLists</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public UseLists ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetValues&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public Mono.DocTest.Generic.MyList&lt;T&gt; GetValues&lt;T&gt; (T value) where T : struct;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class Mono.DocTest.Generic.MyList`1&lt;!!T&gt; GetValues&lt;struct .ctor (class System.ValueType) T&gt;(!!T value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Generic.MyList&lt;T&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T">
+          <Constraints>
+            <ParameterAttribute>DefaultConstructorConstraint</ParameterAttribute>
+            <ParameterAttribute>NotNullableValueTypeConstraint</ParameterAttribute>
+            <BaseTypeName>System.ValueType</BaseTypeName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="value" Type="T" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">Something</typeparam>
+        <param name="value">A <c>T</c>.</param>
+        <summary>To be added.</summary>
+        <returns>A <see cref="T:Mono.DocTest.Generic.MyList`1" /> instance.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.UseLists.GetValues``1(``0)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Process">
+      <MemberSignature Language="C#" Value="public void Process (Mono.DocTest.Generic.MyList&lt;int&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Process(class Mono.DocTest.Generic.MyList`1&lt;int32&gt; list) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="list" Type="Mono.DocTest.Generic.MyList&lt;System.Int32&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="list">A <see cref="T:Mono.DocTest.Generic.MyList{System.Int32}" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.UseLists.Process(Mono.DocTest.MyList{System.Int32})</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Process">
+      <MemberSignature Language="C#" Value="public void Process (System.Collections.Generic.List&lt;int&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Process(class System.Collections.Generic.List`1&lt;int32&gt; list) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="list" Type="System.Collections.Generic.List&lt;System.Int32&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="list">Another <see cref="T:Mono.DocTest.Generic.MyList{System.Int32}" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <para>
+            <c>M:Mono.DocTest.UseLists.Process(System.Collections.Generic.List{System.Int32})</c>.</para>
+          <para>
+            <see cref="M:System.Collections.Generic.List{System.Int32}.Remove(`0)" />
+          </para>
+        </remarks>
+        <exception cref="Whatever">text!</exception>
+      </Docs>
+    </Member>
+    <Member MemberName="Process">
+      <MemberSignature Language="C#" Value="public void Process (System.Collections.Generic.List&lt;Predicate&lt;int&gt;&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Process(class System.Collections.Generic.List`1&lt;class System.Predicate`1&lt;int32&gt;&gt; list) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="list" Type="System.Collections.Generic.List&lt;System.Predicate&lt;System.Int32&gt;&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="list">A <see cref="T:Mono.DocTest.Generic.MyList{System.Predicate{System.Int32}}" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.UseLists.Process(System.Collections.Generic.List{System.Predicate{System.Int32}})</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Process&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public void Process&lt;T&gt; (System.Collections.Generic.List&lt;Predicate&lt;T&gt;&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Process&lt;T&gt;(class System.Collections.Generic.List`1&lt;class System.Predicate`1&lt;!!T&gt;&gt; list) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="list" Type="System.Collections.Generic.List&lt;System.Predicate&lt;T&gt;&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">Something Else</typeparam>
+        <param name="list">A <see cref="T:Mono.DocTest.Generic.MyList{System.Predicate{``0}}" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.UseLists.Process``1(System.Collections.Generic.List{System.Predicate{``0}})</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseHelper&lt;T,U,V&gt;">
+      <MemberSignature Language="C#" Value="public void UseHelper&lt;T,U,V&gt; (Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U,V&gt; helper);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void UseHelper&lt;T, U, V&gt;(class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!!T, !!U, !!V&gt; helper) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+        <TypeParameter Name="U" />
+        <TypeParameter Name="V" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="helper" Type="Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">
+          <c>T</c>
+        </typeparam>
+        <typeparam name="U">
+          <c>U</c>
+        </typeparam>
+        <typeparam name="V">
+          <c>V</c>
+        </typeparam>
+        <param name="helper">A <see cref="T:Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2}" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.UseLists.UseHelper``3(Mono.DocTest.Generic.MyList{``0}.Helper{``1,``2})</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+Del.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+Del.xml
@@ -1,0 +1,23 @@
+<Type Name="Widget+Del" FullName="Mono.DocTest.Widget+Del">
+  <TypeSignature Language="C#" Value="public delegate void Widget.Del(int i);" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed Widget/Del extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="i" Type="System.Int32" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Void</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <param name="i">To be added.</param>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Widget.Del</c>.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+Direction.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+Direction.xml
@@ -1,0 +1,91 @@
+<Type Name="Widget+Direction" FullName="Mono.DocTest.Widget+Direction">
+  <TypeSignature Language="C#" Value="protected enum Widget.Direction" />
+  <TypeSignature Language="ILAsm" Value=".class nested protected auto ansi sealed Widget/Direction extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.Flags</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Widget.Direction</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="East">
+      <MemberSignature Language="C#" Value="East" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Widget/Direction East = int32(2)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Direction</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>T:Mono.DocTest.Widget.Direction.East</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="North">
+      <MemberSignature Language="C#" Value="North" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Widget/Direction North = int32(0)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Direction</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>T:Mono.DocTest.Widget.Direction.North</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="South">
+      <MemberSignature Language="C#" Value="South" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Widget/Direction South = int32(1)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Direction</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>T:Mono.DocTest.Widget.Direction.South</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="West">
+      <MemberSignature Language="C#" Value="West" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Widget/Direction West = int32(3)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Direction</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>T:Mono.DocTest.Widget.Direction.West</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+IMenuItem.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+IMenuItem.xml
@@ -1,0 +1,52 @@
+<Type Name="Widget+IMenuItem" FullName="Mono.DocTest.Widget+IMenuItem">
+  <TypeSignature Language="C#" Value="public interface Widget.IMenuItem" />
+  <TypeSignature Language="ILAsm" Value=".class nested public interface auto ansi abstract Widget/IMenuItem" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Widget.IMenuItem</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="A">
+      <MemberSignature Language="C#" Value="public void A ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void A() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.IMenuItem.A</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="B">
+      <MemberSignature Language="C#" Value="public int B { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 B" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>
+          <c>P:Mono.DocTest.Widget.IMenuItem.P</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+NestedClass+Double+Triple+Quadruple.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+NestedClass+Double+Triple+Quadruple.xml
@@ -1,0 +1,33 @@
+<Type Name="Widget+NestedClass+Double+Triple+Quadruple" FullName="Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple">
+  <TypeSignature Language="C#" Value="public class Widget.NestedClass.Double.Triple.Quadruple" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit Widget/NestedClass/Double/Triple/Quadruple extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Quadruple ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+NestedClass+Double+Triple.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+NestedClass+Double+Triple.xml
@@ -1,0 +1,33 @@
+<Type Name="Widget+NestedClass+Double+Triple" FullName="Mono.DocTest.Widget+NestedClass+Double+Triple">
+  <TypeSignature Language="C#" Value="public class Widget.NestedClass.Double.Triple" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit Widget/NestedClass/Double/Triple extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Widget.NestedClass.Double.Triple</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Triple ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+NestedClass+Double.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+NestedClass+Double.xml
@@ -1,0 +1,33 @@
+<Type Name="Widget+NestedClass+Double" FullName="Mono.DocTest.Widget+NestedClass+Double">
+  <TypeSignature Language="C#" Value="public class Widget.NestedClass.Double" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit Widget/NestedClass/Double extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Widget.NestedClass.Double</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Double ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+NestedClass.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+NestedClass.xml
@@ -1,0 +1,71 @@
+<Type Name="Widget+NestedClass" FullName="Mono.DocTest.Widget+NestedClass">
+  <TypeSignature Language="C#" Value="public class Widget.NestedClass" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit Widget/NestedClass extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Widget.NestedClass</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public NestedClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M">
+      <MemberSignature Language="C#" Value="public void M (int i);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="i" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="i">Some <see cref="T:System.Int32" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.NestedClass.M(System.Int32)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="value">
+      <MemberSignature Language="C#" Value="public int value;" />
+      <MemberSignature Language="ILAsm" Value=".field public int32 value" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.NestedClass.value</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+NestedClass`1.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+NestedClass`1.xml
@@ -1,0 +1,75 @@
+<Type Name="Widget+NestedClass&lt;T&gt;" FullName="Mono.DocTest.Widget+NestedClass&lt;T&gt;">
+  <TypeSignature Language="C#" Value="public class Widget.NestedClass&lt;T&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit Widget/NestedClass`1&lt;T&gt; extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <typeparam name="T">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Widget.NestedClass`1</c>.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public NestedClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M">
+      <MemberSignature Language="C#" Value="public void M (int i);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="i" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="i">Another <see cref="T:System.Int32" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.NestedClass`1.M(System.Int32)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="value">
+      <MemberSignature Language="C#" Value="public int value;" />
+      <MemberSignature Language="ILAsm" Value=".field public int32 value" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.NestedClass`1.value</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget.xml
@@ -1,0 +1,970 @@
+<Type Name="Widget" FullName="Mono.DocTest.Widget">
+  <TypeSignature Language="C#" Value="public class Widget : Mono.DocTest.IProcess" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Widget extends System.Object implements class Mono.DocTest.IProcess" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Mono.DocTest.IProcess</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:Mono.DocTest.Widget</c>.</remarks>
+    <altmember cref="P:Mono.DocTest.Widget.Item(System.Int32)" />
+    <extra>Some extra tag value</extra>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Widget ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <para>
+            <c>C:Mono.DocTest.Widget</c>.</para>
+          <para>
+            <c>M:Mono.DocTest.Widget.#ctor</c>.</para>
+          <para>
+            <see cref="C:Mono.DocTest.Widget(System.String)" />
+          </para>
+          <para>
+            <see cref="C:Mono.DocTest.Widget(System.Converter{System.String,System.String})" />
+          </para>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Widget (Converter&lt;string,string&gt; c);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(class System.Converter`2&lt;string, string&gt; c) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="c" Type="System.Converter&lt;System.String,System.String&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="c">A <see cref="T:System.Converter{System.String,System.String}" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <para>
+            <c>C:Mono.DocTest.Widget(System.Converter{System.String,System.String})</c>.</para>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Widget (string s);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string s) cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="s" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="s">A <see cref="T:System.String" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <para>
+            <c>C:Mono.DocTest.Widget(System.String)</c>.</para>
+          <para>
+            <c>M:Mono.DocTest.Widget.#ctor(System.String)</c>.</para>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AnEvent">
+      <MemberSignature Language="C#" Value="public event Mono.DocTest.Widget.Del AnEvent;" />
+      <MemberSignature Language="ILAsm" Value=".event class Mono.DocTest.Widget/Del AnEvent" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("Del event")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>add: Mono.DocTest.Doc("Del add accessor")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>remove: Mono.DocTest.Doc("Del remove accessor")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Del</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>E:Mono.DocTest.Widget.AnEvent</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AnotherEvent">
+      <MemberSignature Language="C#" Value="protected event Mono.DocTest.Widget.Del AnotherEvent;" />
+      <MemberSignature Language="ILAsm" Value=".event class Mono.DocTest.Widget/Del AnotherEvent" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Del</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>E:Mono.DocTest.Widget.AnotherEvent</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="array1">
+      <MemberSignature Language="C#" Value="public long[] array1;" />
+      <MemberSignature Language="ILAsm" Value=".field public int64[] array1" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int64[]</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.array1</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="array2">
+      <MemberSignature Language="C#" Value="public Mono.DocTest.Widget[,] array2;" />
+      <MemberSignature Language="ILAsm" Value=".field public class Mono.DocTest.Widget[,] array2" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget[,]</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.array2</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="classCtorError">
+      <MemberSignature Language="C#" Value="public static readonly string[] classCtorError;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly string[] classCtorError" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String[]</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.classCtorError</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Default">
+      <MemberSignature Language="C#" Value="public void Default (int a = 1, int b = 2);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Default(int32 a, int32 b) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="System.Int32" />
+        <Parameter Name="b" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="a">To be added.</param>
+        <param name="b">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.Default(System.Int32,System.Int32)</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Default">
+      <MemberSignature Language="C#" Value="public void Default (string a = &quot;a&quot;, char b = 'b');" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Default(string a, char b) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="System.String" />
+        <Parameter Name="b" Type="System.Char" />
+      </Parameters>
+      <Docs>
+        <param name="a">To be added.</param>
+        <param name="b">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.Default(System.String,System.Char)</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="defaultColor">
+      <MemberSignature Language="C#" Value="protected static Mono.DocTest.Color defaultColor;" />
+      <MemberSignature Language="ILAsm" Value=".field family static valuetype Mono.DocTest.Color defaultColor" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.defaultColor</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Dynamic0">
+      <MemberSignature Language="C#" Value="public dynamic Dynamic0 (dynamic a, dynamic b);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance object Dynamic0(object a, object b) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="System.Object" />
+        <Parameter Name="b" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="a">To be added.</param>
+        <param name="b">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Dynamic1">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.Dictionary&lt;dynamic,string&gt; Dynamic1 (System.Collections.Generic.Dictionary&lt;dynamic,string&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Collections.Generic.Dictionary`2&lt;object, string&gt; Dynamic1(class System.Collections.Generic.Dictionary`2&lt;object, string&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.Dictionary&lt;System.Object,System.String&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Collections.Generic.Dictionary&lt;System.Object,System.String&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Dynamic2">
+      <MemberSignature Language="C#" Value="public Func&lt;string,dynamic&gt; Dynamic2 (Func&lt;string,dynamic&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Func`2&lt;string, object&gt; Dynamic2(class System.Func`2&lt;string, object&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.String,System.Object&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Func&lt;System.String,System.Object&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Dynamic3">
+      <MemberSignature Language="C#" Value="public Func&lt;Func&lt;string,dynamic&gt;,Func&lt;dynamic,string&gt;&gt; Dynamic3 (Func&lt;Func&lt;string,dynamic&gt;,Func&lt;dynamic,string&gt;&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Func`2&lt;class System.Func`2&lt;string, object&gt;, class System.Func`2&lt;object, string&gt;&gt; Dynamic3(class System.Func`2&lt;class System.Func`2&lt;string, object&gt;, class System.Func`2&lt;object, string&gt;&gt; value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.Func&lt;System.String,System.Object&gt;,System.Func&lt;System.Object,System.String&gt;&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Func&lt;System.Func&lt;System.String,System.Object&gt;,System.Func&lt;System.Object,System.String&gt;&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DynamicE1">
+      <MemberSignature Language="C#" Value="public event Func&lt;dynamic&gt; DynamicE1;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.Func`1&lt;object&gt; DynamicE1" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Obsolete("why not")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.Object&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>E:Mono.DocTest.Widget.DynamicE1</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DynamicE2">
+      <MemberSignature Language="C#" Value="public event Func&lt;dynamic&gt; DynamicE2;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.Func`1&lt;object&gt; DynamicE2" />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.Object&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>E:Mono.DocTest.Widget.DynamicE2</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DynamicF">
+      <MemberSignature Language="C#" Value="public Func&lt;Func&lt;string,dynamic,string&gt;,Func&lt;dynamic,Func&lt;dynamic&gt;,string&gt;&gt; DynamicF;" />
+      <MemberSignature Language="ILAsm" Value=".field public class System.Func`2&lt;class System.Func`3&lt;string, object, string&gt;, class System.Func`3&lt;object, class System.Func`1&lt;object&gt;, string&gt;&gt; DynamicF" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.Func&lt;System.String,System.Object,System.String&gt;,System.Func&lt;System.Object,System.Func&lt;System.Object&gt;,System.String&gt;&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.DynamicF</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DynamicP">
+      <MemberSignature Language="C#" Value="public Func&lt;Func&lt;string,dynamic,string&gt;,Func&lt;dynamic,Func&lt;dynamic&gt;,string&gt;&gt; DynamicP { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Func`2&lt;class System.Func`3&lt;string, object, string&gt;, class System.Func`3&lt;object, class System.Func`1&lt;object&gt;, string&gt;&gt; DynamicP" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.Func&lt;System.String,System.Object,System.String&gt;,System.Func&lt;System.Object,System.Func&lt;System.Object&gt;,System.String&gt;&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>
+          <c>P:Mono.DocTest.Widget.DynamicP</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Height">
+      <MemberSignature Language="C#" Value="protected long Height { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int64 Height" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("Height property")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Int64</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>A <see cref="T:System.Int64" /> value...</value>
+        <remarks>
+          <c>P:Mono.DocTest.Widget.Height</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Item">
+      <MemberSignature Language="C#" Value="public int this[int i] { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 Item(int32)" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("Item property")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>set: Mono.DocTest.Doc("Item property set accessor")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="i" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="i">TODO</param>
+        <summary>To be added.</summary>
+        <value>A <see cref="T:System.Int32" /> instance.</value>
+        <remarks>
+          <c>P:Mono.DocTest.Widget.Item(System.Int32)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Item">
+      <MemberSignature Language="C#" Value="public int this[string s, int i] { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 Item(string, int32)" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="s" Type="System.String" />
+        <Parameter Name="i" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="s">Some <see cref="T:System.String" />.</param>
+        <param name="i">I love <see cref="T:System.Int32" />s.</param>
+        <summary>To be added.</summary>
+        <value>A <see cref="T:System.Int32" /> instance.</value>
+        <remarks>
+          <c>P:Mono.DocTest.Widget.Item(System.String,System.Int32)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M0">
+      <MemberSignature Language="C#" Value="public static void M0 ();" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void M0() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.M0</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M1">
+      <MemberSignature Language="C#" Value="public void M1 (char c, out float f, ref Mono.DocTest.DocValueType v);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M1(char c, float32 f, valuetype Mono.DocTest.DocValueType v) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("normal DocAttribute", Field=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+        <Attributes>
+          <Attribute>
+            <AttributeName>Mono.DocTest.Doc("return:DocAttribute", Property=typeof(Mono.DocTest.Widget))</AttributeName>
+          </Attribute>
+        </Attributes>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="c" Type="System.Char">
+          <Attributes>
+            <Attribute>
+              <AttributeName>Mono.DocTest.Doc("c", FlagsEnum=System.ConsoleModifiers.Alt | System.ConsoleModifiers.Control)</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+        <Parameter Name="f" Type="System.Single&amp;" RefType="out">
+          <Attributes>
+            <Attribute>
+              <AttributeName>Mono.DocTest.Doc("f", NonFlagsEnum=Mono.DocTest.Color.Red)</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+        <Parameter Name="v" Type="Mono.DocTest.DocValueType&amp;" RefType="ref">
+          <Attributes>
+            <Attribute>
+              <AttributeName>Mono.DocTest.Doc("v")</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+      </Parameters>
+      <Docs>
+        <param name="c">A <see cref="T:System.Char" />.</param>
+        <param name="f">A <see cref="T:System.Single" />.</param>
+        <param name="v">A <see cref="T:Mono.DocTest.DocValueType" />.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.M1(System.Char,System.Signle@,Mono.DocTest.DocValueType@)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M2">
+      <MemberSignature Language="C#" Value="public void M2 (short[] x1, int[,] x2, long[][] x3);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M2(int16[] x1, int32[,] x2, int64[][] x3) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x1" Type="System.Int16[]" />
+        <Parameter Name="x2" Type="System.Int32[,]" />
+        <Parameter Name="x3" Type="System.Int64[][]" />
+      </Parameters>
+      <Docs>
+        <param name="x1">A <see cref="T:System.Int16" /> array.</param>
+        <param name="x2">A <see cref="T:System.Int32" /> array.</param>
+        <param name="x3">A <see cref="T:System.Int64" /> array.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.M2(System.Int16[],System.Int32[0:,0:],System.Int64[][])</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M3">
+      <MemberSignature Language="C#" Value="protected void M3 (long[][] x3, Mono.DocTest.Widget[,,][] x4);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M3(int64[][] x3, class Mono.DocTest.Widget[,,][] x4) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x3" Type="System.Int64[][]" />
+        <Parameter Name="x4" Type="Mono.DocTest.Widget[,,][]" />
+      </Parameters>
+      <Docs>
+        <param name="x3">Another <see cref="T:System.Int64" /> array.</param>
+        <param name="x4">A <see cref="T:Mono.DocTest.Widget" /> array.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.M3(System.Int64[][],Mono.DocTest.Widget[0:,0:,0:][])</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M4">
+      <MemberSignature Language="C#" Value="protected void M4 (char* pc, Mono.DocTest.Color** ppf);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M4(char* pc, valuetype Mono.DocTest.Color** ppf) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="pc" Type="System.Char*" />
+        <Parameter Name="ppf" Type="Mono.DocTest.Color**" />
+      </Parameters>
+      <Docs>
+        <param name="pc">A <see cref="T:System.Char" /> pointer.</param>
+        <param name="ppf">A <see cref="T:Mono.DocTest.Color" /> pointer.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.M4(System.Char*,Mono.DocTest.Color**)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M5">
+      <MemberSignature Language="C#" Value="protected void M5 (void* pv, double*[,][] pd);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M5(void* pv, float64*[,][] pd) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="pv" Type="System.Void*" />
+        <Parameter Name="pd" Type="System.Double*[,][]" />
+      </Parameters>
+      <Docs>
+        <param name="pv">A <see cref="T:System.Void" /> pointer.</param>
+        <param name="pd">A <see cref="T:System.Double" /> array.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.M5(System.Void*,System.Double*[0:,0:][])</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M6">
+      <MemberSignature Language="C#" Value="protected void M6 (int i, object[] args);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M6(int32 i, object[] args) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="i" Type="System.Int32" />
+        <Parameter Name="args" Type="System.Object[]">
+          <Attributes>
+            <Attribute>
+              <AttributeName>System.ParamArray</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+      </Parameters>
+      <Docs>
+        <param name="i">Yet another <see cref="T:System.Int32" />.</param>
+        <param name="args">An <see cref="T:System.Object" /> array.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.M6(System.Int32,System.Object[])</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M7">
+      <MemberSignature Language="C#" Value="public void M7 (Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple a);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M7(class Mono.DocTest.Widget/NestedClass/Double/Triple/Quadruple a) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple" />
+      </Parameters>
+      <Docs>
+        <param name="a">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.M7(Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="message">
+      <MemberSignature Language="C#" Value="public string message;" />
+      <MemberSignature Language="ILAsm" Value=".field public string message" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.message</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="monthlyAverage">
+      <MemberSignature Language="C#" Value="protected readonly double monthlyAverage;" />
+      <MemberSignature Language="ILAsm" Value=".field familyorassembly initonly float64 monthlyAverage" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.monthlyAverage</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Addition">
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_Addition (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_Addition(class Mono.DocTest.Widget x1, class Mono.DocTest.Widget x2) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x1" Type="Mono.DocTest.Widget" />
+        <Parameter Name="x2" Type="Mono.DocTest.Widget" />
+      </Parameters>
+      <Docs>
+        <param name="x1">Yet Another <see cref="T:Mono.DocTest.Widget" />.</param>
+        <param name="x2">Yay, <see cref="T:Mono.DocTest.Widget" />s.</param>
+        <summary>To be added.</summary>
+        <returns>A <see cref="T:Mono.DocTest.Widget" /> instance (2).</returns>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.op_Addition(Mono.DocTest.Widget,Mono.DocTest.Widget)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Division">
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_Division;" />
+      <MemberSignature Language="ILAsm" Value=".field public static class Mono.DocTest.Widget op_Division" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>A <see cref="T:Mono.DocTest.Widget" /> instance.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.op_Division</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Explicit">
+      <MemberSignature Language="C#" Value="public static int op_Explicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int32 op_Explicit(class Mono.DocTest.Widget x) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="Mono.DocTest.Widget" />
+      </Parameters>
+      <Docs>
+        <param name="x">
+          <see cref="T:Mono.DocTest.Widget" />s are fun!.</param>
+        <summary>To be added.</summary>
+        <returns>A <see cref="T:System.Int32" /> instance.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.op_Explicit(Mono.DocTest.Widget)~System.Int32</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Implicit">
+      <MemberSignature Language="C#" Value="public static long op_Implicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int64 op_Implicit(class Mono.DocTest.Widget x) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int64</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="Mono.DocTest.Widget" />
+      </Parameters>
+      <Docs>
+        <param name="x">
+          <c>foo</c>; <see cref="T:Mono.DocTest.Widget" />.</param>
+        <summary>To be added.</summary>
+        <returns>A <see cref="T:System.Int64" /> instance.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.op_Implicit(Mono.DocTest.Widget)~System.Int64</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_UnaryPlus">
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_UnaryPlus (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_UnaryPlus(class Mono.DocTest.Widget x) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="Mono.DocTest.Widget" />
+      </Parameters>
+      <Docs>
+        <param name="x">Another <see cref="T:Mono.DocTest.Widget" />.</param>
+        <summary>To be added.</summary>
+        <returns>A <see cref="T:Mono.DocTest.Widget" /> instance.</returns>
+        <remarks>
+          <c>M:Mono.DocTest.Widget.op_UnaryPlus(Mono.DocTest.Widget)</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="pCount">
+      <MemberSignature Language="C#" Value="public int* pCount;" />
+      <MemberSignature Language="ILAsm" Value=".field public int32* pCount" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32*</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.pCount</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PI">
+      <MemberSignature Language="C#" Value="protected const double PI = 3.14159;" />
+      <MemberSignature Language="ILAsm" Value=".field familyorassembly static literal float64 PI = (3.14159)" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <MemberValue>3.14159</MemberValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.PI</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ppValues">
+      <MemberSignature Language="C#" Value="public float** ppValues;" />
+      <MemberSignature Language="ILAsm" Value=".field public float32** ppValues" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single**</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>
+          <c>F:Mono.DocTest.Widget.ppValues</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Width">
+      <MemberSignature Language="C#" Value="public int Width { get; protected set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 Width" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("Width property")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>get: Mono.DocTest.Doc("Width get accessor")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>set: Mono.DocTest.Doc("Width set accessor")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>A <see cref="T:System.Int32" /> value...</value>
+        <remarks>
+          <c>P:Mono.DocTest.Widget.Width</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="X">
+      <MemberSignature Language="C#" Value="protected short X { set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int16 X" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int16</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>A <see cref="T:System.Int16" /> value...</value>
+        <remarks>
+          <c>P:Mono.DocTest.Widget.X</c>.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Y">
+      <MemberSignature Language="C#" Value="protected double Y { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance float64 Y" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>A <see cref="T:System.Double" /> value...</value>
+        <remarks>
+          <c>P:Mono.DocTest.Widget.Y</c>.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/MyFramework.MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-fx-import/MyFramework.MyNamespace/MyClass.xml
@@ -1,0 +1,87 @@
+<Type Name="MyClass" FullName="MyFramework.MyNamespace.MyClass">
+  <TypeSignature Language="C#" Value="public class MyClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyClass extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>MyClass summary</summary>
+    <remarks>my class remarks</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Hello">
+      <MemberSignature Language="C#" Value="public float Hello (int value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="MyProperty">
+      <MemberSignature Language="C#" Value="public string MyProperty { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string MyProperty" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>MyProperty Summary</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="OnlyInClassic">
+      <MemberSignature Language="C#" Value="public double OnlyInClassic { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance float64 OnlyInClassic" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/MyFramework.MyNamespace/MyClassExtensions.xml
+++ b/mdoc/Test/en.expected-fx-import/MyFramework.MyNamespace/MyClassExtensions.xml
@@ -1,0 +1,39 @@
+<Type Name="MyClassExtensions" FullName="MyFramework.MyNamespace.MyClassExtensions">
+  <TypeSignature Language="C#" Value="public static class MyClassExtensions" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit MyClassExtensions extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="AnExtension">
+      <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/MyFramework.MyOtherNamespace/MyOtherClass.xml
+++ b/mdoc/Test/en.expected-fx-import/MyFramework.MyOtherNamespace/MyOtherClass.xml
@@ -1,7 +1,7 @@
 <Type Name="MyOtherClass" FullName="MyFramework.MyOtherNamespace.MyOtherClass">
   <TypeSignature Language="C#" Value="public class MyOtherClass" />
   <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyOtherClass extends System.Object" />
-  <AssemblyInfo apistyle="classic">
+  <AssemblyInfo>
     <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
   </AssemblyInfo>
@@ -10,15 +10,15 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
+    <summary>Make sure the namespace in this assembly doesn't get 'dropped'</summary>
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
-    <Member MemberName=".ctor" apistyle="classic">
+    <Member MemberName=".ctor">
       <MemberSignature Language="C#" Value="public MyOtherClass ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
       <MemberType>Constructor</MemberType>
-      <AssemblyInfo apistyle="classic">
+      <AssemblyInfo>
         <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
@@ -28,11 +28,11 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Hello" apistyle="classic">
+    <Member MemberName="Hello">
       <MemberSignature Language="C#" Value="public float Hello (double value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(float64 value) cil managed" />
       <MemberType>Method</MemberType>
-      <AssemblyInfo apistyle="classic">
+      <AssemblyInfo>
         <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
@@ -44,16 +44,16 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
+        <summary>Is it me you're looking for</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="Hello" apistyle="classic">
+    <Member MemberName="Hello">
       <MemberSignature Language="C#" Value="public float Hello (int value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
       <MemberType>Method</MemberType>
-      <AssemblyInfo apistyle="classic">
+      <AssemblyInfo>
         <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
@@ -65,16 +65,16 @@
       </Parameters>
       <Docs>
         <param name="value">To be added.</param>
-        <summary>To be added.</summary>
+        <summary>Hello</summary>
         <returns>To be added.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
-    <Member MemberName="MyProperty" apistyle="classic">
+    <Member MemberName="MyProperty">
       <MemberSignature Language="C#" Value="public string MyProperty { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string MyProperty" />
       <MemberType>Property</MemberType>
-      <AssemblyInfo apistyle="classic">
+      <AssemblyInfo>
         <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>

--- a/mdoc/Test/en.expected-fx-import/NoNamespace.xml
+++ b/mdoc/Test/en.expected-fx-import/NoNamespace.xml
@@ -1,0 +1,34 @@
+<Type Name="NoNamespace" FullName="NoNamespace">
+  <TypeSignature Language="C#" Value="public class NoNamespace" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit NoNamespace extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>Namespace Test: [<see cref="N:Mono.DocTest" />] <see href="http://www.mono-project.com/">Mono Project</see></summary>
+    <remarks>
+      <c>T:NoNamespace</c>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public NoNamespace ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/System/Action`1.xml
+++ b/mdoc/Test/en.expected-fx-import/System/Action`1.xml
@@ -1,0 +1,28 @@
+<Type Name="Action&lt;T&gt;" FullName="System.Action&lt;T&gt;">
+  <TypeSignature Language="C#" Value="public delegate void Action&lt;T&gt;(T obj);" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed Action`1&lt;T&gt; extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="obj" Type="T" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Void</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <typeparam name="T">To be added.</typeparam>
+    <param name="obj">To be added.</param>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:System.Action`1</c>
+    </remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/System/Array.xml
+++ b/mdoc/Test/en.expected-fx-import/System/Array.xml
@@ -1,0 +1,112 @@
+<Type Name="Array" FullName="System.Array">
+  <TypeSignature Language="C#" Value="public class Array" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Array extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Array ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AsReadOnly&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt; AsReadOnly&lt;T&gt; (T[] array);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.ObjectModel.ReadOnlyCollection`1&lt;!!T&gt; AsReadOnly&lt;T&gt;(!!T[] array) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="array" Type="T[]" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="array">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertAll&lt;TInput,TOutput&gt;">
+      <MemberSignature Language="C#" Value="public static TOutput[] ConvertAll&lt;TInput,TOutput&gt; (TInput[] array, Converter&lt;TInput,TOutput&gt; converter);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig !!TOutput[] ConvertAll&lt;TInput, TOutput&gt;(!!TInput[] array, class System.Converter`2&lt;!!TInput, !!TOutput&gt; converter) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>TOutput[]</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TInput" />
+        <TypeParameter Name="TOutput" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="array" Type="TInput[]" />
+        <Parameter Name="converter" Type="System.Converter&lt;TInput,TOutput&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TInput">To be added.</typeparam>
+        <typeparam name="TOutput">To be added.</typeparam>
+        <param name="array">To be added.</param>
+        <param name="converter">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Resize&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static void Resize&lt;T&gt; (ref T[] array, int newSize);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Resize&lt;T&gt;(!!T[] array, int32 newSize) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="array" Type="T[]&amp;" RefType="ref" />
+        <Parameter Name="newSize" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="array">To be added.</param>
+        <param name="newSize">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/System/AsyncCallback.xml
+++ b/mdoc/Test/en.expected-fx-import/System/AsyncCallback.xml
@@ -1,0 +1,22 @@
+<Type Name="AsyncCallback" FullName="System.AsyncCallback">
+  <TypeSignature Language="C#" Value="public delegate void AsyncCallback(IAsyncResult ar);" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed AsyncCallback extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="ar" Type="System.IAsyncResult" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Void</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <param name="ar">To be added.</param>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/System/Environment+SpecialFolder.xml
+++ b/mdoc/Test/en.expected-fx-import/System/Environment+SpecialFolder.xml
@@ -1,0 +1,18 @@
+<Type Name="Environment+SpecialFolder" FullName="System.Environment+SpecialFolder">
+  <TypeSignature Language="C#" Value="public enum Environment.SpecialFolder" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed Environment/SpecialFolder extends System.Enum" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:System.Environment+SpecialFolder</c>
+    </remarks>
+  </Docs>
+  <Members />
+</Type>

--- a/mdoc/Test/en.expected-fx-import/System/Environment.xml
+++ b/mdoc/Test/en.expected-fx-import/System/Environment.xml
@@ -1,0 +1,78 @@
+<Type Name="Environment" FullName="System.Environment">
+  <TypeSignature Language="C#" Value="public static class Environment" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit Environment extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>
+      <c>T:System.Environment</c>
+    </remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="GetFolderPath">
+      <MemberSignature Language="C#" Value="public static string GetFolderPath (Environment.SpecialFolder folder);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig string GetFolderPath(valuetype System.Environment/SpecialFolder folder) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="folder" Type="System.Environment+SpecialFolder" />
+      </Parameters>
+      <Docs>
+        <param name="folder">
+               A <see cref="T:System.Environment+SpecialFolder" /> instance.
+             </param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>
+          <c>M:System.Environment.GetFolderPath(System.Environment+SpecialFolder)</c>
+        </remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsAligned&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static bool IsAligned&lt;T&gt; (this T[] vect, int index) where T : struct;" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsAligned&lt;struct .ctor (class System.ValueType) T&gt;(!!T[] vect, int32 index) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T">
+          <Constraints>
+            <ParameterAttribute>DefaultConstructorConstraint</ParameterAttribute>
+            <ParameterAttribute>NotNullableValueTypeConstraint</ParameterAttribute>
+            <BaseTypeName>System.ValueType</BaseTypeName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="vect" Type="T[]" RefType="this" />
+        <Parameter Name="index" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="vect">To be added.</param>
+        <param name="index">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/index.xml
+++ b/mdoc/Test/en.expected-fx-import/index.xml
@@ -1,0 +1,278 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="DocTest" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="">
+      <Type Name="NoNamespace" Kind="Class" />
+    </Namespace>
+    <Namespace Name="Mono.DocTest">
+      <Type Name="Color" Kind="Enumeration" />
+      <Type Name="D" Kind="Delegate" />
+      <Type Name="DocAttribute" Kind="Class" />
+      <Type Name="DocValueType" Kind="Structure" />
+      <Type Name="IProcess" Kind="Interface" />
+      <Type Name="UseLists" Kind="Class" />
+      <Type Name="Widget" Kind="Class" />
+      <Type Name="Widget+Del" Kind="Delegate" />
+      <Type Name="Widget+Direction" Kind="Enumeration" />
+      <Type Name="Widget+IMenuItem" Kind="Interface" />
+      <Type Name="Widget+NestedClass" Kind="Class" />
+      <Type Name="Widget+NestedClass`1" DisplayName="Widget+NestedClass&lt;T&gt;" Kind="Class" />
+      <Type Name="Widget+NestedClass+Double" Kind="Class" />
+      <Type Name="Widget+NestedClass+Double+Triple" Kind="Class" />
+      <Type Name="Widget+NestedClass+Double+Triple+Quadruple" Kind="Class" />
+    </Namespace>
+    <Namespace Name="Mono.DocTest.Generic">
+      <Type Name="Extensions" Kind="Class" />
+      <Type Name="Func`2" DisplayName="Func&lt;TArg,TRet&gt;" Kind="Delegate" />
+      <Type Name="GenericBase`1" DisplayName="GenericBase&lt;U&gt;" Kind="Class" />
+      <Type Name="GenericBase`1+FooEventArgs" DisplayName="GenericBase&lt;U&gt;+FooEventArgs" Kind="Class" />
+      <Type Name="GenericBase`1+NestedCollection" DisplayName="GenericBase&lt;U&gt;+NestedCollection" Kind="Class" />
+      <Type Name="GenericBase`1+NestedCollection+Enumerator" DisplayName="GenericBase&lt;U&gt;+NestedCollection+Enumerator" Kind="Structure" />
+      <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
+      <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
+      <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
+    </Namespace>
+    <Namespace Name="MyFramework.MyNamespace">
+      <Type Name="MyClass" Kind="Class" />
+      <Type Name="MyClassExtensions" Kind="Class" />
+    </Namespace>
+    <Namespace Name="MyFramework.MyOtherNamespace">
+      <Type Name="MyOtherClass" Kind="Class" />
+    </Namespace>
+    <Namespace Name="System">
+      <Type Name="Action`1" DisplayName="Action&lt;T&gt;" Kind="Delegate" />
+      <Type Name="Array" Kind="Class" />
+      <Type Name="AsyncCallback" Kind="Delegate" />
+      <Type Name="Environment" Kind="Class" />
+      <Type Name="Environment+SpecialFolder" Kind="Enumeration" />
+    </Namespace>
+  </Types>
+  <Title>Untitled</Title>
+  <ExtensionMethods>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Mono.DocTest.Generic.IFoo`1" />
+      </Targets>
+      <Member MemberName="Bar&lt;T&gt;">
+        <MemberSignature Language="C#" Value="public static void Bar&lt;T&gt; (this Mono.DocTest.Generic.IFoo&lt;T&gt; self, string s);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Bar&lt;T&gt;(class Mono.DocTest.Generic.IFoo`1&lt;!!T&gt; self, string s) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Void</ReturnType>
+        </ReturnValue>
+        <TypeParameters>
+          <TypeParameter Name="T" />
+        </TypeParameters>
+        <Parameters>
+          <Parameter Name="self" Type="Mono.DocTest.Generic.IFoo&lt;T&gt;" RefType="this" />
+          <Parameter Name="s" Type="System.String" />
+        </Parameters>
+        <Docs>
+          <typeparam name="T">To be added.</typeparam>
+          <param name="self">To be added.</param>
+          <param name="s">To be added.</param>
+          <summary>
+            <see cref="T:Mono.DocTest.Generic.IFoo`1" /> extension method</summary>
+        </Docs>
+        <Link Type="Mono.DocTest.Generic.Extensions" Member="M:Mono.DocTest.Generic.Extensions.Bar``1(Mono.DocTest.Generic.IFoo{``0},System.String)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:System.Collections.Generic.IEnumerable`1" />
+      </Targets>
+      <Member MemberName="ForEach&lt;T&gt;">
+        <MemberSignature Language="C#" Value="public static void ForEach&lt;T&gt; (this System.Collections.Generic.IEnumerable&lt;T&gt; self, Action&lt;T&gt; a);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig void ForEach&lt;T&gt;(class System.Collections.Generic.IEnumerable`1&lt;!!T&gt; self, class System.Action`1&lt;!!T&gt; a) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Void</ReturnType>
+        </ReturnValue>
+        <TypeParameters>
+          <TypeParameter Name="T" />
+        </TypeParameters>
+        <Parameters>
+          <Parameter Name="self" Type="System.Collections.Generic.IEnumerable&lt;T&gt;" RefType="this" />
+          <Parameter Name="a" Type="System.Action&lt;T&gt;" />
+        </Parameters>
+        <Docs>
+          <typeparam name="T">To be added.</typeparam>
+          <param name="self">To be added.</param>
+          <param name="a">To be added.</param>
+          <summary>
+            <see cref="T:System.Collections.Generic.IEnumerable`1" /> extension method</summary>
+        </Docs>
+        <Link Type="Mono.DocTest.Generic.Extensions" Member="M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:System.Collections.Generic.IEnumerable`1" />
+      </Targets>
+      <Member MemberName="ToDouble">
+        <MemberSignature Language="C#" Value="public static System.Collections.Generic.IEnumerable&lt;double&gt; ToDouble (this System.Collections.Generic.IEnumerable&lt;int&gt; list);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.Generic.IEnumerable`1&lt;float64&gt; ToDouble(class System.Collections.Generic.IEnumerable`1&lt;int32&gt; list) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Double&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="list" Type="System.Collections.Generic.IEnumerable&lt;System.Int32&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="list">To be added.</param>
+          <summary>
+            <see cref="T:System.Collections.Generic.IEnumerable{System.Int32}" /> 
+               extension method.
+             </summary>
+        </Docs>
+        <Link Type="Mono.DocTest.Generic.Extensions" Member="M:Mono.DocTest.Generic.Extensions.ToDouble(System.Collections.Generic.IEnumerable{System.Int32})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Mono.DocTest.Generic.IFoo`1" />
+      </Targets>
+      <Member MemberName="ToDouble&lt;T&gt;">
+        <MemberSignature Language="C#" Value="public static double ToDouble&lt;T&gt; (this T val) where T : Mono.DocTest.Generic.IFoo&lt;T&gt;;" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig float64 ToDouble&lt;(class Mono.DocTest.Generic.IFoo`1&lt;!!T&gt;) T&gt;(!!T val) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Double</ReturnType>
+        </ReturnValue>
+        <TypeParameters>
+          <TypeParameter Name="T">
+            <Constraints>
+              <InterfaceName>Mono.DocTest.Generic.IFoo&lt;T&gt;</InterfaceName>
+            </Constraints>
+          </TypeParameter>
+        </TypeParameters>
+        <Parameters>
+          <Parameter Name="val" Type="T" RefType="this" />
+        </Parameters>
+        <Docs>
+          <typeparam name="T">To be added.</typeparam>
+          <param name="val">To be added.</param>
+          <summary>
+            <see cref="T:Mono.DocTest.Generic.IFoo`1" /> extension method.
+             </summary>
+        </Docs>
+        <Link Type="Mono.DocTest.Generic.Extensions" Member="M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="System.Object" />
+      </Targets>
+      <Member MemberName="ToEnumerable&lt;T&gt;">
+        <MemberSignature Language="C#" Value="public static System.Collections.Generic.IEnumerable&lt;T&gt; ToEnumerable&lt;T&gt; (this T self);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.Generic.IEnumerable`1&lt;!!T&gt; ToEnumerable&lt;T&gt;(!!T self) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Collections.Generic.IEnumerable&lt;T&gt;</ReturnType>
+        </ReturnValue>
+        <TypeParameters>
+          <TypeParameter Name="T" />
+        </TypeParameters>
+        <Parameters>
+          <Parameter Name="self" Type="T" RefType="this" />
+        </Parameters>
+        <Docs>
+          <typeparam name="T">To be added.</typeparam>
+          <param name="self">To be added.</param>
+          <summary>
+            <c>System.Object</c> extension method</summary>
+        </Docs>
+        <Link Type="Mono.DocTest.Generic.Extensions" Member="M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:MyFramework.MyNamespace.MyClass" />
+      </Targets>
+      <Member MemberName="AnExtension">
+        <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="MyFramework.MyNamespace.MyClassExtensions" Member="M:MyFramework.MyNamespace.MyClassExtensions.AnExtension(MyFramework.MyNamespace.MyClass)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:System.Array" />
+      </Targets>
+      <Member MemberName="IsAligned&lt;T&gt;">
+        <MemberSignature Language="C#" Value="public static bool IsAligned&lt;T&gt; (this T[] vect, int index) where T : struct;" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsAligned&lt;struct .ctor (class System.ValueType) T&gt;(!!T[] vect, int32 index) cil managed" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <TypeParameters>
+          <TypeParameter Name="T">
+            <Constraints>
+              <ParameterAttribute>DefaultConstructorConstraint</ParameterAttribute>
+              <ParameterAttribute>NotNullableValueTypeConstraint</ParameterAttribute>
+              <BaseTypeName>System.ValueType</BaseTypeName>
+            </Constraints>
+          </TypeParameter>
+        </TypeParameters>
+        <Parameters>
+          <Parameter Name="vect" Type="T[]" RefType="this" />
+          <Parameter Name="index" Type="System.Int32" />
+        </Parameters>
+        <Docs>
+          <typeparam name="T">To be added.</typeparam>
+          <param name="vect">To be added.</param>
+          <param name="index">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="System.Environment" Member="M:System.Environment.IsAligned``1(``0[],System.Int32)" />
+      </Member>
+    </ExtensionMethod>
+  </ExtensionMethods>
+</Overview>

--- a/mdoc/Test/en.expected-fx-import/ns-.xml
+++ b/mdoc/Test/en.expected-fx-import/ns-.xml
@@ -1,0 +1,6 @@
+<Namespace Name="">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-fx-import/ns-Mono.DocTest.Generic.xml
+++ b/mdoc/Test/en.expected-fx-import/ns-Mono.DocTest.Generic.xml
@@ -1,0 +1,6 @@
+<Namespace Name="Mono.DocTest.Generic">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-fx-import/ns-Mono.DocTest.xml
+++ b/mdoc/Test/en.expected-fx-import/ns-Mono.DocTest.xml
@@ -1,0 +1,6 @@
+<Namespace Name="Mono.DocTest">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-fx-import/ns-MyFramework.MyNamespace.xml
+++ b/mdoc/Test/en.expected-fx-import/ns-MyFramework.MyNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyFramework.MyNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-fx-import/ns-MyFramework.MyOtherNamespace.xml
+++ b/mdoc/Test/en.expected-fx-import/ns-MyFramework.MyOtherNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyFramework.MyOtherNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-fx-import/ns-System.xml
+++ b/mdoc/Test/en.expected-fx-import/ns-System.xml
@@ -1,0 +1,6 @@
+<Namespace Name="System">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/fx-import-configuration.xml
+++ b/mdoc/Test/fx-import-configuration.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Frameworks>
+  <Framework Name="one" Source="one">
+    <assemblySearchPath>dependencies/one</assemblySearchPath>
+    <import>TestEcmaDocs.xml</import>
+  </Framework>
+  <Framework Name="two" Source="two">
+    <assemblySearchPath>dependencies/two</assemblySearchPath>
+    <import>TestEcmaDocs2.xml</import>
+    <import>DocTest-DropNS-classic.xml</import>
+  </Framework>
+</Frameworks>

--- a/mdoc/mdoc.csproj
+++ b/mdoc/mdoc.csproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">anycpu</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{7DA7CD97-614F-4BCD-A2FA-B379590CEA48}</ProjectGuid>
@@ -11,7 +11,7 @@
     <AssemblyName>mdoc</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|anycpu' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
@@ -19,16 +19,16 @@
     <DefineConstants>DEBUG;NET_4_5</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>anycpu</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <Externalconsole>True</Externalconsole>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|anycpu' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>anycpu</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <Externalconsole>True</Externalconsole>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
You can now add a new element to frameworks.xml, `/Frameworks/Framework/import`, which is a path to the import documentation file. An example test case was added in the make target, `check-monodocer-import-fx`, and you can see the sample configuration file here:

```xml
<?xml version="1.0" encoding="utf-8"?>
<Frameworks>
  <Framework Name="one" Source="one">
    <assemblySearchPath>dependencies/one</assemblySearchPath>
    <import>TestEcmaDocs.xml</import>
  </Framework>
  <Framework Name="two" Source="two">
    <assemblySearchPath>dependencies/two</assemblySearchPath>
    <import>TestEcmaDocs2.xml</import>
  </Framework>
</Frameworks>
```