### PR TITLE
DocStat: Added command to fix some common summary errors.

### DIFF
--- a/tools/DocStat/DocStat/DocStat.csproj
+++ b/tools/DocStat/DocStat/DocStat.csproj
@@ -38,6 +38,7 @@
       <Link>Options.cs</Link>
     </Compile>
     <Compile Include="comparereport.cs" />
+    <Compile Include="fixsummaries.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Xml.Linq" />

--- a/tools/DocStat/DocStat/apistat.cs
+++ b/tools/DocStat/DocStat/apistat.cs
@@ -31,7 +31,8 @@ namespace DocStat
                 {"remaining", new RemainingCommand() },
                 {"obsolete", new ObsoleteCommand() },
                 {"comparefix", new CompareFixCommand()},
-                {"reportnew", new CompareReportCommand()}
+                {"reportnew", new CompareReportCommand()},
+                {"fixsummaries", new FixSummariesCommand()}
             };
 
             GetCommand(args.First()).Run(args);

--- a/tools/DocStat/DocStat/fixsummaries.cs
+++ b/tools/DocStat/DocStat/fixsummaries.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using Mono.Options;
+
+namespace DocStat
+{
+    public class FixSummariesCommand : ApiCommand
+    {
+        public FixSummariesCommand()
+        {
+        }
+
+        public override void Run(IEnumerable<string> args)
+        {
+			string rootdir = "";
+			string omitlist = "";
+			string processlist = "";
+			string pattern = "";
+			List<string> extras = CommandUtils.ProcessFileArgs(args,
+															   ref rootdir,
+															   ref omitlist,
+															   ref processlist,
+															   ref pattern
+															  );
+            CommandUtils.ThrowOnFiniteExtras(extras);
+
+            foreach (string file in CommandUtils.GetFileList(processlist, omitlist, rootdir, pattern))
+            {
+                bool changed = false;
+                XDocument xdoc = new XDocument(XElement.Load(file));
+
+                XElement memberRoot = xdoc.Element("Type").Element("Members");
+                if (memberRoot == null || !memberRoot.Descendants().Any())
+                {
+                    continue;
+                }
+
+
+                foreach (XElement m in memberRoot.Elements("Member"))
+                {
+                    changed = false;
+                    XElement summary = m.Element("Docs").Element("summary");
+
+
+                    if (null == summary)
+                    {
+                        continue;
+                    }
+
+                    if (summary.IsEmpty || (summary.Value.Length == 0 && summary.Descendants().Count() == 0))
+                    {
+                        summary.Value = "To be added.";
+                        changed = true;
+                        continue;
+                    }
+
+                    IEnumerable<XElement> mistakeParams = summary.Descendants("param");
+
+                    if (mistakeParams.Count() == 0)
+                    {
+                        continue;
+                    }
+
+
+                    mistakeParams.ToList().ForEach(e => e.Name = "paramref");
+                    changed = true;
+
+                }
+
+				if (changed)
+				{
+					CommandUtils.WriteXDocument(xdoc, file);
+				}
+
+            }
+			
+                
+        }
+    }
+}


### PR DESCRIPTION
Added `fixsummaries` command. This command changes `<param name=... />` within summaries to `<paramref name=... />`, and changes empty summary tags to `<summary>To be added.</summary>`.