### PR TITLE
DocStat: Check for TBA as default for comparereport, ade 'no-check-TBA` opt

### DIFF
--- a/tools/DocStat/DocStat.Tests/CommandUtilsTests.cs
+++ b/tools/DocStat/DocStat.Tests/CommandUtilsTests.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using System;
+namespace DocStat.Tests
+{
+    [TestFixture]
+    public class CommandUtilsTests
+    {
+        [Test]
+        public void CSVStringWith2()
+        {
+            Assert.AreEqual(@"""{0}"",""{1}""", CommandUtils.CSVFormatString(2));
+        }
+
+        [Test]
+        public void CSVStringWithIndexArray()
+        {
+            Assert.AreEqual(@"""{1}"",""{0}""",
+                            CommandUtils.CSVFormatString(2, new int[] { 1, 0 }));
+        }
+    }
+}

--- a/tools/DocStat/DocStat.Tests/DocStat.Tests.csproj
+++ b/tools/DocStat/DocStat.Tests/DocStat.Tests.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EcmaXmlHelperTests.cs" />
+    <Compile Include="CommandUtilsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -44,6 +45,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="TestData\currentxml\newType.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestData\currentxml\AVAssetImageGeneratorCompletionHandler.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="TestData\oldxml\AVAssetImageGeneratorCompletionHandler.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/tools/DocStat/DocStat/CommandUtils.cs
+++ b/tools/DocStat/DocStat/CommandUtils.cs
@@ -200,6 +200,29 @@ namespace DocStat
                              );
         }
 
+        public static string CSVFormatString(int numColumns, int[] order = null)
+        {
+            if (null != order && order.Length != numColumns)
+                throw new ArgumentException(String.Format("Column order array had {0} entries, but {1} columns are needed.",
+                                                          order.Length.ToString(),
+                                                          numColumns.ToString()));
+            Func<int, int> indexFor = null;
 
+            if (null != order)
+            {
+                indexFor = (int i) => order[i];
+            }
+            else
+            {
+                indexFor = (int i) => i;
+            }
+
+            string[] cols = new string[numColumns];
+
+            for (int i = 0; i < numColumns; i++)
+                cols[i] = "\"{" + indexFor(i) + "}\"";
+
+            return String.Join(",", cols);
+        }
     }
 }


### PR DESCRIPTION
Previously, the default report had all new files. Now, boilerplated and authored members are ignored. Entries for new types are created, whether the type summary is authored or "To be added."