### PR TITLE
Fix infinite loop in xsl in maketypelink

### DIFF
--- a/monodoc/Resources/mdoc-html-utils.xsl
+++ b/monodoc/Resources/mdoc-html-utils.xsl
@@ -991,7 +991,7 @@
 		<!-- if this is a generic type parameter, don't make a link but italicize it and give it a tooltip instead -->
 		<xsl:when test="count($ThisType/TypeParameters/TypeParameter[@Name=$type] | 
 				$ThisType/TypeParameters/TypeParameter[child::text()=$type] |
-				ancestor::Member/Docs/typeparam[@name=$type]) = 1">
+				ancestor::Member/Docs/typeparam[@name=$type]) = 1 or $nested = 1">
 			<!-- note that we check if it is a generic type using /Type/TypeParameters because that will have type parameters declared in an outer class if this is a nested class, but then we get the tooltip text from the type parameters documented in this file -->
 			<i title="{$ThisType/Docs/typeparam[@name=$type] | ancestor::Member/Docs/typeparam[@name=$type]}"><xsl:value-of select="$type"/></i>
 		</xsl:when>
@@ -1002,6 +1002,7 @@
 			<xsl:call-template name="maketypelink">
 				<xsl:with-param name="type" select="ancestor::Members/BaseTypeArgument[@TypeParamName=$type]"/>
 				<xsl:with-param name="wrt" select="$wrt"/>
+				<xsl:with-param name="nested" select="1"/>
 			</xsl:call-template>
 		</xsl:when>
 		


### PR DESCRIPTION
I found that under a couple of circumstances that the current xsl would get stuck in an infinite loop. I was generating html docs for the EntityFramework v6.1.3 nuget package. The one case I narrowed down occurs on the CurrentValue property in type DbComplexPropertyEntry<TEntity, TComplexProperty> from the base class DbMemberEntry<TEntity, TProperty> when it attempts to make a link for "TProperty". It looks like this might have something to do with the generic parameter type name changing from the base class, but I didn't get to the point of definitively understanding the cause. This change prevents the infinite loop for this and at least one other scenario it hit in the same nuget. There is probably a more complete fix to be worked out for generating this link, but I felt it was worth it to submit this to prevent the infinite loop.