### PR TITLE
mdoc: added nuspec, for nuget release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CONFIGURATION = Release
 BIN = bin/$(CONFIGURATION)
 MDOC = $(BIN)/mdoc.exe
 
-all: build
+all: build nuget
 
 build: $(MDOC)
 
@@ -23,6 +23,9 @@ check: build check-monodoc check-mdoc
 
 check-mdoc:
 	cd mdoc; $(MAKE) check
+
+nuget:
+	nuget pack mdoc/mdoc.nuspec -outputdirectory bin/Nuget
 
 check-monodoc:
 	cd monodoc; $(MAKE) check

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>mdoc</id>
+    <version>5.0.0.25</version>
+    <title>mdoc</title>
+    <authors>Joel Martinez</authors>
+    <owners>Xamarin</owners>
+    <projectUrl>https://github.com/mono/api-doc-tools</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>.NET API Documentation toolchain</description>
+    <copyright>Copyright 2017</copyright>
+    <tags>mdoc documentation ecmaxml dotnet .net C# F# VB.NET</tags>
+  </metadata>
+  <files>
+    <file src="..\bin\Release\*.*" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
You can build by running `make nuget`. Related to #111