### PR TITLE
mdoc: C# operator signatures are now generated correctly.

### DIFF
--- a/apidoctools.sln
+++ b/apidoctools.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monodoc.Test", "monodoc\Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ICSharpCode.SharpZipLib", "external\SharpZipLib\ICSharpCode.SharpZipLib.NET45\ICSharpCode.SharpZipLib.csproj", "{0E7413FF-EB9E-4714-ACF2-BE3A6A7B2FFD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mdoc.Test", "mdoc\mdoc.Test\mdoc.Test.csproj", "{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,14 @@ Global
 		{0E7413FF-EB9E-4714-ACF2-BE3A6A7B2FFD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0E7413FF-EB9E-4714-ACF2-BE3A6A7B2FFD}.Release|x86.ActiveCfg = Release|Any CPU
 		{0E7413FF-EB9E-4714-ACF2-BE3A6A7B2FFD}.Release|x86.Build.0 = Release|Any CPU
+		{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}.Debug|x86.Build.0 = Debug|Any CPU
+		{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}.Release|x86.ActiveCfg = Release|Any CPU
+		{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,6 +3,6 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.0.0.18";
+		public static string MonoVersion = "5.0.0.19";
 	}
 }

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -55,6 +55,9 @@ endif
 cleanup:
 	-rm -Rf Test/en.actual Test/html.actual
 
+nunit: 
+	mono ../packages/NUnit.ConsoleRunner.3.6.0/tools/nunit3-console.exe mdoc.Test/bin/$(CONFIGURATION)/mdoc.Test.dll
+
 Test/DocTest-addNonGeneric.dll:
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-addNonGeneric.cs
 
@@ -479,5 +482,5 @@ check-doc-tools-update: check-monodocer-since-update \
 	check-mdoc-export-msxdoc-update \
 	check-mdoc-validate-update 
 
-check: check-doc-tools 
+check: nunit check-doc-tools 
 

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -4701,7 +4701,7 @@ class DocIdFormatter : MemberFormatter
 	}
 }
 
-class ILFullMemberFormatter : MemberFormatter {
+public class ILFullMemberFormatter : MemberFormatter {
 
 	public override string Language {
 		get {return "ILAsm";}
@@ -5218,7 +5218,7 @@ class ILFullMemberFormatter : MemberFormatter {
 	}
 }
 
-class ILMemberFormatter : ILFullMemberFormatter {
+public class ILMemberFormatter : ILFullMemberFormatter {
 	protected override StringBuilder AppendNamespace (StringBuilder buf, TypeReference type)
 	{
 		return buf;
@@ -5255,7 +5255,7 @@ class ILMemberFormatter : ILFullMemberFormatter {
 		}
 	}
 
-class CSharpFullMemberFormatter : MemberFormatter {
+public class CSharpFullMemberFormatter : MemberFormatter {
 
 	public override string Language {
 		get {return "C#";}
@@ -5491,7 +5491,7 @@ class CSharpFullMemberFormatter : MemberFormatter {
 
 		return buf.ToString ();
 	}
-	
+
 	protected override string GetMethodDeclaration (MethodDefinition method)
 	{
 		string decl = base.GetMethodDeclaration (method);
@@ -5510,7 +5510,66 @@ class CSharpFullMemberFormatter : MemberFormatter {
 				.Append ('.')
 				.Append (ifaceMethod.Name);
 		}
-		return base.AppendMethodName (buf, method);
+
+		if (method.Name.StartsWith ("op_", StringComparison.Ordinal)) {
+			// this is an operator
+			switch (method.Name) {
+				case "op_Implicit":
+				case "op_Explicit":
+					buf.Length--; // remove the last space, which assumes a member name is coming
+					return buf;
+				case "op_Addition":
+				case "op_UnaryPlus":
+					return buf.Append ("operator +");
+				case "op_Subtraction":
+				case "op_UnaryNegation":
+                    return buf.Append ("operator -");
+				case "op_Division":
+					return buf.Append ("operator /");
+				case "op_Multiply":
+					return buf.Append ("operator *");
+				case "op_Modulus":
+					return buf.Append ("operator %");
+				case "op_BitwiseAnd":
+					return buf.Append ("operator &");
+				case "op_BitwiseOr":
+					return buf.Append ("operator |");
+				case "op_ExclusiveOr":
+					return buf.Append ("operator ^");
+				case "op_LeftShift":
+					return buf.Append ("operator <<");
+				case "op_RightShift":
+					return buf.Append ("operator >>");
+				case "op_LogicalNot":
+					return buf.Append ("operator !");
+				case "op_OnesComplement":
+					return buf.Append ("operator ~");
+				case "op_Decrement":
+					return buf.Append ("operator --");
+				case "op_Increment":
+					return buf.Append ("operator ++");
+				case "op_True":
+					return buf.Append ("operator true");
+				case "op_False":
+					return buf.Append ("operator false");
+				case "op_Equality":
+					return buf.Append ("operator ==");
+				case "op_Inequality":
+					return buf.Append ("operator !=");
+				case "op_LessThan":
+					return buf.Append ("operator <");
+				case "op_LessThanOrEqual":
+					return buf.Append ("operator <=");
+				case "op_GreaterThan":
+					return buf.Append ("operator >");
+				case "op_GreaterThanOrEqual":
+					return buf.Append ("operator >=");
+				default:
+					return base.AppendMethodName (buf, method);
+			}
+		}
+		else
+			return base.AppendMethodName (buf, method);
 	}
 
 	protected override StringBuilder AppendGenericMethodConstraints (StringBuilder buf, MethodDefinition method)
@@ -5552,6 +5611,15 @@ class CSharpFullMemberFormatter : MemberFormatter {
 		if (method.IsAbstract && !declType.IsInterface) modifiers += " abstract";
 		if (method.IsFinal) modifiers += " sealed";
 		if (modifiers == " virtual sealed") modifiers = "";
+
+		switch (method.Name) {
+			case "op_Implicit":
+				modifiers += " implicit operator";
+				break;
+			case "op_Explicit":
+				modifiers += " explicit operator";
+				break;
+		}
 
 		return buf.Append (modifiers);
 	}
@@ -5772,7 +5840,7 @@ class CSharpFullMemberFormatter : MemberFormatter {
 	}
 }
 
-class CSharpMemberFormatter : CSharpFullMemberFormatter {
+public class CSharpMemberFormatter : CSharpFullMemberFormatter {
 	protected override StringBuilder AppendNamespace (StringBuilder buf, TypeReference type)
 	{
 		return buf;

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1.xml
@@ -116,7 +116,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
-      <MemberSignature Language="C#" Value="public static U op_Explicit (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
+      <MemberSignature Language="C#" Value="public static explicit operator U (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname !U op_Explicit(class Mono.DocTest.Generic.GenericBase`1&lt;!U&gt; list) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget.xml
@@ -740,7 +740,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Addition">
-      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_Addition (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_Addition(class Mono.DocTest.Widget x1, class Mono.DocTest.Widget x2) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -782,7 +782,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
-      <MemberSignature Language="C#" Value="public static int op_Explicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static explicit operator int (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int32 op_Explicit(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -805,7 +805,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
-      <MemberSignature Language="C#" Value="public static long op_Implicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static implicit operator long (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int64 op_Implicit(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -828,7 +828,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_UnaryPlus">
-      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_UnaryPlus (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_UnaryPlus(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected.delete/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected.delete/Mono.DocTest.Generic/GenericBase`1.xml
@@ -449,7 +449,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
-      <MemberSignature Language="C#" Value="public static U op_Explicit (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
+      <MemberSignature Language="C#" Value="public static explicit operator U (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname !U op_Explicit(class Mono.DocTest.Generic.GenericBase`1&lt;!U&gt; list) cil managed" />
       <MemberType>Method</MemberType>
       <ReturnValue>

--- a/mdoc/Test/en.expected.delete/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected.delete/Mono.DocTest/Widget.xml
@@ -922,7 +922,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Addition">
-      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_Addition (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_Addition(class Mono.DocTest.Widget x1, class Mono.DocTest.Widget x2) cil managed" />
       <MemberType>Method</MemberType>
       <ReturnValue>
@@ -953,7 +953,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
-      <MemberSignature Language="C#" Value="public static int op_Explicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static explicit operator int (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int32 op_Explicit(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <ReturnValue>
@@ -970,7 +970,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
-      <MemberSignature Language="C#" Value="public static long op_Implicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static implicit operator long (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int64 op_Implicit(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <ReturnValue>
@@ -987,7 +987,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_UnaryPlus">
-      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_UnaryPlus (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_UnaryPlus(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <ReturnValue>

--- a/mdoc/Test/en.expected.importslashdoc/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected.importslashdoc/Mono.DocTest.Generic/GenericBase`1.xml
@@ -469,7 +469,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
-      <MemberSignature Language="C#" Value="public static U op_Explicit (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
+      <MemberSignature Language="C#" Value="public static explicit operator U (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname !U op_Explicit(class Mono.DocTest.Generic.GenericBase`1&lt;!U&gt; list) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected.importslashdoc/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected.importslashdoc/Mono.DocTest/Widget.xml
@@ -1072,7 +1072,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Addition">
-      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_Addition (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_Addition(class Mono.DocTest.Widget x1, class Mono.DocTest.Widget x2) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -1112,7 +1112,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
-      <MemberSignature Language="C#" Value="public static int op_Explicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static explicit operator int (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int32 op_Explicit(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -1134,7 +1134,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
-      <MemberSignature Language="C#" Value="public static long op_Implicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static implicit operator long (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int64 op_Implicit(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -1156,7 +1156,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_UnaryPlus">
-      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_UnaryPlus (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_UnaryPlus(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected.since/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected.since/Mono.DocTest.Generic/GenericBase`1.xml
@@ -488,7 +488,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
-      <MemberSignature Language="C#" Value="public static U op_Explicit (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
+      <MemberSignature Language="C#" Value="public static explicit operator U (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname !U op_Explicit(class Mono.DocTest.Generic.GenericBase`1&lt;!U&gt; list) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected.since/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected.since/Mono.DocTest/Widget.xml
@@ -1052,7 +1052,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Addition">
-      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_Addition (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_Addition(class Mono.DocTest.Widget x1, class Mono.DocTest.Widget x2) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -1091,7 +1091,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
-      <MemberSignature Language="C#" Value="public static int op_Explicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static explicit operator int (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int32 op_Explicit(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -1112,7 +1112,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
-      <MemberSignature Language="C#" Value="public static long op_Implicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static implicit operator long (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int64 op_Implicit(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -1133,7 +1133,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_UnaryPlus">
-      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_UnaryPlus (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_UnaryPlus(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/GenericBase`1.xml
@@ -465,7 +465,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
-      <MemberSignature Language="C#" Value="public static U op_Explicit (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
+      <MemberSignature Language="C#" Value="public static explicit operator U (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname !U op_Explicit(class Mono.DocTest.Generic.GenericBase`1&lt;!U&gt; list) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
@@ -1019,7 +1019,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Addition">
-      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_Addition (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_Addition(class Mono.DocTest.Widget x1, class Mono.DocTest.Widget x2) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -1056,7 +1056,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
-      <MemberSignature Language="C#" Value="public static int op_Explicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static explicit operator int (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int32 op_Explicit(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -1076,7 +1076,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
-      <MemberSignature Language="C#" Value="public static long op_Implicit (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static implicit operator long (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int64 op_Implicit(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
@@ -1096,7 +1096,7 @@
       </Docs>
     </Member>
     <Member MemberName="op_UnaryPlus">
-      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_UnaryPlus (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_UnaryPlus(class Mono.DocTest.Widget x) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -1,0 +1,207 @@
+﻿using NUnit.Framework;
+using System;
+using System.Linq;
+using Mono.Documentation;
+using Mono.Cecil;
+
+using mdoc.Test.SampleClasses;
+using System.Linq.Expressions;
+
+namespace mdoc.Test
+{
+    [TestFixture ()]
+    public class FormatterTests
+    {
+        [Test ()]
+        public void Formatters_VerifyPrivateConstructorNull ()
+        {
+            // this is a private constructor
+            var method = GetMethod<TestClass> (m => m.IsConstructor && !m.IsPublic && m.Parameters.Count () == 1);
+
+            MemberFormatter[] formatters = new MemberFormatter[]
+            {
+                new CSharpFullMemberFormatter (),
+                new CSharpMemberFormatter(),
+                new ILMemberFormatter(),
+                new ILFullMemberFormatter()
+            };
+            var sigs = formatters.Select (f => f.GetDeclaration (method));
+
+            foreach (var sig in sigs)
+                Assert.IsNull (sig);
+        }
+
+        [Test]
+        public void CSharp_op_Addition () =>
+            TestBinaryOp ("Addition", "+");
+
+        [Test]
+        public void CSharp_op_Subtraction () =>
+            TestBinaryOp ("Subtraction", "-");
+
+        [Test]
+        public void CSharp_op_Division () =>
+            TestBinaryOp ("Division", "/");
+
+        [Test]
+        public void CSharp_op_Multiplication () =>
+            TestBinaryOp ("Multiply", "*");
+
+        [Test]
+        public void CSharp_op_Modulus () =>
+            TestBinaryOp ("Modulus", "%");
+
+        [Test]
+        public void CSharp_op_BitwiseAnd () =>
+            TestBinaryOp ("BitwiseAnd", "&");
+
+        [Test]
+        public void CSharp_op_BitwiseOr () =>
+            TestBinaryOp ("BitwiseOr", "|");
+
+        [Test]
+        public void CSharp_op_ExclusiveOr () =>
+            TestBinaryOp ("ExclusiveOr", "^");
+
+        [Test]
+        public void CSharp_op_LeftShift () =>
+            TestBinaryOp ("LeftShift", "<<", secondType: "int");
+
+        [Test]
+        public void CSharp_op_RightShift () =>
+            TestBinaryOp ("RightShift", ">>", secondType: "int");
+
+        [Test]
+        public void CSharp_op_UnaryPlus () =>
+			TestUnaryOp ("UnaryPlus", "+");
+
+		[Test]
+		public void CSharp_op_UnaryNegation () =>
+			TestUnaryOp ("UnaryNegation", "-");
+
+		[Test]
+		public void CSharp_op_LogicalNot () =>
+			TestUnaryOp ("LogicalNot", "!");
+
+        [Test]
+        public void CSharp_op_OnesComplement () =>
+            TestUnaryOp ("OnesComplement", "~");
+
+        [Test]
+        public void CSharp_op_Decrement () =>
+            TestUnaryOp ("Decrement", "--");
+
+		[Test]
+		public void CSharp_op_Increment () =>
+			TestUnaryOp ("Increment", "++");
+
+        [Test]
+        public void CSharp_op_True () =>
+            TestUnaryOp ("True", "true", returnType: "bool");
+
+		[Test]
+		public void CSharp_op_False () =>
+            TestUnaryOp ("False", "false", returnType: "bool");
+
+        [Test]
+        public void CSharp_op_Equality () =>
+            TestComparisonOp ("Equality", "==");
+
+        [Test]
+        public void CSharp_op_Inequality () =>
+            TestComparisonOp ("Inequality", "!=");
+
+        [Test]
+        public void CSharp_op_LessThan () =>
+            TestComparisonOp ("LessThan", "<");
+
+        [Test]
+        public void CSharp_op_GreaterThan () =>
+            TestComparisonOp ("GreaterThan", ">");
+
+        [Test]
+        public void CSharp_op_LessThanOrEqual () =>
+            TestComparisonOp ("LessThanOrEqual", "<=");
+
+        [Test]
+        public void CSharp_op_GreaterThanOrEqual () =>
+            TestComparisonOp ("GreaterThanOrEqual", ">=");
+
+        [Test]
+        public void CSharp_op_Implicit () =>
+            TestConversionOp ("Implicit", "implicit", "TestClass", "TestClassTwo");
+
+        [Test]
+        public void CSharp_op_Implicit_inverse () =>
+            TestConversionOp ("Implicit", "implicit", "TestClassTwo", "TestClass");
+
+        [Test]
+        public void CSharp_op_Explicit () =>
+            TestConversionOp ("Explicit", "explicit", "int", "TestClass");
+
+        [Test]
+        public void CSharp_op_Explicit_inverse () =>
+            TestConversionOp ("Explicit", "explicit", "TestClass", "int");
+
+#region Helper Methods
+        string RealTypeName(string name){
+            switch (name) {
+                case "bool": return "Boolean";
+                case "int": return "Int32";
+                default: return name;
+            }
+        }
+
+        void TestConversionOp (string name, string type, string leftType, string rightType) {
+            TestOp (name, $"public static {type} operator {leftType} ({rightType} c1);", argCount: 1, returnType: leftType);
+        }
+
+        void TestComparisonOp (string name, string op)
+        {
+            TestOp (name, $"public static bool operator {op} (TestClass c1, TestClass c2);", argCount: 2, returnType: "Boolean");    
+        }
+
+        void TestUnaryOp (string name, string op, string returnType = "TestClass")
+        {
+            TestOp (name, $"public static {returnType} operator {op} (TestClass c1);", argCount: 1, returnType: returnType);
+        }
+
+        void TestBinaryOp (string name, string op, string returnType = "TestClass", string secondType = "TestClass")
+        {
+            TestOp (name, $"public static {returnType} operator {op} (TestClass c1, {secondType} c2);", argCount: 2, returnType: returnType);
+        }
+
+        void TestOp (string name, string expectedSig, int argCount, string returnType = "TestClass")
+        {
+            var member = GetMethod<TestClass> (m => m.Name == $"op_{name}" && m.Parameters.Count == argCount && m.ReturnType.Name == RealTypeName (returnType));
+            var formatter = new CSharpMemberFormatter ();
+            var sig = formatter.GetDeclaration (member);
+            Assert.AreEqual (expectedSig, sig);
+        }
+
+        MethodDefinition GetMethod<T> (Func<MethodDefinition, bool> query)
+        {
+            var testclass = GetType<T> ();
+            var methods = testclass.Methods;
+            var member = methods.FirstOrDefault (query).Resolve ();
+            if (member == null)
+                throw new Exception ("Did not find the member in the test class");
+            return member;
+        }
+
+        TypeDefinition GetType<T> ()
+        {
+            var classtype = typeof (T);
+            var module = ModuleDefinition.ReadModule (classtype.Module.FullyQualifiedName);
+            var types = module.GetTypes ();
+            var testclass = types
+                .SingleOrDefault (t => t.FullName == classtype.FullName);
+            if (testclass == null)
+            {
+                throw new Exception ($"Test was unable to find type {classtype.FullName}");
+            }
+            return testclass.Resolve ();
+        }
+#endregion
+    }
+}

--- a/mdoc/mdoc.Test/SampleClasses/TestClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/TestClass.cs
@@ -1,0 +1,46 @@
+﻿using System;
+namespace mdoc.Test.SampleClasses
+{
+    public class TestClass
+    {
+        public TestClass () { }
+        // private constructor
+        TestClass (TestPrivateClass arg) { }
+
+        // Unary Operators
+		public static TestClass operator + (TestClass c1) { return new TestClass (); }
+        public static TestClass operator - (TestClass c1) { return new TestClass (); }
+        public static TestClass operator ! (TestClass c1) { return new TestClass (); }
+        public static TestClass operator ~ (TestClass c1) { return new TestClass (); }
+        public static TestClass operator ++ (TestClass c1) { return new TestClass (); }
+        public static TestClass operator -- (TestClass c1) { return new TestClass (); }
+
+        // Binary Operators
+        public static TestClass operator + (TestClass c1, TestClass c2) { return new TestClass (); }
+		public static TestClass operator - (TestClass c1, TestClass c2) {return new TestClass (); }
+		public static TestClass operator / (TestClass c1, TestClass c2) { return new TestClass (); } 
+        public static TestClass operator * (TestClass c1, TestClass c2) { return new TestClass (); }
+		public static TestClass operator % (TestClass c1, TestClass c2) { return new TestClass (); }
+        public static TestClass operator & (TestClass c1, TestClass c2) { return new TestClass (); }
+        public static TestClass operator | (TestClass c1, TestClass c2) { return new TestClass (); }
+        public static TestClass operator ^ (TestClass c1, TestClass c2) { return new TestClass (); }
+        public static TestClass operator << (TestClass c1, int c2) { return new TestClass (); }
+        public static TestClass operator >> (TestClass c1, int c2) { return new TestClass (); }
+
+        // Comparison Operators
+        public static bool operator true (TestClass c1) { return false; }
+		public static bool operator false (TestClass c1) { return false; }
+		public static bool operator == (TestClass c1, TestClass c2) { return true; }
+		public static bool operator != (TestClass c1, TestClass c2) { return true; }
+        public static bool operator < (TestClass c1, TestClass c2) { return true; }
+        public static bool operator > (TestClass c1, TestClass c2) { return true; }
+        public static bool operator <= (TestClass c1, TestClass c2) { return true; }
+        public static bool operator >= (TestClass c1, TestClass c2) { return true; }
+
+        // Conversion Operators
+        public static implicit operator TestClassTwo (TestClass c1) { return new TestClassTwo (); }
+        public static implicit operator TestClass (TestClassTwo c1) { return new TestClass (); }
+        public static explicit operator int (TestClass c1) { return 0; }
+        public static explicit operator TestClass (int c1) { return new TestClass (); }
+	}
+}

--- a/mdoc/mdoc.Test/SampleClasses/TestClassTwo.cs
+++ b/mdoc/mdoc.Test/SampleClasses/TestClassTwo.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace mdoc.Test.SampleClasses
+{
+    public class TestClassTwo
+    {
+        public TestClassTwo ()
+        {
+        }
+    }
+}

--- a/mdoc/mdoc.Test/SampleClasses/TestPrivateClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/TestPrivateClass.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace mdoc.Test.SampleClasses
+{
+	class TestPrivateClass
+	{
+
+	}
+}

--- a/mdoc/mdoc.Test/mdoc.Test.csproj
+++ b/mdoc/mdoc.Test/mdoc.Test.csproj
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>mdoc.Test</RootNamespace>
+    <AssemblyName>mdoc.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+        <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta5\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta5\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta5\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta5\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FormatterTests.cs" />
+    <Compile Include="SampleClasses\TestClass.cs" />
+    <Compile Include="SampleClasses\TestPrivateClass.cs" />
+    <Compile Include="SampleClasses\TestClassTwo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\mdoc.csproj">
+      <Project>{7DA7CD97-614F-4BCD-A2FA-B379590CEA48}</Project>
+      <Name>mdoc</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\monodoc\monodoc.csproj">
+      <Project>{6E644802-B579-4037-9809-9CF4C7172C9D}</Project>
+      <Name>monodoc</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="SampleClasses\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/mdoc/mdoc.Test/packages.config
+++ b/mdoc/mdoc.Test/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="Mono.Cecil" version="0.10.0-beta5" targetFramework="net45" />
+</packages>

--- a/monodoc/Resources/mdoc-html-utils.xsl
+++ b/monodoc/Resources/mdoc-html-utils.xsl
@@ -455,10 +455,10 @@
 			<!-- return value (comes out "" where not applicable/available) -->
 			<xsl:choose>
 			<xsl:when test="@MemberName='op_Implicit'">
-				<xsl:text>implicit operator</xsl:text>
+				<xsl:text></xsl:text>
 			</xsl:when>
 			<xsl:when test="@MemberName='op_Explicit'">
-				<xsl:text>explicit operator</xsl:text>
+				<xsl:text></xsl:text>
 			</xsl:when>
 			<xsl:otherwise>
 				<xsl:apply-templates select="ReturnValue/ReturnType" mode="typelink">
@@ -2746,7 +2746,6 @@ SkipGenericArgument: invalid type substring '<xsl:value-of select="$s" />'
 
 		<xsl:if test="contains($Sig, ' static ')">static </xsl:if>
 		<xsl:if test="contains($Sig, ' abstract ')">abstract </xsl:if>
-		<xsl:if test="contains($Sig, ' operator ')">operator </xsl:if>
 
 		<xsl:if test="contains($Sig, ' const ')">const </xsl:if>
 		<xsl:if test="contains($Sig, ' readonly ')">readonly </xsl:if>
@@ -2764,8 +2763,8 @@ SkipGenericArgument: invalid type substring '<xsl:value-of select="$s" />'
 			<xsl:if test="contains($Sig, ' checked ')">checked </xsl:if>
 			<xsl:if test="contains($Sig, ' unsafe ')">unsafe </xsl:if>
 			<xsl:if test="contains($Sig, ' volatile ')">volatile </xsl:if>
-			<xsl:if test="contains($Sig, ' explicit ')">explicit </xsl:if>
-			<xsl:if test="contains($Sig, ' implicit ')">implicit </xsl:if>
+			<xsl:if test="contains($Sig, ' explicit ')">explicit operator</xsl:if>
+			<xsl:if test="contains($Sig, ' implicit ')">implicit operator</xsl:if>
 		</xsl:if>
 
 		<xsl:if test="$typetype">


### PR DESCRIPTION
Previously, mdoc simply used the compiler-generated method names for operators, such as `op_Multiply`, instead
of `operator *`. This releases fixes that for all unary, binary, comparison, and conversion operators.
Closes #82