### PR TITLE
mdoc v5.0.0.24

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,6 +3,6 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.0.0.23";
+		public static string MonoVersion = "5.0.0.24";
 	}
 }

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -424,7 +424,7 @@ class MDocUpdater : MDocCommand
 	}
 
 	public static bool IsInAssemblies(string name) {
-		return Instance.assemblies.Any(a => a.Contains(name));
+            return Instance?.assemblies != null ? Instance.assemblies.Any(a => a.Contains(name)) : true;
 	}
 
 	void AddImporter (string path)
@@ -5763,6 +5763,11 @@ public class CSharpFullMemberFormatter : MemberFormatter {
 			else
 				buf.Append ("ref ");
 		}
+            if (parameter.HasCustomAttributes) {
+                var isParams = parameter.CustomAttributes.Any (ca => ca.AttributeType.Name == "ParamArrayAttribute");
+                if (isParams) 
+                    buf.AppendFormat ("params ");
+            }
 		buf.Append (GetTypeName (parameter.ParameterType, new DynamicParserContext (parameter))).Append (" ");
 		buf.Append (parameter.Name);
 		if (parameter.HasDefault && parameter.IsOptional && parameter.HasConstant) {

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -4443,7 +4443,11 @@ public abstract class MemberFormatter {
                 typeName = tname;
             }
 
-            return typeName;
+            modIndex = Math.Max (typeName.LastIndexOf ("modopt(", StringComparison.Ordinal), typeName.LastIndexOf ("modreq(", StringComparison.Ordinal));
+            if (modIndex >= 0)
+                return RemoveMod (typeName);
+            else
+                return typeName;
         }
 
         protected virtual char[] ArrayDelimeters {

--- a/mdoc/Mono.Documentation/monodocer.cs
+++ b/mdoc/Mono.Documentation/monodocer.cs
@@ -1358,7 +1358,7 @@ class MDocUpdater : MDocCommand
 							TypeReference iface;
 							MethodReference imethod;
 
-							if (methdef.Overrides.Count == 1) {
+                        if (methdef.Overrides.Count == 1 && !methdef.IsPublic) {
 								DocUtils.GetInfoForExplicitlyImplementedMethod (methdef, out iface, out imethod);
 								if (!IsPublic (iface.Resolve ())) return false;
 							}

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget.xml
@@ -656,7 +656,7 @@
       </Docs>
     </Member>
     <Member MemberName="M6">
-      <MemberSignature Language="C#" Value="protected void M6 (int i, object[] args);" />
+      <MemberSignature Language="C#" Value="protected void M6 (int i, params object[] args);" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M6(int32 i, object[] args) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected-operators/mdoc.Test.SampleClasses/TestClass.xml
+++ b/mdoc/Test/en.expected-operators/mdoc.Test.SampleClasses/TestClass.xml
@@ -27,6 +27,31 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="DoSomethingWithParams">
+      <MemberSignature Language="C#" Value="public void DoSomethingWithParams (params int[] values);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void DoSomethingWithParams(int32[] values) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="values" Type="System.Int32[]">
+          <Attributes>
+            <Attribute>
+              <AttributeName>System.ParamArray</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+      </Parameters>
+      <Docs>
+        <param name="values">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="op_Addition">
       <MemberSignature Language="C#" Value="public static mdoc.Test.SampleClasses.TestClass operator + (mdoc.Test.SampleClasses.TestClass c1, mdoc.Test.SampleClasses.TestClass c2);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class mdoc.Test.SampleClasses.TestClass op_Addition(class mdoc.Test.SampleClasses.TestClass c1, class mdoc.Test.SampleClasses.TestClass c2) cil managed" />

--- a/mdoc/Test/en.expected.delete/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected.delete/Mono.DocTest/Widget.xml
@@ -858,7 +858,7 @@
       </Docs>
     </Member>
     <Member MemberName="M6">
-      <MemberSignature Language="C#" Value="protected void M6 (int i, object[] args);" />
+      <MemberSignature Language="C#" Value="protected void M6 (int i, params object[] args);" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M6(int32 i, object[] args) cil managed" />
       <MemberType>Method</MemberType>
       <ReturnValue>

--- a/mdoc/Test/en.expected.importslashdoc/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected.importslashdoc/Mono.DocTest/Widget.xml
@@ -992,7 +992,7 @@
       </Docs>
     </Member>
     <Member MemberName="M6">
-      <MemberSignature Language="C#" Value="protected void M6 (int i, object[] args);" />
+      <MemberSignature Language="C#" Value="protected void M6 (int i, params object[] args);" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M6(int32 i, object[] args) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected.since/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected.since/Mono.DocTest/Widget.xml
@@ -972,7 +972,7 @@
       </Docs>
     </Member>
     <Member MemberName="M6">
-      <MemberSignature Language="C#" Value="protected void M6 (int i, object[] args);" />
+      <MemberSignature Language="C#" Value="protected void M6 (int i, params object[] args);" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M6(int32 i, object[] args) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
@@ -943,7 +943,7 @@
       </Docs>
     </Member>
     <Member MemberName="M6">
-      <MemberSignature Language="C#" Value="protected void M6 (int i, object[] args);" />
+      <MemberSignature Language="C#" Value="protected void M6 (int i, params object[] args);" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M6(int32 i, object[] args) cil managed" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -183,6 +183,15 @@ namespace mdoc.Test
             Assert.AreEqual ("System.ValueType*", result);
         }
 
+        [Test]
+        public void Params()
+        {
+            var member = GetMethod<TestClass> (m => m.Name == "DoSomethingWithParams");
+            var formatter = new CSharpMemberFormatter ();
+            var sig = formatter.GetDeclaration (member);
+            Assert.AreEqual ("public void DoSomethingWithParams (params int[] values);", sig);
+        }
+
 #region Helper Methods
         string RealTypeName(string name){
             switch (name) {

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -159,6 +159,30 @@ namespace mdoc.Test
         public void CSharp_pointerref_modreqparam () =>
             TestMod ("SomeFunc4", "public int SomeFunc4 (SomeClass** param, int param2);", returnType: "int");
 
+        [Test]
+        public void DoubleMod ()
+        {
+            string doubledUp = "System.ValueType modopt(System.DateTime) modopt(System.Runtime.CompilerServices.IsBoxed)";
+            string result = MemberFormatter.RemoveMod (doubledUp);
+            Assert.AreEqual ("System.ValueType", result);
+        }
+
+        [Test]
+        public void DoubleMod_Mixed ()
+        {
+            string doubledUp = "System.ValueType modreq(System.DateTime) modopt(System.Runtime.CompilerServices.IsBoxed)";
+            string result = MemberFormatter.RemoveMod (doubledUp);
+            Assert.AreEqual ("System.ValueType", result);
+        }
+
+        [Test]
+        public void DoubleMod_Pointer ()
+        {
+            string doubledUp = "System.ValueType modreq(System.DateTime) modopt(System.Runtime.CompilerServices.IsBoxed)*";
+            string result = MemberFormatter.RemoveMod (doubledUp);
+            Assert.AreEqual ("System.ValueType*", result);
+        }
+
 #region Helper Methods
         string RealTypeName(string name){
             switch (name) {

--- a/mdoc/mdoc.Test/SampleClasses/TestClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/TestClass.cs
@@ -42,5 +42,7 @@ namespace mdoc.Test.SampleClasses
         public static implicit operator TestClass (TestClassTwo c1) { return new TestClass (); }
         public static explicit operator int (TestClass c1) { return 0; }
         public static explicit operator TestClass (int c1) { return new TestClass (); }
+
+        public void DoSomethingWithParams (params int[] values) { }
 	}
 }


### PR DESCRIPTION
- Adjustment to how explicitly implemented methods for private interfaces are documented, which resolves an issue with some c++/cx libraries (#110).
- Fixes an issue with C# signatures, and types that have multiple `modreq` or `modopt` modifiers applied.
- C# signatures now include `params` when appropriate (#78).