### PR TITLE
DocStat: Moved changed flag to file loop, out of member loop

### DIFF
--- a/tools/DocStat/DocStat/fixsummaries.cs
+++ b/tools/DocStat/DocStat/fixsummaries.cs
@@ -40,9 +40,7 @@ namespace DocStat
 
                 foreach (XElement m in memberRoot.Elements("Member"))
                 {
-                    changed = false;
                     XElement summary = m.Element("Docs").Element("summary");
-
 
                     if (null == summary)
                     {
@@ -63,8 +61,8 @@ namespace DocStat
                         continue;
                     }
 
-
                     mistakeParams.ToList().ForEach(e => e.Name = "paramref");
+
                     changed = true;
 
                 }


### PR DESCRIPTION
I was only catching files where the last member in the file had a change. Moving the changed sigil up to the file level fixed this.