### PR TITLE
mdoc: Support VB.NET signatures enhancement

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -4,5 +4,9 @@ namespace Mono.Documentation
 	public static class Consts
 	{
 		public static string MonoVersion = "5.2.0.0";
+		public const string DocId = "DocId";
+		public const string VbNet = "VB.NET";
+		public const string DocIdLowCase = "docid";
+		public const string VbNetLowCase = "vb.net";
 	}
 }

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -161,6 +161,17 @@ check-monodocer-docid: Test/FrameworkTestData
 	-rm -Rf Test/en.actual
 	$(MONO) $(PROGRAM) update -use-docid -o Test/en.actual -frameworks Test/FrameworkTestData
 	$(DIFF) Test/en.expected-docid Test/en.actual
+	
+check-monodocer-vbnet: Test/FrameworkTestData
+	-rm -Rf Test/en.actual
+	$(MONO) $(PROGRAM) update -lang vb.net -o Test/en.actual -frameworks Test/FrameworkTestData
+	$(DIFF) Test/en.expected-vbnet Test/en.actual
+	
+check-monodocer-vbnet2: 
+	-rm -Rf Test/en.actual
+	$(MAKE) Test/DocTest.dll-v1
+	$(MONO) $(PROGRAM) update -lang vb.net -o Test/en.actual Test/DocTest.dll
+	$(DIFF) Test/en.expected-vbnet2 Test/en.actual
 
 check-monodocer-addNonGeneric: 
 	-rm -Rf Test/en.actual
@@ -266,7 +277,7 @@ check-monodocer-internal-interface:
 	# Tests to make sure internal interfaces that are explicitly implemented are not documented
 	-rm -Rf Test/en.actual
 	$(MAKE) Test/DocTest-InternalInterface.dll
-	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-InternalInterface.dll
+	$(MONO) $(PROGRAM) update --exceptions=all -o Test/en.actual Test/DocTest-InternalInterface.dll -lang VB.NET
 	$(DIFF) Test/en.expected-internal-interface Test/en.actual
 
 check-monodocer-enumerations: 
@@ -530,7 +541,9 @@ check-doc-tools: check-monodocer-since \
 	check-monodocer-docid \
 	check-monodocer-operators \
 	check-monodocer-fx-statistics-remove \
-	check-overwrite-attribute
+	check-overwrite-attribute \
+	check-monodocer-vbnet \
+	check-monodocer-vbnet2 
 
 check-doc-tools-update: check-monodocer-since-update \
 	check-monodocer-importecmadoc-update \

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -592,51 +592,23 @@ namespace Mono.Documentation.Updater
 
             buf.Append (' ').Append (GetTypeName (field.FieldType, new DynamicParserContext (field))).Append (' ');
             buf.Append (field.Name);
-            AppendFieldValue (buf, field);
+            DocUtils.AppendFieldValue (buf, field);
             buf.Append (';');
 
             return buf.ToString ();
         }
 
-        static StringBuilder AppendFieldVisibility (StringBuilder buf, FieldDefinition field)
+        static void AppendFieldVisibility (StringBuilder buf, FieldDefinition field)
         {
             if (field.IsPublic)
-                return buf.Append ("public");
-            if (field.IsFamily || field.IsFamilyOrAssembly)
-                return buf.Append ("protected");
-            return buf;
-        }
-
-        static StringBuilder AppendFieldValue (StringBuilder buf, FieldDefinition field)
-        {
-            // enums have a value__ field, which we ignore
-            if (((TypeDefinition)field.DeclaringType).IsEnum ||
-                    field.DeclaringType.IsGenericType ())
-                return buf;
-            if (field.HasConstant && field.IsLiteral)
             {
-                object val = null;
-                try
-                {
-                    val = field.Constant;
-                }
-                catch
-                {
-                    return buf;
-                }
-                if (val == null)
-                    buf.Append (" = ").Append ("null");
-                else if (val is Enum)
-                    buf.Append (" = ").Append (val.ToString ());
-                else if (val is IFormattable)
-                {
-                    string value = ((IFormattable)val).ToString (null, CultureInfo.InvariantCulture);
-                    if (val is string)
-                        value = "\"" + value + "\"";
-                    buf.Append (" = ").Append (value);
-                }
+                buf.Append("public");
+                return;
             }
-            return buf;
+            if (field.IsFamily || field.IsFamilyOrAssembly)
+            {
+                buf.Append("protected");
+            }
         }
 
         protected override string GetEventDeclaration (EventDefinition e)

--- a/mdoc/Mono.Documentation/Updater/Formatters/DocIdFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/DocIdFormatter.cs
@@ -6,10 +6,7 @@ namespace Mono.Documentation.Updater
 {
     class DocIdFormatter : MemberFormatter
     {
-        public override string Language
-        {
-            get { return "DocId"; }
-        }
+        public override string Language => Consts.DocId;
 
         public override string GetDeclaration (TypeReference tref)
         {

--- a/mdoc/Mono.Documentation/Updater/Formatters/MemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/MemberFormatter.cs
@@ -190,9 +190,9 @@ namespace Mono.Documentation.Updater
                     .Append (PointerModifier);
         }
 
-        protected virtual char[] GenericTypeContainer
+        protected virtual string[] GenericTypeContainer
         {
-            get { return new char[] { '<', '>' }; }
+            get { return new string[] { "<", ">" }; }
         }
 
         protected virtual char NestedTypeSeparator
@@ -242,9 +242,9 @@ namespace Mono.Documentation.Updater
             var args = new List<TypeReference> ();
             GenericInstanceType inst = type as GenericInstanceType;
             if (inst != null)
-                args.AddRange (inst.GenericArguments.Cast<TypeReference> ());
+                args.AddRange (inst.GenericArguments);
             else
-                args.AddRange (type.GenericParameters.Cast<TypeReference> ());
+                args.AddRange (type.GenericParameters);
             return args;
         }
 
@@ -280,6 +280,8 @@ namespace Mono.Documentation.Updater
 
         public virtual string GetDeclaration (TypeReference tref)
         {
+            if (!IsSupported(tref))
+                return null;
             var typeSpec = tref as TypeSpecification;
             if (typeSpec != null && typeSpec.Resolve () == null && typeSpec.IsArray && typeSpec.ContainsGenericParameter)
             {
@@ -295,6 +297,8 @@ namespace Mono.Documentation.Updater
 
         public virtual string GetDeclaration (MemberReference mreference)
         {
+            if (!IsSupported(mreference))
+                return null;
             return GetDeclaration (mreference.Resolve ());
         }
 
@@ -418,6 +422,10 @@ namespace Mono.Documentation.Updater
             return GetEventName (e);
         }
 
+        public virtual bool IsSupported(TypeReference tref) => true;
+
+        public virtual bool IsSupported(MemberReference mref) => true;
+        
         protected static bool IsPublicEII (EventDefinition e)
         {
             bool isPublicEII = false;

--- a/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
@@ -11,9 +11,9 @@ namespace Mono.Documentation.Updater
     class SlashDocMemberFormatter : MemberFormatter
     {
 
-        protected override char[] GenericTypeContainer
+        protected override string[] GenericTypeContainer
         {
-            get { return new char[] { '{', '}' }; }
+            get { return new string[] { "{", "}" }; }
         }
 
         private bool AddTypeCount = true;

--- a/mdoc/Mono.Documentation/Updater/Formatters/VBFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/VBFullMemberFormatter.cs
@@ -1,0 +1,853 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Mono.Cecil;
+using Mono.Documentation.Util;
+
+namespace Mono.Documentation.Updater
+{
+    public class VBFullMemberFormatter : MemberFormatter
+    {
+        public override string Language => Consts.VbNet;
+
+        protected override StringBuilder AppendNamespace(StringBuilder buf, TypeReference type)
+        {
+            string ns = DocUtils.GetNamespace(type);
+            if (GetVBType(type.FullName) == null && !string.IsNullOrEmpty(ns) && ns != "System")
+                buf.Append(ns).Append('.');
+            return buf;
+        }
+
+        protected virtual string GetVBType(string t)
+        {
+            // make sure there are no modifiers in the type string (add them back before returning)
+            string typeToCompare = t;
+            string[] splitType = null;
+            if (t.Contains(' '))
+            {
+                splitType = t.Split(' ');
+                typeToCompare = splitType[0];
+            }
+
+            switch (typeToCompare)
+            {
+                case "System.Byte": typeToCompare = "Byte"; break;
+                case "System.SByte": typeToCompare = "SByte"; break;
+                case "System.Int16": typeToCompare = "Short"; break;
+                case "System.Int32": typeToCompare = "Integer"; break;
+                case "System.Int64": typeToCompare = "Long"; break;
+
+                case "System.UInt16": typeToCompare = "UShort"; break;
+                case "System.UInt32": typeToCompare = "UInteger"; break;
+                case "System.UInt64": typeToCompare = "ULong"; break;
+
+                case "System.Single": typeToCompare = "Single"; break;
+                case "System.Double": typeToCompare = "Double"; break;
+                case "System.Decimal": typeToCompare = "Decimal"; break;
+                case "System.Boolean": typeToCompare = "Boolean"; break;
+                case "System.Char": typeToCompare = "Char"; break;
+                case "System.String": typeToCompare = "String"; break;
+                case "System.Object": typeToCompare = "Object"; break;
+            }
+
+            if (splitType != null)
+            {
+                // re-add modreq/modopt if it was there
+                splitType[0] = typeToCompare;
+                typeToCompare = string.Join(" ", splitType);
+            }
+            return typeToCompare == t ? null : typeToCompare;
+        }
+
+        protected override StringBuilder AppendTypeName(StringBuilder buf, TypeReference type, DynamicParserContext context)
+        {
+            if (type is GenericParameter)
+                return AppendGenericParameterConstraints(buf, (GenericParameter)type, context).Append(type.Name);
+            string t = type.FullName;
+            if (!t.StartsWith("System."))
+            {
+                return base.AppendTypeName(buf, type, context);
+            }
+
+            string s = GetVBType(t);
+            if (s != null)
+            {
+                if (context != null)
+                    context.TransformIndex++;
+                return buf.Append(s);
+            }
+
+            return base.AppendTypeName(buf, type, context);
+        }
+
+        private StringBuilder AppendGenericParameterConstraints(StringBuilder buf, GenericParameter type, DynamicParserContext context)
+        {
+            if (MemberFormatterState != MemberFormatterState.WithinGenericTypeParameters)
+                return buf;
+            GenericParameterAttributes attrs = type.Attributes;
+            bool isout = (attrs & GenericParameterAttributes.Covariant) != 0;
+            bool isin = (attrs & GenericParameterAttributes.Contravariant) != 0;
+            if (isin)
+                buf.Append("In ");
+            else if (isout)
+                buf.Append("Out ");
+            return buf;
+        }
+
+        protected override string GetTypeDeclaration(TypeDefinition type)
+        {
+            string visibility = GetTypeVisibility(type.Attributes);
+            if (visibility == null)
+                return null;
+
+            StringBuilder buf = new StringBuilder();
+
+            buf.Append(visibility);
+            buf.Append(" ");
+
+            MemberFormatter full = new VBMemberFormatter();
+            if (DocUtils.IsDelegate(type))
+            {
+                buf.Append("Delegate ");
+                MethodDefinition invoke = type.GetMethod("Invoke");
+                bool isFunction = invoke.ReturnType.FullName != "System.Void";
+                if (isFunction)
+                    buf.Append("Function ");
+                else
+                    buf.Append("Sub ");
+                buf.Append(GetName(type));
+                AppendParameters(buf, invoke, invoke.Parameters);
+                if (isFunction)
+                {
+                    buf.Append(" As ");
+                    buf.Append(full.GetName(invoke.ReturnType, new DynamicParserContext(invoke.MethodReturnType))).Append(" ");
+                }
+
+                return buf.ToString();
+            }
+
+            if (type.IsAbstract && !type.IsInterface && !IsModule(type))
+                buf.Append("MustInherit ");
+            if (type.IsSealed && !DocUtils.IsDelegate(type) && !type.IsValueType && !IsModule(type))
+                buf.Append("NotInheritable ");
+            buf.Replace(" MustInherit NotInheritable", "");
+
+            buf.Append(GetTypeKind(type));
+            buf.Append(" ");
+            buf.Append(GetVBType(type.FullName) == null
+                    ? GetName(type)
+                    : type.Name);
+
+            if (!type.IsEnum)
+            {
+                TypeReference basetype = type.BaseType;
+                if (basetype != null && basetype.FullName == "System.Object" || type.IsValueType)
+                    basetype = null;
+
+                if (basetype != null)
+                {
+                    buf.Append(GetLineEnding()).Append("Inherits ");
+                    buf.Append(full.GetName(basetype));
+                }
+
+                List<string> interfaceNames = DocUtils.GetUserImplementedInterfaces(type)
+                        .Select(iface => full.GetName(iface))
+                        .OrderBy(s => s)
+                        .ToList();
+                if (interfaceNames.Count > 0)
+                {
+                    buf.Append(GetLineEnding()).Append("Implements ");
+                    buf.Append(string.Join(", ", interfaceNames));
+                }
+            }
+
+            return buf.ToString();
+        }
+
+        protected override string[] GenericTypeContainer
+        {
+            get { return new[] {"(Of ", ")"}; }
+        }
+        
+        static string GetTypeKind(TypeDefinition t)
+        {
+            if (IsModule(t))
+                return "Module";
+            if (t.IsEnum)
+                return "Enum";
+            if (t.IsValueType)
+                return "Structure";
+            if (t.IsClass || t.FullName == "System.Enum")
+                return "Class";
+            if (t.IsInterface)
+                return "Interface";
+            throw new ArgumentException(t.FullName);
+        }
+
+        static string GetTypeVisibility(TypeAttributes ta)
+        {
+            switch (ta & TypeAttributes.VisibilityMask)
+            {
+                case TypeAttributes.Public:
+                case TypeAttributes.NestedPublic:
+                    return "Public";
+
+                case TypeAttributes.NestedFamily:
+                case TypeAttributes.NestedFamORAssem:
+                    return "Protected";
+
+                default:
+                    return null;
+            }
+        }
+
+        protected override StringBuilder AppendGenericType(StringBuilder buf, TypeReference type, DynamicParserContext context)
+        {
+            List<TypeReference> decls = DocUtils.GetDeclaringTypes(
+                    type is GenericInstanceType ? type.GetElementType() : type);
+            List<TypeReference> genArgs = GetGenericArguments(type);
+            int argIdx = 0;
+            int displayedInParentArguments = 0;
+            bool insertNested = false;
+            foreach (var decl in decls)
+            {
+                TypeReference declDef = decl.Resolve() ?? decl;
+                if (insertNested)
+                {
+                    buf.Append(NestedTypeSeparator);
+                }
+                insertNested = true;
+
+                AppendTypeName(buf, declDef, context);
+
+                int argumentCount = DocUtils.GetGenericArgumentCount(declDef);
+                int notYetDisplayedArguments = argumentCount - displayedInParentArguments;
+                displayedInParentArguments = argumentCount;// nested TypeReferences have parents' generic arguments, but we shouldn't display them
+                if (notYetDisplayedArguments > 0)
+                {
+                    buf.Append(GenericTypeContainer[0]);
+                    var origState = MemberFormatterState;
+                    MemberFormatterState = MemberFormatterState.WithinGenericTypeParameters;
+                    for (int i = 0; i < notYetDisplayedArguments; ++i)
+                    {
+                        if (i > 0)
+                            buf.Append(", ");
+                        var genArg = genArgs[argIdx++];
+                        _AppendTypeName(buf, genArg, context);
+                        var genericParameter = genArg as GenericParameter;
+                        if (genericParameter != null)
+                            AppendConstraints(buf, genericParameter);
+                    }
+                    MemberFormatterState = origState;
+                    buf.Append(GenericTypeContainer[1]);
+                }
+            }
+            return buf;
+        }
+
+        protected override StringBuilder AppendGenericTypeConstraints(StringBuilder buf, TypeReference type)
+        {
+            return buf;
+        }
+
+        private void AppendConstraints(StringBuilder buf, GenericParameter genArg)
+        {
+            if (MemberFormatterState == MemberFormatterState.WithinGenericTypeParameters)
+            {
+                // check to avoid such a code: 
+                // Public Class MyList(Of A As {Class, Generic.IList(Of B --->As {Class, A}<----), New}, B As {Class, A})
+                return;
+            }
+
+            GenericParameterAttributes attrs = genArg.Attributes;
+            IList<TypeReference> constraints = genArg.Constraints;
+            if (attrs == GenericParameterAttributes.NonVariant && constraints.Count == 0)
+                return;
+
+            bool isref = (attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
+            bool isvt = (attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
+            bool isnew = (attrs & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
+            bool comma = false;
+
+            if (!isref && !isvt && !isnew && constraints.Count == 0)
+                return;
+            int constraintsCount = Convert.ToInt32(isref) + Convert.ToInt32(isvt) + Convert.ToInt32(isnew) + constraints.Count;
+            buf.Append(" As ");
+
+            if (constraintsCount > 1 && !isvt)
+                buf.Append("{");
+            if (isref)
+            {
+                buf.Append("Class");
+                comma = true;
+            }
+            else if (isvt)
+            {
+                buf.Append("Structure");
+                comma = true;
+            }
+            if (constraints.Count > 0 && !isvt)
+            {
+                if (comma)
+                    buf.Append(", ");
+                buf.Append(GetTypeName(constraints[0]));
+                for (int i = 1; i < constraints.Count; ++i)
+                    buf.Append(", ").Append(GetTypeName(constraints[i]));
+            }
+            if (isnew && !isvt)
+            {
+                if (comma)
+                    buf.Append(", ");
+                buf.Append("New");
+            }
+            if (constraintsCount > 1 && !isvt)
+                buf.Append("}");
+        }
+
+        protected override string GetConstructorDeclaration(MethodDefinition constructor)
+        {
+            StringBuilder buf = new StringBuilder();
+            AppendVisibility(buf, constructor);
+            if (buf.Length == 0)
+                return null;
+
+            buf.Append(" Sub New ");
+            AppendParameters(buf, constructor, constructor.Parameters);
+
+            return buf.ToString();
+        }
+
+        protected override string GetMethodDeclaration(MethodDefinition method)
+        {
+            if (method.HasCustomAttributes && method.CustomAttributes.Cast<CustomAttribute>().Any(
+                        ca => ca.GetDeclaringType() == "System.Diagnostics.Contracts.ContractInvariantMethodAttribute"))
+                return null;
+
+            
+            // Special signature for destructors.
+            if (method.Name == "Finalize" && method.Parameters.Count == 0)
+                return GetFinalizerName(method);
+
+            StringBuilder buf = new StringBuilder();
+            if (DocUtils.IsExtensionMethod(method))
+                buf.Append("<Extension()>" + GetLineEnding());
+
+            AppendVisibility(buf, method);
+            if (buf.Length == 0 &&
+                    !(DocUtils.IsExplicitlyImplemented(method) && !method.IsSpecialName))
+                return null;
+
+            AppendModifiers(buf, method);
+            if (buf.Length != 0)
+                buf.Append(" ");
+            bool isFunction = method.MethodReturnType.ReturnType.FullName != "System.Void";
+            if (!IsOperator(method))
+            {
+                if (isFunction)
+                    buf.Append("Function ");
+                else
+                    buf.Append("Sub ");
+            }
+            AppendMethodName(buf, method);
+
+            AppendGenericMethod(buf, method).Append(" ");
+            AppendParameters(buf, method, method.Parameters);
+            AppendGenericMethodConstraints(buf, method);
+            if (isFunction)
+                buf.Append(" As ").Append(GetTypeName(method.ReturnType, new DynamicParserContext(method.MethodReturnType)));
+
+            if (DocUtils.IsExplicitlyImplemented(method))
+            {
+                TypeReference iface;
+                MethodReference ifaceMethod;
+                DocUtils.GetInfoForExplicitlyImplementedMethod(method, out iface, out ifaceMethod);
+                buf.Append(" Implements ")
+                    .Append(new VBMemberFormatter().GetName(iface))
+                    .Append('.')
+                    .Append(ifaceMethod.Name);
+            }
+
+            return buf.ToString();
+        }
+
+        protected override StringBuilder AppendMethodName(StringBuilder buf, MethodDefinition method)
+        {
+            if (DocUtils.IsExplicitlyImplemented(method))
+            {
+                return buf.Append(method.Name.Split('.').Last());
+            }
+
+            if (IsOperator(method))
+            {
+                // this is an operator
+                switch (method.Name)
+                {
+                    case "op_Implicit":
+                    case "op_Explicit":
+                        buf.Length--; // remove the last space, which assumes a member name is coming
+                        return buf;
+                    case "op_Addition":
+                    case "op_UnaryPlus":
+                        return buf.Append("Operator +");
+                    case "op_Subtraction":
+                    case "op_UnaryNegation":
+                        return buf.Append("Operator -");
+                    case "op_IntegerDivision":
+                        return buf.Append("Operator \\");
+                    case "op_Division":
+                        return buf.Append("Operator /");
+                    case "op_Multiply":
+                        return buf.Append("Operator *");
+                    case "op_Modulus":
+                        return buf.Append("Operator Mod");
+                    case "op_BitwiseAnd":
+                        return buf.Append("Operator And");
+                    case "op_BitwiseOr":
+                        return buf.Append("Operator Or");
+                    case "op_ExclusiveOr":
+                        return buf.Append("Operator Xor");
+                    case "op_LeftShift":
+                        return buf.Append("Operator <<");
+                    case "op_RightShift":
+                        return buf.Append("Operator >>");
+                    case "op_LogicalNot":
+                        return buf.Append("Operator Not");
+                    case "op_OnesComplement":
+                        return buf.Append("Operator Not");
+                    case "op_True":
+                        return buf.Append("Operator IsTrue");
+                    case "op_False":
+                        return buf.Append("Operator IsFalse");
+                    case "op_Equality":
+                        return buf.Append("Operator ==");
+                    case "op_Inequality":
+                        return buf.Append("Operator !=");
+                    case "op_LessThan":
+                        return buf.Append("Operator <");
+                    case "op_LessThanOrEqual":
+                        return buf.Append("Operator <=");
+                    case "op_GreaterThan":
+                        return buf.Append("Operator >");
+                    case "op_GreaterThanOrEqual":
+                        return buf.Append("Operator >=");
+                    case "op_Like":
+                        return buf.Append("Operator Like");
+                    default:
+                        return base.AppendMethodName(buf, method);
+                }
+            }
+            else
+                return base.AppendMethodName(buf, method);
+        }
+
+        protected override StringBuilder AppendGenericMethodConstraints(StringBuilder buf, MethodDefinition method)
+        {
+            return buf;
+        }
+
+        protected override string RefTypeModifier
+        {
+            get { return ""; }
+        }
+
+        protected override string GetFinalizerName(MethodDefinition method)
+        {
+            return method.Name + " ()";
+        }
+
+        protected override StringBuilder AppendVisibility(StringBuilder buf, MethodDefinition method)
+        {
+            if (method == null)
+                return buf;
+            if (method.IsPublic)
+                return buf.Append("Public");
+            if (method.IsFamily || method.IsFamilyOrAssembly)
+                return buf.Append("Protected");
+            return buf;
+        }
+
+        protected override StringBuilder AppendModifiers(StringBuilder buf, MethodDefinition method)
+        {
+            string modifiers = String.Empty;
+            if (method.IsStatic && !IsModule(method.DeclaringType)) modifiers += " Shared";
+            if (IsIteratorMethod(method)) modifiers += " Iterator";
+            if (method.IsVirtual && !method.IsAbstract)
+            {
+                if ((method.Attributes & MethodAttributes.NewSlot) != 0) modifiers += " Overridable";
+                else modifiers += " Overrides";
+            }
+            TypeDefinition declType = (TypeDefinition)method.DeclaringType;
+            if (method.IsAbstract && !declType.IsInterface) modifiers += " MustOverride";
+            if (method.IsFinal) modifiers += " NotOverridable";
+            if (modifiers == " MustOverride NotOverridable") modifiers = "";
+            if (modifiers == " Overridable NotOverridable") modifiers = "";
+
+            switch (method.Name)
+            {
+                case "op_Implicit":
+                    modifiers += " Widening Operator CType";
+                    break;
+                case "op_Explicit":
+                    modifiers += " Narrowing Operator CType";
+                    break;
+            }
+
+            return buf.Append(modifiers);
+        }
+
+        protected override StringBuilder AppendGenericMethod(StringBuilder buf, MethodDefinition method)
+        {
+            if (method.IsGenericMethod())
+            {
+                IList<GenericParameter> args = method.GenericParameters;
+                if (args.Count > 0)
+                {
+                    buf.Append(GenericTypeContainer[0]);
+                    buf.Append(args[0].Name);
+                    AppendConstraints(buf, args[0]);
+                    for (int i = 1; i < args.Count; ++i)
+                    {
+                        buf.Append(", ").Append(args[i].Name);
+                        AppendConstraints(buf, args[0]);
+                    }
+                    buf.Append(GenericTypeContainer[1]);
+                }
+            }
+            return buf;
+        }
+
+        protected override StringBuilder AppendParameters(StringBuilder buf, MethodDefinition method, IList<ParameterDefinition> parameters)
+        {
+            return AppendParameters(buf, method, parameters, '(', ')');
+        }
+
+        private StringBuilder AppendParameters(StringBuilder buf, MethodDefinition method, IList<ParameterDefinition> parameters, char begin, char end)
+        {
+            buf.Append(begin);
+
+            if (parameters.Count > 0)
+            {
+                AppendParameter(buf, parameters[0]);
+                for (int i = 1; i < parameters.Count; ++i)
+                {
+                    buf.Append(", ");
+                    AppendParameter(buf, parameters[i]);
+                }
+            }
+
+            return buf.Append(end);
+        }
+
+        private StringBuilder AppendParameter(StringBuilder buf, ParameterDefinition parameter)
+        {
+            if (parameter.IsOptional)
+            {
+                buf.Append("Optional ");
+            }
+            if (parameter.ParameterType is ByReferenceType)
+            {
+                buf.Append("ByRef ");
+            }
+            if (parameter.HasCustomAttributes)
+            {
+                var isParams = parameter.CustomAttributes.Any(ca => ca.AttributeType.Name == "ParamArrayAttribute");
+                if (isParams)
+                    buf.AppendFormat("ParamArray ");
+            }
+            buf.Append(parameter.Name);
+            buf.Append(" As ");
+            buf.Append(GetTypeName(parameter.ParameterType, new DynamicParserContext(parameter)));
+            if (parameter.HasDefault && parameter.IsOptional && parameter.HasConstant)
+            {
+                buf.AppendFormat(" = {0}", MDocUpdater.MakeAttributesValueString(parameter.Constant, parameter.ParameterType));
+            }
+            return buf;
+        }
+
+        protected override string GetPropertyDeclaration(PropertyDefinition property)
+        {
+            MethodDefinition method;
+            
+            string getVisible = null;
+            if ((method = property.GetMethod) != null &&
+                    (DocUtils.IsExplicitlyImplemented(method) ||
+                     (!method.IsPrivate && !method.IsAssembly && !method.IsFamilyAndAssembly)))
+                getVisible = AppendVisibility(new StringBuilder(), method).ToString();
+            string setVisible = null;
+            if ((method = property.SetMethod) != null &&
+                    (DocUtils.IsExplicitlyImplemented(method) ||
+                     (!method.IsPrivate && !method.IsAssembly && !method.IsFamilyAndAssembly)))
+                setVisible = AppendVisibility(new StringBuilder(), method).ToString();
+
+            if ((setVisible == null) && (getVisible == null))
+                return null;
+
+            string visibility;
+            StringBuilder buf = new StringBuilder();
+            IEnumerable<MemberReference> defs = property.DeclaringType.GetDefaultMembers();
+            bool indexer = false;
+            foreach (MemberReference mi in defs)
+            {
+                if (mi == property)
+                {
+                    indexer = true;
+                    break;
+                }
+            }
+            if (indexer)
+                buf.Append("Default ");
+            if (getVisible != null && (setVisible == null || (setVisible != null && getVisible == setVisible)))
+                buf.Append(visibility = getVisible);
+            else if (setVisible != null && getVisible == null)
+                buf.Append(visibility = setVisible);
+            else
+                buf.Append(visibility = "Public");
+
+            // Pick an accessor to use for static/virtual/override/etc. checks.
+            method = property.SetMethod;
+            if (method == null)
+                method = property.GetMethod;
+
+            string modifiers = String.Empty;
+            if (method.IsStatic && !IsModule(method.DeclaringType)) modifiers += " Shared";
+            if (method.IsVirtual && !method.IsAbstract)
+            {
+                if ((method.Attributes & MethodAttributes.NewSlot) != 0)
+                    modifiers += " Overridable";
+                else
+                    modifiers += " Overrides";
+            }
+            TypeDefinition declDef = (TypeDefinition)method.DeclaringType;
+            if (method.IsAbstract && !declDef.IsInterface)
+                modifiers += " MustOverride";
+            if (method.IsFinal)
+                modifiers += " NotOverridable";
+            if (modifiers == " MustOverride NotOverridable")
+                modifiers = "";
+            if (modifiers == " Overridable NotOverridable")
+                modifiers = "";
+            buf.Append(modifiers).Append(' ');
+
+            if (getVisible != null && setVisible == null)
+                buf.Append("ReadOnly ");
+
+            buf.Append("Property ");
+
+            buf.Append(DocUtils.GetPropertyName(property).Split('.').Last());
+
+            if (property.Parameters.Count != 0)
+            {
+                AppendParameters(buf, method, property.Parameters, '(', ')');
+            }
+            buf.Append(" As ");
+            buf.Append(GetTypeName(property.PropertyType, new DynamicParserContext(property)));
+            if (DocUtils.IsExplicitlyImplemented(property.GetMethod))
+            {
+                TypeReference iface;
+                MethodReference ifaceMethod;
+                DocUtils.GetInfoForExplicitlyImplementedMethod(method, out iface, out ifaceMethod);
+                buf.Append(" Implements ")
+                    .Append(new VBMemberFormatter().GetName(iface))
+                    .Append('.')
+                    .Append(DocUtils.GetPropertyName(property).Split('.').Last());
+            }
+            return buf.ToString();
+        }
+
+        protected override string GetFieldDeclaration(FieldDefinition field)
+        {
+            TypeDefinition declType = (TypeDefinition)field.DeclaringType;
+            if (declType.IsEnum && field.Name == "value__")
+                return null; // This member of enums aren't documented.
+
+            StringBuilder buf = new StringBuilder();
+            AppendFieldVisibility(buf, field);
+            if (buf.Length == 0)
+                return null;
+
+            if (declType.IsEnum)
+                return field.Name;
+
+            if (field.IsStatic && !field.IsLiteral && !IsModule(field.DeclaringType))
+                buf.Append(" Shared");
+            if (field.IsInitOnly)
+                buf.Append(" ReadOnly");
+            if (field.IsLiteral)
+                buf.Append(" Const");
+
+            buf.Append(' ').Append(field.Name);
+            buf.Append(" As ").Append(GetTypeName(field.FieldType, new DynamicParserContext(field))).Append(' ');
+            DocUtils.AppendFieldValue(buf, field);
+
+            return buf.ToString();
+        }
+
+        static void AppendFieldVisibility(StringBuilder buf, FieldDefinition field)
+        {
+            if (field.IsPublic)
+            {
+                buf.Append("Public");
+                return;
+            }
+            if (field.IsFamily || field.IsFamilyOrAssembly)
+            {
+                buf.Append("Protected");
+            }
+        }
+
+        protected override string GetEventDeclaration(EventDefinition e)
+        {
+            StringBuilder buf = new StringBuilder();
+            bool isPublicEII = IsPublicEII(e);
+
+            if (AppendVisibility(buf, e.AddMethod).Length == 0 && !isPublicEII)
+            {
+                return null;
+            }
+            if (e.DeclaringType.IsInterface) // There is no access modifiers in interfaces
+            {
+                buf.Clear();
+            }
+            AppendModifiers(buf, e.AddMethod);
+            if (e.AddMethod.CustomAttributes.All(
+                i => i.AttributeType.FullName != "System.Runtime.CompilerServices.CompilerGeneratedAttribute")
+                && !e.DeclaringType.IsInterface)// There is no 'Custom' modifier in interfaces
+            {
+                if (buf.Length > 0)
+                    buf.Append(' ');
+                buf.Append("Custom");
+            }
+
+            if (buf.Length > 0)
+                buf.Append(' ');
+            buf.Append("Event ");
+            if (isPublicEII)
+                buf.Append(e.Name.Split('.').Last());
+            else
+                buf.Append(e.Name);
+            buf.Append(" As ").Append(GetTypeName(e.EventType, new DynamicParserContext(e.AddMethod.Parameters[0]))).Append(' ');
+            if (isPublicEII)
+                buf.Append($"Implements {e.Name.Substring(0, e.Name.LastIndexOf('.'))}");
+
+            return buf.ToString();
+        }
+
+        protected override char[] ArrayDelimeters
+        {
+            get { return new[] {'(', ')'}; }
+        }
+
+        public override bool IsSupported(TypeReference tref)
+        {
+            return !tref.Name.Contains('*');
+        }
+
+        public override bool IsSupported(MemberReference mref)
+        {
+            var field = mref as FieldDefinition;
+            if (field != null)
+            {
+                return IsSupported(field.FieldType)
+                    && IsSupportedNaming(field);
+            }
+
+            var method = mref as MethodDefinition;
+            if (method != null)
+            {
+                return IsSupported(method.ReturnType)
+                    && method.Parameters.All(i => IsSupported(i.ParameterType))
+                    && IsSupportedNaming(method);
+            }
+
+            var property = mref as PropertyDefinition;
+            if (property != null)
+            {
+                return IsSupported(property.PropertyType)
+                    && IsSupportedNaming(property);
+            }
+
+            var @event = mref as EventDefinition;
+            if (@event != null)
+            {
+                return IsSupported(@event.EventType)
+                    && IsSupportedNaming(@event);
+            }
+
+            throw new NotSupportedException("Unsupported member type: " + mref.GetType().FullName);
+        }
+
+        private bool IsSupportedNaming(EventDefinition @event)
+        {
+            return !@event.Name.Equals(@event.EventType.Name, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        private bool IsSupportedNaming(PropertyDefinition property)
+        {
+            return !property.Name.Equals(property.DeclaringType.Name, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        private bool IsSupportedNaming(MethodDefinition method)
+        {
+            var allTypes = method.Parameters.Select(i => i.ParameterType)
+                                            .Concat(method.GenericParameters)
+                                            .Concat(new[] { method.ReturnType })
+                                            .ToList();
+            foreach (var typeReference in allTypes)
+            {
+                foreach (var typeReference2 in allTypes)
+                {
+                    // if there are types which differ only in letter case
+                    if (typeReference.Name.Equals(typeReference2.Name, StringComparison.InvariantCultureIgnoreCase)
+                        && typeReference.Name != typeReference2.Name)
+                        return false;
+                }
+                foreach (var parameterDefinition in method.Parameters)
+                {
+                    // it there's a parameter which name is case-insensitively equal to typename 
+                    if (parameterDefinition.Name.Equals(typeReference.Name, StringComparison.InvariantCultureIgnoreCase))
+                        return false;
+                }
+            }
+
+            foreach (var parameterDefinition in method.Parameters)
+            {
+                foreach (var parameterDefinition2 in method.Parameters)
+                {
+                    // if there're parameters which names are case-insensitively equal
+                    if (parameterDefinition.Name.Equals(parameterDefinition2.Name, StringComparison.InvariantCultureIgnoreCase)
+                        && parameterDefinition.Name != parameterDefinition2.Name)
+                        return false;
+                }
+            }
+            return true;
+        }
+
+        private bool IsSupportedNaming(FieldDefinition field)
+        {
+            return !field.Name.Equals(field.DeclaringType.Name, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        private static bool IsModule(TypeDefinition typeDefinition)
+        {
+            return typeDefinition.CustomAttributes.Any(i => i.AttributeType.FullName == "Microsoft.VisualBasic.CompilerServices.StandardModuleAttribute")
+                || typeDefinition.Methods.Any(DocUtils.IsExtensionMethod);
+        }
+
+        private bool IsIteratorMethod(MethodDefinition method)
+        {
+            return method.CustomAttributes.Any(i => i.AttributeType.FullName == "System.Runtime.CompilerServices.IteratorStateMachineAttribute");
+        }
+
+        private bool IsOperator(MethodDefinition method)
+        {
+            return method.Name.StartsWith("op_", StringComparison.Ordinal);
+        }
+
+        private static string GetLineEnding()
+        {
+            return "\n";
+        }
+    }
+}

--- a/mdoc/Mono.Documentation/Updater/Formatters/VBMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/VBMemberFormatter.cs
@@ -1,0 +1,13 @@
+using System.Text;
+using Mono.Cecil;
+
+namespace Mono.Documentation.Updater
+{
+    public class VBMemberFormatter : VBFullMemberFormatter
+    {
+        protected override StringBuilder AppendNamespace(StringBuilder buf, TypeReference type)
+        {
+            return buf;
+        }
+    }
+}

--- a/mdoc/Test/en.expected-internal-interface/MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-internal-interface/MyNamespace/MyClass.xml
@@ -1,6 +1,7 @@
 <Type Name="MyClass" FullName="MyNamespace.MyClass">
   <TypeSignature Language="C#" Value="public class MyClass : MyNamespace.MyPublicInterface" />
   <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyClass extends System.Object implements class MyNamespace.MyPublicInterface" />
+  <TypeSignature Language="VB.NET" Value="Public Class MyClass&#xA;Implements MyPublicInterface" />
   <AssemblyInfo>
     <AssemblyName>DocTest-InternalInterface</AssemblyName>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -21,6 +22,7 @@
     <Member MemberName=".ctor">
       <MemberSignature Language="C#" Value="public MyClass ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -34,6 +36,7 @@
     <Member MemberName="Bar">
       <MemberSignature Language="C#" Value="public string Bar { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance string Bar" />
+      <MemberSignature Language="VB.NET" Value="Public Property Bar As String" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -55,6 +58,7 @@
     <Member MemberName="BarMeth">
       <MemberSignature Language="C#" Value="public void BarMeth ();" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void BarMeth() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub BarMeth ()" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -71,6 +75,7 @@
     <Member MemberName="InstanceEvent">
       <MemberSignature Language="C#" Value="public event EventHandler&lt;int&gt; InstanceEvent;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;int32&gt; InstanceEvent" />
+      <MemberSignature Language="VB.NET" Value="Public Custom Event InstanceEvent As EventHandler(Of Integer) " />
       <MemberType>Event</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -86,6 +91,7 @@
     <Member MemberName="MyNamespace.MyPublicInterface.PublicEvent">
       <MemberSignature Language="C#" Value="event EventHandler&lt;string&gt; MyNamespace.MyPublicInterface.PublicEvent;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;string&gt; MyNamespace.MyPublicInterface.PublicEvent" />
+      <MemberSignature Language="VB.NET" Value="Custom Event PublicEvent As EventHandler(Of String) Implements MyNamespace.MyPublicInterface" />
       <MemberType>Event</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-internal-interface/MyNamespace/MyPublicInterface.xml
+++ b/mdoc/Test/en.expected-internal-interface/MyNamespace/MyPublicInterface.xml
@@ -1,6 +1,7 @@
 <Type Name="MyPublicInterface" FullName="MyNamespace.MyPublicInterface">
   <TypeSignature Language="C#" Value="public interface MyPublicInterface" />
   <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract MyPublicInterface" />
+  <TypeSignature Language="VB.NET" Value="Public Interface MyPublicInterface" />
   <AssemblyInfo>
     <AssemblyName>DocTest-InternalInterface</AssemblyName>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -14,6 +15,7 @@
     <Member MemberName="PublicEvent">
       <MemberSignature Language="C#" Value="public event EventHandler&lt;string&gt; PublicEvent;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;string&gt; PublicEvent" />
+      <MemberSignature Language="VB.NET" Value="Event PublicEvent As EventHandler(Of String) " />
       <MemberType>Event</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-internal-interface/index.xml
+++ b/mdoc/Test/en.expected-internal-interface/index.xml
@@ -29,6 +29,7 @@
       <Member MemberName="IsAligned&lt;T&gt;">
         <MemberSignature Language="C#" Value="public static bool IsAligned&lt;T&gt; (this T[] vect, int index) where T : struct;" />
         <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsAligned&lt;struct .ctor (class System.ValueType) T&gt;(!!T[] vect, int32 index) cil managed" />
+        <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Function IsAligned(Of T As Structure) (vect As T(), index As Integer) As Boolean" />
         <MemberType>ExtensionMethod</MemberType>
         <ReturnValue>
           <ReturnType>System.Boolean</ReturnType>

--- a/mdoc/Test/en.expected-vbnet/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-vbnet/FrameworksIndex/One.xml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework Name="One">
+  <Namespace Name="MyFramework.MyNamespace">
+    <Type Name="MyFramework.MyNamespace.MyClass" Id="T:MyFramework.MyNamespace.MyClass">
+      <Member Id="M:MyFramework.MyNamespace.MyClass.#ctor" />
+      <Member Id="M:MyFramework.MyNamespace.MyClass.Hello(System.Int32)" />
+      <Member Id="P:MyFramework.MyNamespace.MyClass.MyProperty" />
+      <Member Id="P:MyFramework.MyNamespace.MyClass.OnlyInClassic" />
+    </Type>
+    <Type Name="MyFramework.MyNamespace.MyClassExtensions" Id="T:MyFramework.MyNamespace.MyClassExtensions">
+      <Member Id="M:MyFramework.MyNamespace.MyClassExtensions.AnExtension(MyFramework.MyNamespace.MyClass)" />
+    </Type>
+  </Namespace>
+  <Namespace Name="MyNamespace">
+    <Type Name="MyNamespace.MyClass" Id="T:MyNamespace.MyClass">
+      <Member Id="M:MyNamespace.MyClass.#ctor" />
+      <Member Id="M:MyNamespace.MyClass.SomeMethod``1" />
+    </Type>
+  </Namespace>
+</Framework>

--- a/mdoc/Test/en.expected-vbnet/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-vbnet/FrameworksIndex/Two.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework Name="Two">
+  <Namespace Name="MyFramework.MyOtherNamespace">
+    <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">
+      <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.#ctor" />
+      <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Double)" />
+      <Member Id="M:MyFramework.MyOtherNamespace.MyOtherClass.Hello(System.Int32)" />
+      <Member Id="P:MyFramework.MyOtherNamespace.MyOtherClass.MyProperty" />
+    </Type>
+  </Namespace>
+  <Namespace Name="MyNamespace">
+    <Type Name="MyNamespace.MyClass" Id="T:MyNamespace.MyClass">
+      <Member Id="M:MyNamespace.MyClass.#ctor" />
+      <Member Id="M:MyNamespace.MyClass.SomeMethod``1" />
+    </Type>
+  </Namespace>
+</Framework>

--- a/mdoc/Test/en.expected-vbnet/MyFramework.MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-vbnet/MyFramework.MyNamespace/MyClass.xml
@@ -1,0 +1,92 @@
+<Type Name="MyClass" FullName="MyFramework.MyNamespace.MyClass">
+  <TypeSignature Language="C#" Value="public class MyClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyClass extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class MyClass" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Hello">
+      <MemberSignature Language="C#" Value="public float Hello (int value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function Hello (value As Integer) As Single" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="MyProperty">
+      <MemberSignature Language="C#" Value="public string MyProperty { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string MyProperty" />
+      <MemberSignature Language="VB.NET" Value="Public Property MyProperty As String" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="OnlyInClassic">
+      <MemberSignature Language="C#" Value="public double OnlyInClassic { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance float64 OnlyInClassic" />
+      <MemberSignature Language="VB.NET" Value="Public Property OnlyInClassic As Double" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet/MyFramework.MyNamespace/MyClassExtensions.xml
+++ b/mdoc/Test/en.expected-vbnet/MyFramework.MyNamespace/MyClassExtensions.xml
@@ -1,0 +1,41 @@
+<Type Name="MyClassExtensions" FullName="MyFramework.MyNamespace.MyClassExtensions">
+  <TypeSignature Language="C#" Value="public static class MyClassExtensions" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit MyClassExtensions extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Module MyClassExtensions" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="AnExtension">
+      <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+      <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Function AnExtension (value As MyClass) As Boolean" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet/MyFramework.MyOtherNamespace/MyOtherClass.xml
+++ b/mdoc/Test/en.expected-vbnet/MyFramework.MyOtherNamespace/MyOtherClass.xml
@@ -1,0 +1,96 @@
+<Type Name="MyOtherClass" FullName="MyFramework.MyOtherNamespace.MyOtherClass">
+  <TypeSignature Language="C#" Value="public class MyOtherClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyOtherClass extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class MyOtherClass" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyOtherClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Hello">
+      <MemberSignature Language="C#" Value="public float Hello (double value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(float64 value) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function Hello (value As Double) As Single" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Double" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Hello">
+      <MemberSignature Language="C#" Value="public float Hello (int value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function Hello (value As Integer) As Single" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="MyProperty">
+      <MemberSignature Language="C#" Value="public string MyProperty { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string MyProperty" />
+      <MemberSignature Language="VB.NET" Value="Public Property MyProperty As String" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet/MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-vbnet/MyNamespace/MyClass.xml
@@ -1,0 +1,57 @@
+<Type Name="MyClass" FullName="MyNamespace.MyClass">
+  <TypeSignature Language="C#" Value="public class MyClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyClass extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class MyClass" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-addNonGeneric</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-addNonGeneric</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SomeMethod&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public string SomeMethod&lt;T&gt; ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance string SomeMethod&lt;T&gt;() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function SomeMethod(Of T) () As String" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-addNonGeneric</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters />
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet/index.xml
+++ b/mdoc/Test/en.expected-vbnet/index.xml
@@ -1,0 +1,73 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="MyFramework.MyNamespace">
+      <Type Name="MyClass" Kind="Class" />
+      <Type Name="MyClassExtensions" Kind="Class" />
+    </Namespace>
+    <Namespace Name="MyFramework.MyOtherNamespace">
+      <Type Name="MyOtherClass" Kind="Class" />
+    </Namespace>
+    <Namespace Name="MyNamespace">
+      <Type Name="MyClass" Kind="Class" />
+    </Namespace>
+  </Types>
+  <Title>Untitled</Title>
+  <ExtensionMethods>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:MyFramework.MyNamespace.MyClass" />
+      </Targets>
+      <Member MemberName="AnExtension">
+        <MemberSignature Language="C#" Value="public static bool AnExtension (this MyFramework.MyNamespace.MyClass value);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool AnExtension(class MyFramework.MyNamespace.MyClass value) cil managed" />
+        <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Function AnExtension (value As MyClass) As Boolean" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="value" Type="MyFramework.MyNamespace.MyClass" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="value">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="MyFramework.MyNamespace.MyClassExtensions" Member="M:MyFramework.MyNamespace.MyClassExtensions.AnExtension(MyFramework.MyNamespace.MyClass)" />
+      </Member>
+    </ExtensionMethod>
+  </ExtensionMethods>
+</Overview>

--- a/mdoc/Test/en.expected-vbnet/ns-MyFramework.MyNamespace.xml
+++ b/mdoc/Test/en.expected-vbnet/ns-MyFramework.MyNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyFramework.MyNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-vbnet/ns-MyFramework.MyOtherNamespace.xml
+++ b/mdoc/Test/en.expected-vbnet/ns-MyFramework.MyOtherNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyFramework.MyOtherNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-vbnet/ns-MyNamespace.xml
+++ b/mdoc/Test/en.expected-vbnet/ns-MyNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="MyNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/Extensions.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/Extensions.xml
@@ -1,0 +1,146 @@
+<Type Name="Extensions" FullName="Mono.DocTest.Generic.Extensions">
+  <TypeSignature Language="C#" Value="public static class Extensions" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit Extensions extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Module Extensions" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Bar&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static void Bar&lt;T&gt; (this Mono.DocTest.Generic.IFoo&lt;T&gt; self, string s);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Bar&lt;T&gt;(class Mono.DocTest.Generic.IFoo`1&lt;!!T&gt; self, string s) cil managed" />
+      <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Sub Bar(Of T) (self As IFoo(Of T), s As String)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="self" Type="Mono.DocTest.Generic.IFoo&lt;T&gt;" RefType="this" />
+        <Parameter Name="s" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="self">To be added.</param>
+        <param name="s">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ForEach&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static void ForEach&lt;T&gt; (this System.Collections.Generic.IEnumerable&lt;T&gt; self, Action&lt;T&gt; a);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void ForEach&lt;T&gt;(class System.Collections.Generic.IEnumerable`1&lt;!!T&gt; self, class System.Action`1&lt;!!T&gt; a) cil managed" />
+      <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Sub ForEach(Of T) (self As IEnumerable(Of T), a As Action(Of T))" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="self" Type="System.Collections.Generic.IEnumerable&lt;T&gt;" RefType="this" />
+        <Parameter Name="a" Type="System.Action&lt;T&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="self">To be added.</param>
+        <param name="a">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ToDouble">
+      <MemberSignature Language="C#" Value="public static System.Collections.Generic.IEnumerable&lt;double&gt; ToDouble (this System.Collections.Generic.IEnumerable&lt;int&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.Generic.IEnumerable`1&lt;float64&gt; ToDouble(class System.Collections.Generic.IEnumerable`1&lt;int32&gt; list) cil managed" />
+      <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Function ToDouble (list As IEnumerable(Of Integer)) As IEnumerable(Of Double)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Double&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="list" Type="System.Collections.Generic.IEnumerable&lt;System.Int32&gt;" RefType="this" />
+      </Parameters>
+      <Docs>
+        <param name="list">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ToDouble&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static double ToDouble&lt;T&gt; (this T val) where T : Mono.DocTest.Generic.IFoo&lt;T&gt;;" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig float64 ToDouble&lt;(class Mono.DocTest.Generic.IFoo`1&lt;!!T&gt;) T&gt;(!!T val) cil managed" />
+      <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Function ToDouble(Of T As IFoo(Of T)) (val As T) As Double" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T">
+          <Constraints>
+            <InterfaceName>Mono.DocTest.Generic.IFoo&lt;T&gt;</InterfaceName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="val" Type="T" RefType="this" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="val">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ToEnumerable&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static System.Collections.Generic.IEnumerable&lt;T&gt; ToEnumerable&lt;T&gt; (this T self);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.Generic.IEnumerable`1&lt;!!T&gt; ToEnumerable&lt;T&gt;(!!T self) cil managed" />
+      <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Function ToEnumerable(Of T) (self As T) As IEnumerable(Of T)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IEnumerable&lt;T&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="self" Type="T" RefType="this" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="self">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/Func`2.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/Func`2.xml
@@ -1,0 +1,65 @@
+<Type Name="Func&lt;TArg,TRet&gt;" FullName="Mono.DocTest.Generic.Func&lt;TArg,TRet&gt;">
+  <TypeSignature Language="C#" Value="public delegate TRet Func&lt;in TArg,out TRet&gt;(TArg a) where TArg : Exception;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed Func`2&lt;(class System.Exception) - TArg, + TRet&gt; extends System.MulticastDelegate" />
+  <TypeSignature Language="VB.NET" Value="Public Delegate Function Func(Of In TArg, Out TRet)(a As TArg) As TRet " />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="TArg">
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("arg!")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <Constraints>
+        <ParameterAttribute>Contravariant</ParameterAttribute>
+        <BaseTypeName>System.Exception</BaseTypeName>
+      </Constraints>
+    </TypeParameter>
+    <TypeParameter Name="TRet">
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("ret!")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <Constraints>
+        <ParameterAttribute>Covariant</ParameterAttribute>
+      </Constraints>
+    </TypeParameter>
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Mono.DocTest.Doc("method")</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Parameters>
+    <Parameter Name="a" Type="TArg">
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("arg-actual")</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Parameter>
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>TRet</ReturnType>
+    <Attributes>
+      <Attribute>
+        <AttributeName>Mono.DocTest.Doc("return", Field=false)</AttributeName>
+      </Attribute>
+    </Attributes>
+  </ReturnValue>
+  <Docs>
+    <typeparam name="TArg">To be added.</typeparam>
+    <typeparam name="TRet">To be added.</typeparam>
+    <param name="a">To be added.</param>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/GenericBase`1+FooEventArgs.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/GenericBase`1+FooEventArgs.xml
@@ -1,0 +1,36 @@
+<Type Name="GenericBase&lt;U&gt;+FooEventArgs" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs">
+  <TypeSignature Language="C#" Value="public class GenericBase&lt;U&gt;.FooEventArgs : EventArgs" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit GenericBase`1/FooEventArgs&lt;U&gt; extends System.EventArgs" />
+  <TypeSignature Language="VB.NET" Value="Public Class GenericBase(Of U).FooEventArgs&#xA;Inherits EventArgs" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="U" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.EventArgs</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FooEventArgs ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
@@ -1,0 +1,21 @@
+<Type Name="GenericBase&lt;U&gt;+NestedCollection+Enumerator" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator">
+  <TypeSignature Language="C#" Value="protected struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
+  <TypeSignature Language="ILAsm" Value=".class nested protected sequential ansi sealed beforefieldinit GenericBase`1/NestedCollection/Enumerator&lt;U&gt; extends System.ValueType" />
+  <TypeSignature Language="VB.NET" Value="Protected Structure GenericBase(Of U).NestedCollection.Enumerator" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="U" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.ValueType</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members />
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/GenericBase`1+NestedCollection.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/GenericBase`1+NestedCollection.xml
@@ -1,0 +1,36 @@
+<Type Name="GenericBase&lt;U&gt;+NestedCollection" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection">
+  <TypeSignature Language="C#" Value="public class GenericBase&lt;U&gt;.NestedCollection" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit GenericBase`1/NestedCollection&lt;U&gt; extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class GenericBase(Of U).NestedCollection" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="U" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public NestedCollection ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/GenericBase`1.xml
@@ -1,0 +1,153 @@
+<Type Name="GenericBase&lt;U&gt;" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;">
+  <TypeSignature Language="C#" Value="public class GenericBase&lt;U&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit GenericBase`1&lt;U&gt; extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class GenericBase(Of U)" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="U" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <typeparam name="U">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public GenericBase ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="BaseMethod&lt;S&gt;">
+      <MemberSignature Language="C#" Value="public U BaseMethod&lt;S&gt; (S genericParameter);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance !U BaseMethod&lt;S&gt;(!!S genericParameter) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function BaseMethod(Of S) (genericParameter As S) As U" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>U</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="S">
+          <Attributes>
+            <Attribute>
+              <AttributeName>Mono.DocTest.Doc("S")</AttributeName>
+            </Attribute>
+          </Attributes>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="genericParameter" Type="S" />
+      </Parameters>
+      <Docs>
+        <typeparam name="S">To be added.</typeparam>
+        <param name="genericParameter">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConstField1">
+      <MemberSignature Language="C#" Value="public const int ConstField1;" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal int32 ConstField1" />
+      <MemberSignature Language="VB.NET" Value="Public Const ConstField1 As Integer " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ItemChanged">
+      <MemberSignature Language="C#" Value="public event Action&lt;Mono.DocTest.Generic.MyList&lt;U&gt;,Mono.DocTest.Generic.MyList&lt;U&gt;.Helper&lt;U,U&gt;&gt; ItemChanged;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.Action`2&lt;class Mono.DocTest.Generic.MyList`1&lt;!U&gt;, class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!U, !U, !U&gt;&gt; ItemChanged" />
+      <MemberSignature Language="VB.NET" Value="Public Custom Event ItemChanged As Action(Of MyList(Of U), MyList(Of U).Helper(Of U, U)) " />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Action&lt;Mono.DocTest.Generic.MyList&lt;U&gt;,Mono.DocTest.Generic.MyList&lt;U&gt;+Helper&lt;U,U&gt;&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="MyEvent">
+      <MemberSignature Language="C#" Value="public event EventHandler&lt;Mono.DocTest.Generic.GenericBase&lt;U&gt;.FooEventArgs&gt; MyEvent;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;class Mono.DocTest.Generic.GenericBase`1/FooEventArgs&lt;!U&gt;&gt; MyEvent" />
+      <MemberSignature Language="VB.NET" Value="Public Custom Event MyEvent As EventHandler(Of GenericBase(Of U).FooEventArgs) " />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.EventHandler&lt;Mono.DocTest.Generic.GenericBase&lt;U&gt;+FooEventArgs&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Explicit">
+      <MemberSignature Language="C#" Value="public static explicit operator U (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname !U op_Explicit(class Mono.DocTest.Generic.GenericBase`1&lt;!U&gt; list) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Shared Narrowing Operator CType (list As GenericBase(Of U)) As U" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>U</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="list" Type="Mono.DocTest.Generic.GenericBase&lt;U&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="list">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="StaticField1">
+      <MemberSignature Language="C#" Value="public static readonly Mono.DocTest.Generic.GenericBase&lt;U&gt; StaticField1;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class Mono.DocTest.Generic.GenericBase`1&lt;!U&gt; StaticField1" />
+      <MemberSignature Language="VB.NET" Value="Public Shared ReadOnly StaticField1 As GenericBase(Of U) " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Generic.GenericBase&lt;U&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/IFoo`1.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/IFoo`1.xml
@@ -1,0 +1,46 @@
+<Type Name="IFoo&lt;T&gt;" FullName="Mono.DocTest.Generic.IFoo&lt;T&gt;">
+  <TypeSignature Language="C#" Value="public interface IFoo&lt;T&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract IFoo`1&lt;T&gt;" />
+  <TypeSignature Language="VB.NET" Value="Public Interface IFoo(Of T)" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T" />
+  </TypeParameters>
+  <Interfaces />
+  <Docs>
+    <typeparam name="T">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="Method&lt;U&gt;">
+      <MemberSignature Language="C#" Value="public T Method&lt;U&gt; (T t, U u);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance !T Method&lt;U&gt;(!T t, !!U u) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>T</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="t" Type="T" />
+        <Parameter Name="u" Type="U" />
+      </Parameters>
+      <Docs>
+        <typeparam name="U">To be added.</typeparam>
+        <param name="t">To be added.</param>
+        <param name="u">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/MyList`1+Helper`2.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/MyList`1+Helper`2.xml
@@ -1,0 +1,64 @@
+<Type Name="MyList&lt;T&gt;+Helper&lt;U,V&gt;" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;">
+  <TypeSignature Language="C#" Value="public class MyList&lt;T&gt;.Helper&lt;U,V&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit MyList`1/Helper`2&lt;T, U, V&gt; extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class MyList(Of T).Helper(Of U, V)" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T" />
+    <TypeParameter Name="U" />
+    <TypeParameter Name="V" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <typeparam name="U">To be added.</typeparam>
+    <typeparam name="V">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Helper ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseT">
+      <MemberSignature Language="C#" Value="public void UseT (T a, U b, V c);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void UseT(!T a, !U b, !V c) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub UseT (a As T, b As U, c As V)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="T" />
+        <Parameter Name="b" Type="U" />
+        <Parameter Name="c" Type="V" />
+      </Parameters>
+      <Docs>
+        <param name="a">To be added.</param>
+        <param name="b">To be added.</param>
+        <param name="c">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/MyList`1.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/MyList`1.xml
@@ -1,0 +1,205 @@
+<Type Name="MyList&lt;T&gt;" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;">
+  <TypeSignature Language="C#" Value="public class MyList&lt;T&gt; : Mono.DocTest.Generic.GenericBase&lt;T&gt;, System.Collections.Generic.IEnumerable&lt;int[]&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyList`1&lt;T&gt; extends Mono.DocTest.Generic.GenericBase`1&lt;!T&gt; implements class System.Collections.Generic.IEnumerable`1&lt;int32[]&gt;, class System.Collections.IEnumerable" />
+  <TypeSignature Language="VB.NET" Value="Public Class MyList(Of T)&#xA;Inherits GenericBase(Of T)&#xA;Implements IEnumerable(Of Integer())" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T">
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("Type Parameter!")</AttributeName>
+        </Attribute>
+      </Attributes>
+    </TypeParameter>
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>Mono.DocTest.Generic.GenericBase&lt;T&gt;</BaseTypeName>
+    <BaseTypeArguments>
+      <BaseTypeArgument TypeParamName="U">T</BaseTypeArgument>
+    </BaseTypeArguments>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>System.Collections.Generic.IEnumerable&lt;System.Int32[]&gt;</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <typeparam name="T">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyList ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetEnumerator">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.IEnumerator&lt;int[]&gt; GetEnumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class System.Collections.Generic.IEnumerator`1&lt;int32[]&gt; GetEnumerator() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function GetEnumerator () As IEnumerator(Of Integer())" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IEnumerator&lt;System.Int32[]&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetHelper&lt;U,V&gt;">
+      <MemberSignature Language="C#" Value="public Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U,V&gt; GetHelper&lt;U,V&gt; ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!T, !!U, !!V&gt; GetHelper&lt;U, V&gt;() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function GetHelper(Of U, V) () As MyList(Of T).Helper(Of U, V)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+        <TypeParameter Name="V" />
+      </TypeParameters>
+      <Parameters />
+      <Docs>
+        <typeparam name="U">To be added.</typeparam>
+        <typeparam name="V">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Method&lt;U&gt;">
+      <MemberSignature Language="C#" Value="public void Method&lt;U&gt; (T t, U u);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Method&lt;U&gt;(!T t, !!U u) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="t" Type="T" />
+        <Parameter Name="u" Type="U" />
+      </Parameters>
+      <Docs>
+        <typeparam name="U">To be added.</typeparam>
+        <param name="t">To be added.</param>
+        <param name="u">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RefMethod&lt;U&gt;">
+      <MemberSignature Language="C#" Value="public void RefMethod&lt;U&gt; (ref T t, ref U u);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void RefMethod&lt;U&gt;(!T&amp; t, !!U&amp; u) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="t" Type="T&amp;" RefType="ref" />
+        <Parameter Name="u" Type="U&amp;" RefType="ref" />
+      </Parameters>
+      <Docs>
+        <typeparam name="U">To be added.</typeparam>
+        <param name="t">To be added.</param>
+        <param name="u">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
+      <MemberSignature Language="C#" Value="System.Collections.IEnumerator IEnumerable.GetEnumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Function GetEnumerator () As IEnumerator Implements IEnumerable.GetEnumerator" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.IEnumerator</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Test">
+      <MemberSignature Language="C#" Value="public void Test (T t);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Test(!T t) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="t" Type="T" />
+      </Parameters>
+      <Docs>
+        <param name="t">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseHelper&lt;U,V&gt;">
+      <MemberSignature Language="C#" Value="public void UseHelper&lt;U,V&gt; (Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U,V&gt; helper);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void UseHelper&lt;U, V&gt;(class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!T, !!U, !!V&gt; helper) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub UseHelper(Of U, V) (helper As MyList(Of T).Helper(Of U, V))" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+        <TypeParameter Name="V" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="helper" Type="Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="U">To be added.</typeparam>
+        <typeparam name="V">To be added.</typeparam>
+        <param name="helper">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/MyList`2.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/MyList`2.xml
@@ -1,0 +1,402 @@
+<Type Name="MyList&lt;A,B&gt;" FullName="Mono.DocTest.Generic.MyList&lt;A,B&gt;">
+  <TypeSignature Language="C#" Value="public class MyList&lt;A,B&gt; : Mono.DocTest.Generic.GenericBase&lt;System.Collections.Generic.Dictionary&lt;A,B&gt;&gt;, Mono.DocTest.Generic.IFoo&lt;A&gt;, System.Collections.Generic.ICollection&lt;A&gt;, System.Collections.Generic.IEnumerable&lt;A&gt;, System.Collections.Generic.IEnumerator&lt;A&gt; where A : class, IList&lt;B&gt;, new() where B : class, A" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit MyList`2&lt;class .ctor (class System.Collections.Generic.IList`1&lt;!B&gt;) A, class (!A) B&gt; extends Mono.DocTest.Generic.GenericBase`1&lt;class System.Collections.Generic.Dictionary`2&lt;!A, !B&gt;&gt; implements class Mono.DocTest.Generic.IFoo`1&lt;!A&gt;, class System.Collections.Generic.ICollection`1&lt;!A&gt;, class System.Collections.Generic.IEnumerable`1&lt;!A&gt;, class System.Collections.Generic.IEnumerator`1&lt;!A&gt;, class System.Collections.IEnumerable, class System.Collections.IEnumerator, class System.IDisposable" />
+  <TypeSignature Language="VB.NET" Value="Public Class MyList(Of A, B)&#xA;Inherits GenericBase(Of Dictionary(Of A, B))&#xA;Implements ICollection(Of A), IEnumerable(Of A), IEnumerator(Of A), IFoo(Of A)" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="A">
+      <Constraints>
+        <ParameterAttribute>DefaultConstructorConstraint</ParameterAttribute>
+        <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+        <InterfaceName>System.Collections.Generic.IList&lt;B&gt;</InterfaceName>
+      </Constraints>
+    </TypeParameter>
+    <TypeParameter Name="B">
+      <Constraints>
+        <ParameterAttribute>ReferenceTypeConstraint</ParameterAttribute>
+        <BaseTypeName>A</BaseTypeName>
+      </Constraints>
+    </TypeParameter>
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>Mono.DocTest.Generic.GenericBase&lt;System.Collections.Generic.Dictionary&lt;A,B&gt;&gt;</BaseTypeName>
+    <BaseTypeArguments>
+      <BaseTypeArgument TypeParamName="U">System.Collections.Generic.Dictionary&lt;A,B&gt;</BaseTypeArgument>
+    </BaseTypeArguments>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Mono.DocTest.Generic.IFoo&lt;A&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>System.Collections.Generic.ICollection&lt;A&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>System.Collections.Generic.IEnumerable&lt;A&gt;</InterfaceName>
+    </Interface>
+    <Interface>
+      <InterfaceName>System.Collections.Generic.IEnumerator&lt;A&gt;</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <typeparam name="A">To be added.</typeparam>
+    <typeparam name="B">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public MyList ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="CopyTo">
+      <MemberSignature Language="C#" Value="public void CopyTo (A[] array, int arrayIndex);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void CopyTo(!A[] array, int32 arrayIndex) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub CopyTo (array As A(), arrayIndex As Integer)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="array" Type="A[]" />
+        <Parameter Name="arrayIndex" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="array">To be added.</param>
+        <param name="arrayIndex">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Count">
+      <MemberSignature Language="C#" Value="public int Count { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 Count" />
+      <MemberSignature Language="VB.NET" Value="Public ReadOnly Property Count As Integer" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Current">
+      <MemberSignature Language="C#" Value="public A Current { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance !A Current" />
+      <MemberSignature Language="VB.NET" Value="Public ReadOnly Property Current As A" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>A</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Dispose">
+      <MemberSignature Language="C#" Value="public void Dispose ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Dispose() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub Dispose ()" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Foo">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.KeyValuePair&lt;System.Collections.Generic.IEnumerable&lt;A&gt;,System.Collections.Generic.IEnumerable&lt;B&gt;&gt; Foo ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance valuetype System.Collections.Generic.KeyValuePair`2&lt;class System.Collections.Generic.IEnumerable`1&lt;!A&gt;, class System.Collections.Generic.IEnumerable`1&lt;!B&gt;&gt; Foo() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function Foo () As KeyValuePair(Of IEnumerable(Of A), IEnumerable(Of B))" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.KeyValuePair&lt;System.Collections.Generic.IEnumerable&lt;A&gt;,System.Collections.Generic.IEnumerable&lt;B&gt;&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetEnumerator">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.List&lt;A&gt;.Enumerator GetEnumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance valuetype System.Collections.Generic.List`1/Enumerator&lt;!A&gt; GetEnumerator() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function GetEnumerator () As List(Of A).Enumerator" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.List&lt;A&gt;+Enumerator</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt;">
+      <MemberSignature Language="C#" Value="A IFoo&lt;A&gt;.Method&lt;U&gt; (A a, U u);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance !A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt;(!A a, !!U u) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>A</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="U" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="a" Type="A" />
+        <Parameter Name="u" Type="U" />
+      </Parameters>
+      <Docs>
+        <typeparam name="U">To be added.</typeparam>
+        <param name="a">To be added.</param>
+        <param name="u">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="MoveNext">
+      <MemberSignature Language="C#" Value="public bool MoveNext ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance bool MoveNext() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function MoveNext () As Boolean" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Reset">
+      <MemberSignature Language="C#" Value="public void Reset ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Reset() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub Reset ()" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Add">
+      <MemberSignature Language="C#" Value="void ICollection&lt;A&gt;.Add (A item);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void System.Collections.Generic.ICollection&lt;A&gt;.Add(!A item) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Sub Add (item As A) Implements ICollection(Of A).Add" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="A" />
+      </Parameters>
+      <Docs>
+        <param name="item">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Clear">
+      <MemberSignature Language="C#" Value="void ICollection&lt;A&gt;.Clear ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void System.Collections.Generic.ICollection&lt;A&gt;.Clear() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Sub Clear () Implements ICollection(Of A).Clear" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Contains">
+      <MemberSignature Language="C#" Value="bool ICollection&lt;A&gt;.Contains (A item);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(!A item) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Function Contains (item As A) As Boolean Implements ICollection(Of A).Contains" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="A" />
+      </Parameters>
+      <Docs>
+        <param name="item">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.IsReadOnly">
+      <MemberSignature Language="C#" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.IsReadOnly { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance bool System.Collections.Generic.ICollection&lt;A&gt;.IsReadOnly" />
+      <MemberSignature Language="VB.NET" Value=" ReadOnly Property IsReadOnly As Boolean Implements ICollection(Of A).IsReadOnly" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Remove">
+      <MemberSignature Language="C#" Value="bool ICollection&lt;A&gt;.Remove (A item);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(!A item) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Function Remove (item As A) As Boolean Implements ICollection(Of A).Remove" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="A" />
+      </Parameters>
+      <Docs>
+        <param name="item">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.IEnumerable&lt;A&gt;.GetEnumerator">
+      <MemberSignature Language="C#" Value="System.Collections.Generic.IEnumerator&lt;A&gt; IEnumerable&lt;A&gt;.GetEnumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class System.Collections.Generic.IEnumerator`1&lt;!A&gt; System.Collections.Generic.IEnumerable&lt;A&gt;.GetEnumerator() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Function GetEnumerator () As IEnumerator(Of A) Implements IEnumerable(Of A).GetEnumerator" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.IEnumerator&lt;A&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.Generic.IEnumerator&lt;A&gt;.Current">
+      <MemberSignature Language="C#" Value="A System.Collections.Generic.IEnumerator&lt;A&gt;.Current { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance !A System.Collections.Generic.IEnumerator&lt;A&gt;.Current" />
+      <MemberSignature Language="VB.NET" Value=" ReadOnly Property Current As A Implements IEnumerator(Of A).Current" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>A</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.IEnumerable.GetEnumerator">
+      <MemberSignature Language="C#" Value="System.Collections.IEnumerator IEnumerable.GetEnumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance class System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Function GetEnumerator () As IEnumerator Implements IEnumerable.GetEnumerator" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.IEnumerator</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="System.Collections.IEnumerator.Current">
+      <MemberSignature Language="C#" Value="object System.Collections.IEnumerator.Current { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance object System.Collections.IEnumerator.Current" />
+      <MemberSignature Language="VB.NET" Value=" ReadOnly Property Current As Object Implements IEnumerator.Current" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Color.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Color.xml
@@ -1,0 +1,78 @@
+<Type Name="Color" FullName="Mono.DocTest.Color">
+  <TypeSignature Language="C#" Value="public enum Color" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed Color extends System.Enum" />
+  <TypeSignature Language="VB.NET" Value="Public Enum Color" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="AnotherGreen">
+      <MemberSignature Language="C#" Value="AnotherGreen" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Color AnotherGreen = int32(2)" />
+      <MemberSignature Language="VB.NET" Value="AnotherGreen" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Blue">
+      <MemberSignature Language="C#" Value="Blue" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Color Blue = int32(1)" />
+      <MemberSignature Language="VB.NET" Value="Blue" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Green">
+      <MemberSignature Language="C#" Value="Green" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Color Green = int32(2)" />
+      <MemberSignature Language="VB.NET" Value="Green" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="Red">
+      <MemberSignature Language="C#" Value="Red" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Color Red = int32(0)" />
+      <MemberSignature Language="VB.NET" Value="Red" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/D.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/D.xml
@@ -1,0 +1,24 @@
+<Type Name="D" FullName="Mono.DocTest.D">
+  <TypeSignature Language="C#" Value="public delegate dynamic D(Func&lt;string,dynamic,object&gt; value);" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed D extends System.MulticastDelegate" />
+  <TypeSignature Language="VB.NET" Value="Public Delegate Function D(value As Func(Of String, Object, Object)) As Object " />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="value" Type="System.Func&lt;System.String,System.Object,System.Object&gt;" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Object</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <param name="value">To be added.</param>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/DocAttribute.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/DocAttribute.xml
@@ -1,0 +1,106 @@
+<Type Name="DocAttribute" FullName="Mono.DocTest.DocAttribute">
+  <TypeSignature Language="C#" Value="public class DocAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit DocAttribute extends System.Attribute" />
+  <TypeSignature Language="VB.NET" Value="Public Class DocAttribute&#xA;Inherits Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.AttributeUsage(System.AttributeTargets.All)</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public DocAttribute (string docs);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string docs) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New (docs As String)" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="docs" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="docs">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Field">
+      <MemberSignature Language="C#" Value="public bool Field;" />
+      <MemberSignature Language="ILAsm" Value=".field public bool Field" />
+      <MemberSignature Language="VB.NET" Value="Public Field As Boolean " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="FlagsEnum">
+      <MemberSignature Language="C#" Value="public ConsoleModifiers FlagsEnum;" />
+      <MemberSignature Language="ILAsm" Value=".field public valuetype System.ConsoleModifiers FlagsEnum" />
+      <MemberSignature Language="VB.NET" Value="Public FlagsEnum As ConsoleModifiers " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.ConsoleModifiers</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NonFlagsEnum">
+      <MemberSignature Language="C#" Value="public Mono.DocTest.Color NonFlagsEnum;" />
+      <MemberSignature Language="ILAsm" Value=".field public valuetype Mono.DocTest.Color NonFlagsEnum" />
+      <MemberSignature Language="VB.NET" Value="Public NonFlagsEnum As Color " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Property">
+      <MemberSignature Language="C#" Value="public Type Property { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Type Property" />
+      <MemberSignature Language="VB.NET" Value="Public Property Property As Type" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Type</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/DocValueType.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/DocValueType.xml
@@ -1,0 +1,59 @@
+<Type Name="DocValueType" FullName="Mono.DocTest.DocValueType">
+  <TypeSignature Language="C#" Value="public struct DocValueType : Mono.DocTest.IProcess" />
+  <TypeSignature Language="ILAsm" Value=".class public sequential ansi sealed beforefieldinit DocValueType extends System.ValueType implements class Mono.DocTest.IProcess" />
+  <TypeSignature Language="VB.NET" Value="Public Structure DocValueType&#xA;Implements IProcess" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.ValueType</BaseTypeName>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Mono.DocTest.IProcess</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="M">
+      <MemberSignature Language="C#" Value="public void M (int i);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub M (i As Integer)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="i" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="i">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="total">
+      <MemberSignature Language="C#" Value="public int total;" />
+      <MemberSignature Language="ILAsm" Value=".field public int32 total" />
+      <MemberSignature Language="VB.NET" Value="Public total As Integer " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/IProcess.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/IProcess.xml
@@ -1,0 +1,15 @@
+<Type Name="IProcess" FullName="Mono.DocTest.IProcess">
+  <TypeSignature Language="C#" Value="public interface IProcess" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract IProcess" />
+  <TypeSignature Language="VB.NET" Value="Public Interface IProcess" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members />
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/UseLists.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/UseLists.xml
@@ -1,0 +1,176 @@
+<Type Name="UseLists" FullName="Mono.DocTest.UseLists">
+  <TypeSignature Language="C#" Value="public class UseLists" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit UseLists extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class UseLists" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public UseLists ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="GetValues&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public Mono.DocTest.Generic.MyList&lt;T&gt; GetValues&lt;T&gt; (T value) where T : struct;" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class Mono.DocTest.Generic.MyList`1&lt;!!T&gt; GetValues&lt;struct .ctor (class System.ValueType) T&gt;(!!T value) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function GetValues(Of T As Structure) (value As T) As MyList(Of T)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Generic.MyList&lt;T&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T">
+          <Constraints>
+            <ParameterAttribute>DefaultConstructorConstraint</ParameterAttribute>
+            <ParameterAttribute>NotNullableValueTypeConstraint</ParameterAttribute>
+            <BaseTypeName>System.ValueType</BaseTypeName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="value" Type="T" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Process">
+      <MemberSignature Language="C#" Value="public void Process (Mono.DocTest.Generic.MyList&lt;int&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Process(class Mono.DocTest.Generic.MyList`1&lt;int32&gt; list) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub Process (list As MyList(Of Integer))" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="list" Type="Mono.DocTest.Generic.MyList&lt;System.Int32&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="list">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Process">
+      <MemberSignature Language="C#" Value="public void Process (System.Collections.Generic.List&lt;int&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Process(class System.Collections.Generic.List`1&lt;int32&gt; list) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub Process (list As List(Of Integer))" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="list" Type="System.Collections.Generic.List&lt;System.Int32&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="list">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Process">
+      <MemberSignature Language="C#" Value="public void Process (System.Collections.Generic.List&lt;Predicate&lt;int&gt;&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Process(class System.Collections.Generic.List`1&lt;class System.Predicate`1&lt;int32&gt;&gt; list) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub Process (list As List(Of Predicate(Of Integer)))" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="list" Type="System.Collections.Generic.List&lt;System.Predicate&lt;System.Int32&gt;&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="list">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Process&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public void Process&lt;T&gt; (System.Collections.Generic.List&lt;Predicate&lt;T&gt;&gt; list);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Process&lt;T&gt;(class System.Collections.Generic.List`1&lt;class System.Predicate`1&lt;!!T&gt;&gt; list) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub Process(Of T) (list As List(Of Predicate(Of T)))" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="list" Type="System.Collections.Generic.List&lt;System.Predicate&lt;T&gt;&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="list">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="UseHelper&lt;T,U,V&gt;">
+      <MemberSignature Language="C#" Value="public void UseHelper&lt;T,U,V&gt; (Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U,V&gt; helper);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void UseHelper&lt;T, U, V&gt;(class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!!T, !!U, !!V&gt; helper) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub UseHelper(Of T, U, V) (helper As MyList(Of T).Helper(Of U, V))" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+        <TypeParameter Name="U" />
+        <TypeParameter Name="V" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="helper" Type="Mono.DocTest.Generic.MyList&lt;T&gt;+Helper&lt;U,V&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <typeparam name="U">To be added.</typeparam>
+        <typeparam name="V">To be added.</typeparam>
+        <param name="helper">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+Del.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+Del.xml
@@ -1,0 +1,23 @@
+<Type Name="Widget+Del" FullName="Mono.DocTest.Widget+Del">
+  <TypeSignature Language="C#" Value="public delegate void Widget.Del(int i);" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed Widget/Del extends System.MulticastDelegate" />
+  <TypeSignature Language="VB.NET" Value="Public Delegate Sub Widget.Del(i As Integer)" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="i" Type="System.Int32" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Void</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <param name="i">To be added.</param>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+Direction.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+Direction.xml
@@ -1,0 +1,83 @@
+<Type Name="Widget+Direction" FullName="Mono.DocTest.Widget+Direction">
+  <TypeSignature Language="C#" Value="protected enum Widget.Direction" />
+  <TypeSignature Language="ILAsm" Value=".class nested protected auto ansi sealed Widget/Direction extends System.Enum" />
+  <TypeSignature Language="VB.NET" Value="Protected Enum Widget.Direction" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Attributes>
+    <Attribute>
+      <AttributeName>System.Flags</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="East">
+      <MemberSignature Language="C#" Value="East" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Widget/Direction East = int32(2)" />
+      <MemberSignature Language="VB.NET" Value="East" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Direction</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="North">
+      <MemberSignature Language="C#" Value="North" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Widget/Direction North = int32(0)" />
+      <MemberSignature Language="VB.NET" Value="North" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Direction</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="South">
+      <MemberSignature Language="C#" Value="South" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Widget/Direction South = int32(1)" />
+      <MemberSignature Language="VB.NET" Value="South" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Direction</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+    <Member MemberName="West">
+      <MemberSignature Language="C#" Value="West" />
+      <MemberSignature Language="ILAsm" Value=".field public static literal valuetype Mono.DocTest.Widget/Direction West = int32(3)" />
+      <MemberSignature Language="VB.NET" Value="West" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Direction</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+IMenuItem.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+IMenuItem.xml
@@ -1,0 +1,50 @@
+<Type Name="Widget+IMenuItem" FullName="Mono.DocTest.Widget+IMenuItem">
+  <TypeSignature Language="C#" Value="public interface Widget.IMenuItem" />
+  <TypeSignature Language="ILAsm" Value=".class nested public interface auto ansi abstract Widget/IMenuItem" />
+  <TypeSignature Language="VB.NET" Value="Public Interface Widget.IMenuItem" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="A">
+      <MemberSignature Language="C#" Value="public void A ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void A() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub A ()" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="B">
+      <MemberSignature Language="C#" Value="public int B { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 B" />
+      <MemberSignature Language="VB.NET" Value="Public Property B As Integer" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+NestedClass+Double+Triple+Quadruple.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+NestedClass+Double+Triple+Quadruple.xml
@@ -1,0 +1,33 @@
+<Type Name="Widget+NestedClass+Double+Triple+Quadruple" FullName="Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple">
+  <TypeSignature Language="C#" Value="public class Widget.NestedClass.Double.Triple.Quadruple" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit Widget/NestedClass/Double/Triple/Quadruple extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class Widget.NestedClass.Double.Triple.Quadruple" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Quadruple ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+NestedClass+Double+Triple.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+NestedClass+Double+Triple.xml
@@ -1,0 +1,33 @@
+<Type Name="Widget+NestedClass+Double+Triple" FullName="Mono.DocTest.Widget+NestedClass+Double+Triple">
+  <TypeSignature Language="C#" Value="public class Widget.NestedClass.Double.Triple" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit Widget/NestedClass/Double/Triple extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class Widget.NestedClass.Double.Triple" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Triple ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+NestedClass+Double.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+NestedClass+Double.xml
@@ -1,0 +1,33 @@
+<Type Name="Widget+NestedClass+Double" FullName="Mono.DocTest.Widget+NestedClass+Double">
+  <TypeSignature Language="C#" Value="public class Widget.NestedClass.Double" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit Widget/NestedClass/Double extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class Widget.NestedClass.Double" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Double ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+NestedClass.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+NestedClass.xml
@@ -1,0 +1,69 @@
+<Type Name="Widget+NestedClass" FullName="Mono.DocTest.Widget+NestedClass">
+  <TypeSignature Language="C#" Value="public class Widget.NestedClass" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit Widget/NestedClass extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class Widget.NestedClass" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public NestedClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M">
+      <MemberSignature Language="C#" Value="public void M (int i);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub M (i As Integer)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="i" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="i">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="value">
+      <MemberSignature Language="C#" Value="public int value;" />
+      <MemberSignature Language="ILAsm" Value=".field public int32 value" />
+      <MemberSignature Language="VB.NET" Value="Public value As Integer " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+NestedClass`1.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+NestedClass`1.xml
@@ -1,0 +1,73 @@
+<Type Name="Widget+NestedClass&lt;T&gt;" FullName="Mono.DocTest.Widget+NestedClass&lt;T&gt;">
+  <TypeSignature Language="C#" Value="public class Widget.NestedClass&lt;T&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi beforefieldinit Widget/NestedClass`1&lt;T&gt; extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class Widget.NestedClass(Of T)" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <typeparam name="T">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public NestedClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M">
+      <MemberSignature Language="C#" Value="public void M (int i);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub M (i As Integer)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="i" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="i">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="value">
+      <MemberSignature Language="C#" Value="public int value;" />
+      <MemberSignature Language="ILAsm" Value=".field public int32 value" />
+      <MemberSignature Language="VB.NET" Value="Public value As Integer " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget.xml
@@ -1,0 +1,900 @@
+<Type Name="Widget" FullName="Mono.DocTest.Widget">
+  <TypeSignature Language="C#" Value="public class Widget : Mono.DocTest.IProcess" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Widget extends System.Object implements class Mono.DocTest.IProcess" />
+  <TypeSignature Language="VB.NET" Value="Public Class Widget&#xA;Implements IProcess" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Mono.DocTest.IProcess</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Widget ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Widget (Converter&lt;string,string&gt; c);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(class System.Converter`2&lt;string, string&gt; c) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New (c As Converter(Of String, String))" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="c" Type="System.Converter&lt;System.String,System.String&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="c">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Widget (string s);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string s) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New (s As String)" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters>
+        <Parameter Name="s" Type="System.String" />
+      </Parameters>
+      <Docs>
+        <param name="s">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AnEvent">
+      <MemberSignature Language="C#" Value="public event Mono.DocTest.Widget.Del AnEvent;" />
+      <MemberSignature Language="ILAsm" Value=".event class Mono.DocTest.Widget/Del AnEvent" />
+      <MemberSignature Language="VB.NET" Value="Public Custom Event AnEvent As Widget.Del " />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("Del event")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>add: Mono.DocTest.Doc("Del add accessor")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>remove: Mono.DocTest.Doc("Del remove accessor")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Del</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AnotherEvent">
+      <MemberSignature Language="C#" Value="protected event Mono.DocTest.Widget.Del AnotherEvent;" />
+      <MemberSignature Language="ILAsm" Value=".event class Mono.DocTest.Widget/Del AnotherEvent" />
+      <MemberSignature Language="VB.NET" Value="Protected Custom Event AnotherEvent As Widget.Del " />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget+Del</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="array1">
+      <MemberSignature Language="C#" Value="public long[] array1;" />
+      <MemberSignature Language="ILAsm" Value=".field public int64[] array1" />
+      <MemberSignature Language="VB.NET" Value="Public array1 As Long() " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int64[]</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="array2">
+      <MemberSignature Language="C#" Value="public Mono.DocTest.Widget[,] array2;" />
+      <MemberSignature Language="ILAsm" Value=".field public class Mono.DocTest.Widget[,] array2" />
+      <MemberSignature Language="VB.NET" Value="Public array2 As Widget(,) " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget[,]</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="classCtorError">
+      <MemberSignature Language="C#" Value="public static readonly string[] classCtorError;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly string[] classCtorError" />
+      <MemberSignature Language="VB.NET" Value="Public Shared ReadOnly classCtorError As String() " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String[]</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Default">
+      <MemberSignature Language="C#" Value="public void Default (int a = 1, int b = 2);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Default(int32 a, int32 b) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub Default (Optional a As Integer = 1, Optional b As Integer = 2)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="System.Int32" />
+        <Parameter Name="b" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="a">To be added.</param>
+        <param name="b">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Default">
+      <MemberSignature Language="C#" Value="public void Default (string a = &quot;a&quot;, char b = 'b');" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Default(string a, char b) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub Default (Optional a As String = &quot;a&quot;, Optional b As Char = 'b')" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="System.String" />
+        <Parameter Name="b" Type="System.Char" />
+      </Parameters>
+      <Docs>
+        <param name="a">To be added.</param>
+        <param name="b">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="defaultColor">
+      <MemberSignature Language="C#" Value="protected static Mono.DocTest.Color defaultColor;" />
+      <MemberSignature Language="ILAsm" Value=".field family static valuetype Mono.DocTest.Color defaultColor" />
+      <MemberSignature Language="VB.NET" Value="Protected Shared defaultColor As Color " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Color</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Dynamic0">
+      <MemberSignature Language="C#" Value="public dynamic Dynamic0 (dynamic a, dynamic b);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance object Dynamic0(object a, object b) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function Dynamic0 (a As Object, b As Object) As Object" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Object</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="System.Object" />
+        <Parameter Name="b" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="a">To be added.</param>
+        <param name="b">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Dynamic1">
+      <MemberSignature Language="C#" Value="public System.Collections.Generic.Dictionary&lt;dynamic,string&gt; Dynamic1 (System.Collections.Generic.Dictionary&lt;dynamic,string&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Collections.Generic.Dictionary`2&lt;object, string&gt; Dynamic1(class System.Collections.Generic.Dictionary`2&lt;object, string&gt; value) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function Dynamic1 (value As Dictionary(Of Object, String)) As Dictionary(Of Object, String)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.Generic.Dictionary&lt;System.Object,System.String&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Collections.Generic.Dictionary&lt;System.Object,System.String&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Dynamic2">
+      <MemberSignature Language="C#" Value="public Func&lt;string,dynamic&gt; Dynamic2 (Func&lt;string,dynamic&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Func`2&lt;string, object&gt; Dynamic2(class System.Func`2&lt;string, object&gt; value) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function Dynamic2 (value As Func(Of String, Object)) As Func(Of String, Object)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.String,System.Object&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Func&lt;System.String,System.Object&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Dynamic3">
+      <MemberSignature Language="C#" Value="public Func&lt;Func&lt;string,dynamic&gt;,Func&lt;dynamic,string&gt;&gt; Dynamic3 (Func&lt;Func&lt;string,dynamic&gt;,Func&lt;dynamic,string&gt;&gt; value);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance class System.Func`2&lt;class System.Func`2&lt;string, object&gt;, class System.Func`2&lt;object, string&gt;&gt; Dynamic3(class System.Func`2&lt;class System.Func`2&lt;string, object&gt;, class System.Func`2&lt;object, string&gt;&gt; value) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function Dynamic3 (value As Func(Of Func(Of String, Object), Func(Of Object, String))) As Func(Of Func(Of String, Object), Func(Of Object, String))" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.Func&lt;System.String,System.Object&gt;,System.Func&lt;System.Object,System.String&gt;&gt;</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="value" Type="System.Func&lt;System.Func&lt;System.String,System.Object&gt;,System.Func&lt;System.Object,System.String&gt;&gt;" />
+      </Parameters>
+      <Docs>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DynamicE1">
+      <MemberSignature Language="C#" Value="public event Func&lt;dynamic&gt; DynamicE1;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.Func`1&lt;object&gt; DynamicE1" />
+      <MemberSignature Language="VB.NET" Value="Public Custom Event DynamicE1 As Func(Of Object) " />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Obsolete("why not")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.Object&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DynamicE2">
+      <MemberSignature Language="C#" Value="public event Func&lt;dynamic&gt; DynamicE2;" />
+      <MemberSignature Language="ILAsm" Value=".event class System.Func`1&lt;object&gt; DynamicE2" />
+      <MemberSignature Language="VB.NET" Value="Public Custom Event DynamicE2 As Func(Of Object) " />
+      <MemberType>Event</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.Object&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DynamicF">
+      <MemberSignature Language="C#" Value="public Func&lt;Func&lt;string,dynamic,string&gt;,Func&lt;dynamic,Func&lt;dynamic&gt;,string&gt;&gt; DynamicF;" />
+      <MemberSignature Language="ILAsm" Value=".field public class System.Func`2&lt;class System.Func`3&lt;string, object, string&gt;, class System.Func`3&lt;object, class System.Func`1&lt;object&gt;, string&gt;&gt; DynamicF" />
+      <MemberSignature Language="VB.NET" Value="Public DynamicF As Func(Of Func(Of String, Object, String), Func(Of Object, Func(Of Object), String)) " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.Func&lt;System.String,System.Object,System.String&gt;,System.Func&lt;System.Object,System.Func&lt;System.Object&gt;,System.String&gt;&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DynamicP">
+      <MemberSignature Language="C#" Value="public Func&lt;Func&lt;string,dynamic,string&gt;,Func&lt;dynamic,Func&lt;dynamic&gt;,string&gt;&gt; DynamicP { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance class System.Func`2&lt;class System.Func`3&lt;string, object, string&gt;, class System.Func`3&lt;object, class System.Func`1&lt;object&gt;, string&gt;&gt; DynamicP" />
+      <MemberSignature Language="VB.NET" Value="Public ReadOnly Property DynamicP As Func(Of Func(Of String, Object, String), Func(Of Object, Func(Of Object), String))" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Func&lt;System.Func&lt;System.String,System.Object,System.String&gt;,System.Func&lt;System.Object,System.Func&lt;System.Object&gt;,System.String&gt;&gt;</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Height">
+      <MemberSignature Language="C#" Value="protected long Height { get; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int64 Height" />
+      <MemberSignature Language="VB.NET" Value="Protected ReadOnly Property Height As Long" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("Height property")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Int64</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Item">
+      <MemberSignature Language="C#" Value="public int this[int i] { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 Item(int32)" />
+      <MemberSignature Language="VB.NET" Value="Default Public Property Item(i As Integer) As Integer" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("Item property")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>set: Mono.DocTest.Doc("Item property set accessor")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="i" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="i">To be added.</param>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Item">
+      <MemberSignature Language="C#" Value="public int this[string s, int i] { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 Item(string, int32)" />
+      <MemberSignature Language="VB.NET" Value="Default Public Property Item(s As String, i As Integer) As Integer" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="s" Type="System.String" />
+        <Parameter Name="i" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="s">To be added.</param>
+        <param name="i">To be added.</param>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M0">
+      <MemberSignature Language="C#" Value="public static void M0 ();" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void M0() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Shared Sub M0 ()" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M1">
+      <MemberSignature Language="C#" Value="public void M1 (char c, out float f, ref Mono.DocTest.DocValueType v);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M1(char c, [out] float32&amp; f, valuetype Mono.DocTest.DocValueType&amp; v) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub M1 (c As Char, ByRef f As Single, ByRef v As DocValueType)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("normal DocAttribute", Field=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+        <Attributes>
+          <Attribute>
+            <AttributeName>Mono.DocTest.Doc("return:DocAttribute", Property=typeof(Mono.DocTest.Widget))</AttributeName>
+          </Attribute>
+        </Attributes>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="c" Type="System.Char">
+          <Attributes>
+            <Attribute>
+              <AttributeName>Mono.DocTest.Doc("c", FlagsEnum=System.ConsoleModifiers.Alt | System.ConsoleModifiers.Control)</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+        <Parameter Name="f" Type="System.Single&amp;" RefType="out">
+          <Attributes>
+            <Attribute>
+              <AttributeName>Mono.DocTest.Doc("f", NonFlagsEnum=Mono.DocTest.Color.Red)</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+        <Parameter Name="v" Type="Mono.DocTest.DocValueType&amp;" RefType="ref">
+          <Attributes>
+            <Attribute>
+              <AttributeName>Mono.DocTest.Doc("v")</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+      </Parameters>
+      <Docs>
+        <param name="c">To be added.</param>
+        <param name="f">To be added.</param>
+        <param name="v">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M2">
+      <MemberSignature Language="C#" Value="public void M2 (short[] x1, int[,] x2, long[][] x3);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M2(int16[] x1, int32[,] x2, int64[][] x3) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub M2 (x1 As Short(), x2 As Integer(,), x3 As Long()())" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x1" Type="System.Int16[]" />
+        <Parameter Name="x2" Type="System.Int32[,]" />
+        <Parameter Name="x3" Type="System.Int64[][]" />
+      </Parameters>
+      <Docs>
+        <param name="x1">To be added.</param>
+        <param name="x2">To be added.</param>
+        <param name="x3">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M3">
+      <MemberSignature Language="C#" Value="protected void M3 (long[][] x3, Mono.DocTest.Widget[,,][] x4);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M3(int64[][] x3, class Mono.DocTest.Widget[,,][] x4) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Protected Sub M3 (x3 As Long()(), x4 As Widget(,,)())" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x3" Type="System.Int64[][]" />
+        <Parameter Name="x4" Type="Mono.DocTest.Widget[,,][]" />
+      </Parameters>
+      <Docs>
+        <param name="x3">To be added.</param>
+        <param name="x4">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M4">
+      <MemberSignature Language="C#" Value="protected void M4 (char* pc, Mono.DocTest.Color** ppf);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M4(char* pc, valuetype Mono.DocTest.Color** ppf) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="pc" Type="System.Char*" />
+        <Parameter Name="ppf" Type="Mono.DocTest.Color**" />
+      </Parameters>
+      <Docs>
+        <param name="pc">To be added.</param>
+        <param name="ppf">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M5">
+      <MemberSignature Language="C#" Value="protected void M5 (void* pv, double*[,][] pd);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M5(void* pv, float64*[,][] pd) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="pv" Type="System.Void*" />
+        <Parameter Name="pd" Type="System.Double*[,][]" />
+      </Parameters>
+      <Docs>
+        <param name="pv">To be added.</param>
+        <param name="pd">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M6">
+      <MemberSignature Language="C#" Value="protected void M6 (int i, params object[] args);" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M6(int32 i, object[] args) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Protected Sub M6 (i As Integer, ParamArray args As Object())" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="i" Type="System.Int32" />
+        <Parameter Name="args" Type="System.Object[]">
+          <Attributes>
+            <Attribute>
+              <AttributeName>System.ParamArray</AttributeName>
+            </Attribute>
+          </Attributes>
+        </Parameter>
+      </Parameters>
+      <Docs>
+        <param name="i">To be added.</param>
+        <param name="args">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="M7">
+      <MemberSignature Language="C#" Value="public void M7 (Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple a);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M7(class Mono.DocTest.Widget/NestedClass/Double/Triple/Quadruple a) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub M7 (a As Widget.NestedClass.Double.Triple.Quadruple)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="Mono.DocTest.Widget+NestedClass+Double+Triple+Quadruple" />
+      </Parameters>
+      <Docs>
+        <param name="a">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="message">
+      <MemberSignature Language="C#" Value="public string message;" />
+      <MemberSignature Language="ILAsm" Value=".field public string message" />
+      <MemberSignature Language="VB.NET" Value="Public message As String " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="monthlyAverage">
+      <MemberSignature Language="C#" Value="protected readonly double monthlyAverage;" />
+      <MemberSignature Language="ILAsm" Value=".field familyorassembly initonly float64 monthlyAverage" />
+      <MemberSignature Language="VB.NET" Value="Protected ReadOnly monthlyAverage As Double " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Addition">
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_Addition(class Mono.DocTest.Widget x1, class Mono.DocTest.Widget x2) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Shared Operator + (x1 As Widget, x2 As Widget) As Widget" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x1" Type="Mono.DocTest.Widget" />
+        <Parameter Name="x2" Type="Mono.DocTest.Widget" />
+      </Parameters>
+      <Docs>
+        <param name="x1">To be added.</param>
+        <param name="x2">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Division">
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget op_Division;" />
+      <MemberSignature Language="ILAsm" Value=".field public static class Mono.DocTest.Widget op_Division" />
+      <MemberSignature Language="VB.NET" Value="Public Shared op_Division As Widget " />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Explicit">
+      <MemberSignature Language="C#" Value="public static explicit operator int (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int32 op_Explicit(class Mono.DocTest.Widget x) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Shared Narrowing Operator CType (x As Widget) As Integer" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="Mono.DocTest.Widget" />
+      </Parameters>
+      <Docs>
+        <param name="x">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_Implicit">
+      <MemberSignature Language="C#" Value="public static implicit operator long (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int64 op_Implicit(class Mono.DocTest.Widget x) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Shared Widening Operator CType (x As Widget) As Long" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int64</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="Mono.DocTest.Widget" />
+      </Parameters>
+      <Docs>
+        <param name="x">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="op_UnaryPlus">
+      <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_UnaryPlus(class Mono.DocTest.Widget x) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Shared Operator + (x As Widget) As Widget" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Mono.DocTest.Widget</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="Mono.DocTest.Widget" />
+      </Parameters>
+      <Docs>
+        <param name="x">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="pCount">
+      <MemberSignature Language="C#" Value="public int* pCount;" />
+      <MemberSignature Language="ILAsm" Value=".field public int32* pCount" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32*</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="PI">
+      <MemberSignature Language="C#" Value="protected const double PI = 3.14159;" />
+      <MemberSignature Language="ILAsm" Value=".field familyorassembly static literal float64 PI = (3.14159)" />
+      <MemberSignature Language="VB.NET" Value="Protected Const PI As Double  = 3.14159" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <MemberValue>3.14159</MemberValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ppValues">
+      <MemberSignature Language="C#" Value="public float** ppValues;" />
+      <MemberSignature Language="ILAsm" Value=".field public float32** ppValues" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Single**</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Width">
+      <MemberSignature Language="C#" Value="public int Width { get; protected set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int32 Width" />
+      <MemberSignature Language="VB.NET" Value="Public Property Width As Integer" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Mono.DocTest.Doc("Width property")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>get: Mono.DocTest.Doc("Width get accessor")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>set: Mono.DocTest.Doc("Width set accessor")</AttributeName>
+        </Attribute>
+      </Attributes>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="X">
+      <MemberSignature Language="C#" Value="protected short X { set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance int16 X" />
+      <MemberSignature Language="VB.NET" Value="Protected Property X As Short" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int16</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Y">
+      <MemberSignature Language="C#" Value="protected double Y { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance float64 Y" />
+      <MemberSignature Language="VB.NET" Value="Protected Property Y As Double" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Double</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/NoNamespace.xml
+++ b/mdoc/Test/en.expected-vbnet2/NoNamespace.xml
@@ -1,0 +1,33 @@
+<Type Name="NoNamespace" FullName="NoNamespace">
+  <TypeSignature Language="C#" Value="public class NoNamespace" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit NoNamespace extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class NoNamespace" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public NoNamespace ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/System/Action`1.xml
+++ b/mdoc/Test/en.expected-vbnet2/System/Action`1.xml
@@ -1,0 +1,27 @@
+<Type Name="Action&lt;T&gt;" FullName="System.Action&lt;T&gt;">
+  <TypeSignature Language="C#" Value="public delegate void Action&lt;T&gt;(T obj);" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed Action`1&lt;T&gt; extends System.MulticastDelegate" />
+  <TypeSignature Language="VB.NET" Value="Public Delegate Sub Action(Of T)(obj As T)" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="obj" Type="T" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Void</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <typeparam name="T">To be added.</typeparam>
+    <param name="obj">To be added.</param>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/System/Array.xml
+++ b/mdoc/Test/en.expected-vbnet2/System/Array.xml
@@ -1,0 +1,113 @@
+<Type Name="Array" FullName="System.Array">
+  <TypeSignature Language="C#" Value="public class Array" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit Array extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Class Array" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Array ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Sub New ()" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AsReadOnly&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt; AsReadOnly&lt;T&gt; (T[] array);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.ObjectModel.ReadOnlyCollection`1&lt;!!T&gt; AsReadOnly&lt;T&gt;(!!T[] array) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Shared Function AsReadOnly(Of T) (array As T()) As ReadOnlyCollection(Of T)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="array" Type="T[]" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="array">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="ConvertAll&lt;TInput,TOutput&gt;">
+      <MemberSignature Language="C#" Value="public static TOutput[] ConvertAll&lt;TInput,TOutput&gt; (TInput[] array, Converter&lt;TInput,TOutput&gt; converter);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig !!TOutput[] ConvertAll&lt;TInput, TOutput&gt;(!!TInput[] array, class System.Converter`2&lt;!!TInput, !!TOutput&gt; converter) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Shared Function ConvertAll(Of TInput, TOutput) (array As TInput(), converter As Converter(Of TInput, TOutput)) As TOutput()" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>TOutput[]</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="TInput" />
+        <TypeParameter Name="TOutput" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="array" Type="TInput[]" />
+        <Parameter Name="converter" Type="System.Converter&lt;TInput,TOutput&gt;" />
+      </Parameters>
+      <Docs>
+        <typeparam name="TInput">To be added.</typeparam>
+        <typeparam name="TOutput">To be added.</typeparam>
+        <param name="array">To be added.</param>
+        <param name="converter">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="Resize&lt;T&gt;">
+      <MemberSignature Language="C#" Value="public static void Resize&lt;T&gt; (ref T[] array, int newSize);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Resize&lt;T&gt;(!!T[]&amp; array, int32 newSize) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Shared Sub Resize(Of T) (ByRef array As T(), newSize As Integer)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name="T" />
+      </TypeParameters>
+      <Parameters>
+        <Parameter Name="array" Type="T[]&amp;" RefType="ref" />
+        <Parameter Name="newSize" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <typeparam name="T">To be added.</typeparam>
+        <param name="array">To be added.</param>
+        <param name="newSize">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/System/AsyncCallback.xml
+++ b/mdoc/Test/en.expected-vbnet2/System/AsyncCallback.xml
@@ -1,0 +1,23 @@
+<Type Name="AsyncCallback" FullName="System.AsyncCallback">
+  <TypeSignature Language="C#" Value="public delegate void AsyncCallback(IAsyncResult ar);" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed AsyncCallback extends System.MulticastDelegate" />
+  <TypeSignature Language="VB.NET" Value="Public Delegate Sub AsyncCallback(ar As IAsyncResult)" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="ar" Type="System.IAsyncResult" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Void</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <param name="ar">To be added.</param>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/System/Environment+SpecialFolder.xml
+++ b/mdoc/Test/en.expected-vbnet2/System/Environment+SpecialFolder.xml
@@ -1,0 +1,17 @@
+<Type Name="Environment+SpecialFolder" FullName="System.Environment+SpecialFolder">
+  <TypeSignature Language="C#" Value="public enum Environment.SpecialFolder" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed Environment/SpecialFolder extends System.Enum" />
+  <TypeSignature Language="VB.NET" Value="Public Enum Environment.SpecialFolder" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Enum</BaseTypeName>
+  </Base>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members />
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/System/Environment.xml
+++ b/mdoc/Test/en.expected-vbnet2/System/Environment.xml
@@ -1,9 +1,9 @@
-<Type Name="ArrayX10" FullName="MyNamespace.ArrayX10">
-  <TypeSignature Language="C#" Value="public static class ArrayX10" />
-  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit ArrayX10 extends System.Object" />
-  <TypeSignature Language="VB.NET" Value="Public Module ArrayX10" />
+<Type Name="Environment" FullName="System.Environment">
+  <TypeSignature Language="C#" Value="public static class Environment" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit Environment extends System.Object" />
+  <TypeSignature Language="VB.NET" Value="Public Module Environment" />
   <AssemblyInfo>
-    <AssemblyName>DocTest-InternalInterface</AssemblyName>
+    <AssemblyName>DocTest</AssemblyName>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
   </AssemblyInfo>
   <Base>
@@ -15,6 +15,27 @@
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
+    <Member MemberName="GetFolderPath">
+      <MemberSignature Language="C#" Value="public static string GetFolderPath (Environment.SpecialFolder folder);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig string GetFolderPath(valuetype System.Environment/SpecialFolder folder) cil managed" />
+      <MemberSignature Language="VB.NET" Value="Public Function GetFolderPath (folder As Environment.SpecialFolder) As String" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="folder" Type="System.Environment+SpecialFolder" />
+      </Parameters>
+      <Docs>
+        <param name="folder">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="IsAligned&lt;T&gt;">
       <MemberSignature Language="C#" Value="public static bool IsAligned&lt;T&gt; (this T[] vect, int index) where T : struct;" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsAligned&lt;struct .ctor (class System.ValueType) T&gt;(!!T[] vect, int32 index) cil managed" />

--- a/mdoc/Test/en.expected-vbnet2/index.xml
+++ b/mdoc/Test/en.expected-vbnet2/index.xml
@@ -1,0 +1,228 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="DocTest" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="">
+      <Type Name="NoNamespace" Kind="Class" />
+    </Namespace>
+    <Namespace Name="Mono.DocTest">
+      <Type Name="Color" Kind="Enumeration" />
+      <Type Name="D" Kind="Delegate" />
+      <Type Name="DocAttribute" Kind="Class" />
+      <Type Name="DocValueType" Kind="Structure" />
+      <Type Name="IProcess" Kind="Interface" />
+      <Type Name="UseLists" Kind="Class" />
+      <Type Name="Widget" Kind="Class" />
+      <Type Name="Widget+Del" Kind="Delegate" />
+      <Type Name="Widget+Direction" Kind="Enumeration" />
+      <Type Name="Widget+IMenuItem" Kind="Interface" />
+      <Type Name="Widget+NestedClass" Kind="Class" />
+      <Type Name="Widget+NestedClass`1" DisplayName="Widget+NestedClass&lt;T&gt;" Kind="Class" />
+      <Type Name="Widget+NestedClass+Double" Kind="Class" />
+      <Type Name="Widget+NestedClass+Double+Triple" Kind="Class" />
+      <Type Name="Widget+NestedClass+Double+Triple+Quadruple" Kind="Class" />
+    </Namespace>
+    <Namespace Name="Mono.DocTest.Generic">
+      <Type Name="Extensions" Kind="Class" />
+      <Type Name="Func`2" DisplayName="Func&lt;TArg,TRet&gt;" Kind="Delegate" />
+      <Type Name="GenericBase`1" DisplayName="GenericBase&lt;U&gt;" Kind="Class" />
+      <Type Name="GenericBase`1+FooEventArgs" DisplayName="GenericBase&lt;U&gt;+FooEventArgs" Kind="Class" />
+      <Type Name="GenericBase`1+NestedCollection" DisplayName="GenericBase&lt;U&gt;+NestedCollection" Kind="Class" />
+      <Type Name="GenericBase`1+NestedCollection+Enumerator" DisplayName="GenericBase&lt;U&gt;+NestedCollection+Enumerator" Kind="Structure" />
+      <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
+      <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
+      <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
+    </Namespace>
+    <Namespace Name="System">
+      <Type Name="Action`1" DisplayName="Action&lt;T&gt;" Kind="Delegate" />
+      <Type Name="Array" Kind="Class" />
+      <Type Name="AsyncCallback" Kind="Delegate" />
+      <Type Name="Environment" Kind="Class" />
+      <Type Name="Environment+SpecialFolder" Kind="Enumeration" />
+    </Namespace>
+  </Types>
+  <Title>DocTest</Title>
+  <ExtensionMethods>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Mono.DocTest.Generic.IFoo`1" />
+      </Targets>
+      <Member MemberName="Bar&lt;T&gt;">
+        <MemberSignature Language="C#" Value="public static void Bar&lt;T&gt; (this Mono.DocTest.Generic.IFoo&lt;T&gt; self, string s);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Bar&lt;T&gt;(class Mono.DocTest.Generic.IFoo`1&lt;!!T&gt; self, string s) cil managed" />
+        <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Sub Bar(Of T) (self As IFoo(Of T), s As String)" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Void</ReturnType>
+        </ReturnValue>
+        <TypeParameters>
+          <TypeParameter Name="T" />
+        </TypeParameters>
+        <Parameters>
+          <Parameter Name="self" Type="Mono.DocTest.Generic.IFoo&lt;T&gt;" RefType="this" />
+          <Parameter Name="s" Type="System.String" />
+        </Parameters>
+        <Docs>
+          <typeparam name="T">To be added.</typeparam>
+          <param name="self">To be added.</param>
+          <param name="s">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Mono.DocTest.Generic.Extensions" Member="M:Mono.DocTest.Generic.Extensions.Bar``1(Mono.DocTest.Generic.IFoo{``0},System.String)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:System.Collections.Generic.IEnumerable`1" />
+      </Targets>
+      <Member MemberName="ForEach&lt;T&gt;">
+        <MemberSignature Language="C#" Value="public static void ForEach&lt;T&gt; (this System.Collections.Generic.IEnumerable&lt;T&gt; self, Action&lt;T&gt; a);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig void ForEach&lt;T&gt;(class System.Collections.Generic.IEnumerable`1&lt;!!T&gt; self, class System.Action`1&lt;!!T&gt; a) cil managed" />
+        <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Sub ForEach(Of T) (self As IEnumerable(Of T), a As Action(Of T))" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Void</ReturnType>
+        </ReturnValue>
+        <TypeParameters>
+          <TypeParameter Name="T" />
+        </TypeParameters>
+        <Parameters>
+          <Parameter Name="self" Type="System.Collections.Generic.IEnumerable&lt;T&gt;" RefType="this" />
+          <Parameter Name="a" Type="System.Action&lt;T&gt;" />
+        </Parameters>
+        <Docs>
+          <typeparam name="T">To be added.</typeparam>
+          <param name="self">To be added.</param>
+          <param name="a">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Mono.DocTest.Generic.Extensions" Member="M:Mono.DocTest.Generic.Extensions.ForEach``1(System.Collections.Generic.IEnumerable{``0},System.Action{``0})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:System.Collections.Generic.IEnumerable`1" />
+      </Targets>
+      <Member MemberName="ToDouble">
+        <MemberSignature Language="C#" Value="public static System.Collections.Generic.IEnumerable&lt;double&gt; ToDouble (this System.Collections.Generic.IEnumerable&lt;int&gt; list);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.Generic.IEnumerable`1&lt;float64&gt; ToDouble(class System.Collections.Generic.IEnumerable`1&lt;int32&gt; list) cil managed" />
+        <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Function ToDouble (list As IEnumerable(Of Integer)) As IEnumerable(Of Double)" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Double&gt;</ReturnType>
+        </ReturnValue>
+        <Parameters>
+          <Parameter Name="list" Type="System.Collections.Generic.IEnumerable&lt;System.Int32&gt;" RefType="this" />
+        </Parameters>
+        <Docs>
+          <param name="list">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Mono.DocTest.Generic.Extensions" Member="M:Mono.DocTest.Generic.Extensions.ToDouble(System.Collections.Generic.IEnumerable{System.Int32})" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:Mono.DocTest.Generic.IFoo`1" />
+      </Targets>
+      <Member MemberName="ToDouble&lt;T&gt;">
+        <MemberSignature Language="C#" Value="public static double ToDouble&lt;T&gt; (this T val) where T : Mono.DocTest.Generic.IFoo&lt;T&gt;;" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig float64 ToDouble&lt;(class Mono.DocTest.Generic.IFoo`1&lt;!!T&gt;) T&gt;(!!T val) cil managed" />
+        <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Function ToDouble(Of T As IFoo(Of T)) (val As T) As Double" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Double</ReturnType>
+        </ReturnValue>
+        <TypeParameters>
+          <TypeParameter Name="T">
+            <Constraints>
+              <InterfaceName>Mono.DocTest.Generic.IFoo&lt;T&gt;</InterfaceName>
+            </Constraints>
+          </TypeParameter>
+        </TypeParameters>
+        <Parameters>
+          <Parameter Name="val" Type="T" RefType="this" />
+        </Parameters>
+        <Docs>
+          <typeparam name="T">To be added.</typeparam>
+          <param name="val">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Mono.DocTest.Generic.Extensions" Member="M:Mono.DocTest.Generic.Extensions.ToDouble``1(``0)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="System.Object" />
+      </Targets>
+      <Member MemberName="ToEnumerable&lt;T&gt;">
+        <MemberSignature Language="C#" Value="public static System.Collections.Generic.IEnumerable&lt;T&gt; ToEnumerable&lt;T&gt; (this T self);" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig class System.Collections.Generic.IEnumerable`1&lt;!!T&gt; ToEnumerable&lt;T&gt;(!!T self) cil managed" />
+        <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Function ToEnumerable(Of T) (self As T) As IEnumerable(Of T)" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Collections.Generic.IEnumerable&lt;T&gt;</ReturnType>
+        </ReturnValue>
+        <TypeParameters>
+          <TypeParameter Name="T" />
+        </TypeParameters>
+        <Parameters>
+          <Parameter Name="self" Type="T" RefType="this" />
+        </Parameters>
+        <Docs>
+          <typeparam name="T">To be added.</typeparam>
+          <param name="self">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="Mono.DocTest.Generic.Extensions" Member="M:Mono.DocTest.Generic.Extensions.ToEnumerable``1(``0)" />
+      </Member>
+    </ExtensionMethod>
+    <ExtensionMethod>
+      <Targets>
+        <Target Type="T:System.Array" />
+      </Targets>
+      <Member MemberName="IsAligned&lt;T&gt;">
+        <MemberSignature Language="C#" Value="public static bool IsAligned&lt;T&gt; (this T[] vect, int index) where T : struct;" />
+        <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool IsAligned&lt;struct .ctor (class System.ValueType) T&gt;(!!T[] vect, int32 index) cil managed" />
+        <MemberSignature Language="VB.NET" Value="&lt;Extension()&gt;&#xA;Public Function IsAligned(Of T As Structure) (vect As T(), index As Integer) As Boolean" />
+        <MemberType>ExtensionMethod</MemberType>
+        <ReturnValue>
+          <ReturnType>System.Boolean</ReturnType>
+        </ReturnValue>
+        <TypeParameters>
+          <TypeParameter Name="T">
+            <Constraints>
+              <ParameterAttribute>DefaultConstructorConstraint</ParameterAttribute>
+              <ParameterAttribute>NotNullableValueTypeConstraint</ParameterAttribute>
+              <BaseTypeName>System.ValueType</BaseTypeName>
+            </Constraints>
+          </TypeParameter>
+        </TypeParameters>
+        <Parameters>
+          <Parameter Name="vect" Type="T[]" RefType="this" />
+          <Parameter Name="index" Type="System.Int32" />
+        </Parameters>
+        <Docs>
+          <typeparam name="T">To be added.</typeparam>
+          <param name="vect">To be added.</param>
+          <param name="index">To be added.</param>
+          <summary>To be added.</summary>
+        </Docs>
+        <Link Type="System.Environment" Member="M:System.Environment.IsAligned``1(``0[],System.Int32)" />
+      </Member>
+    </ExtensionMethod>
+  </ExtensionMethods>
+</Overview>

--- a/mdoc/Test/en.expected-vbnet2/ns-.xml
+++ b/mdoc/Test/en.expected-vbnet2/ns-.xml
@@ -1,0 +1,6 @@
+<Namespace Name="">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-vbnet2/ns-Mono.DocTest.Generic.xml
+++ b/mdoc/Test/en.expected-vbnet2/ns-Mono.DocTest.Generic.xml
@@ -1,0 +1,6 @@
+<Namespace Name="Mono.DocTest.Generic">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-vbnet2/ns-Mono.DocTest.xml
+++ b/mdoc/Test/en.expected-vbnet2/ns-Mono.DocTest.xml
@@ -1,0 +1,6 @@
+<Namespace Name="Mono.DocTest">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-vbnet2/ns-System.xml
+++ b/mdoc/Test/en.expected-vbnet2/ns-System.xml
@@ -1,0 +1,6 @@
+<Namespace Name="System">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -25,7 +25,9 @@ namespace mdoc.Test
                 new CSharpFullMemberFormatter (),
                 new CSharpMemberFormatter(),
                 new ILMemberFormatter(),
-                new ILFullMemberFormatter()
+                new ILFullMemberFormatter(),
+                new VBFullMemberFormatter (),
+                new VBMemberFormatter(),
             };
             var sigs = formatters.Select (f => f.GetDeclaration (method));
 

--- a/mdoc/mdoc.Test/VBFormatterTests.cs
+++ b/mdoc/mdoc.Test/VBFormatterTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Linq;
+using mdoc.Test.SampleClasses;
+using Mono.Cecil;
+using Mono.Documentation.Updater;
+using NUnit.Framework;
+
+namespace mdoc.Test
+{
+    [TestFixture()]
+    public class VBFormatterTests
+    {
+        [Test]
+        public void VB_op_Addition() =>
+            TestBinaryOp("Addition", "+");
+
+        [Test]
+        public void VB_op_Subtraction() =>
+            TestBinaryOp("Subtraction", "-");
+
+        [Test]
+        public void VB_op_Division() =>
+            TestBinaryOp("Division", "/");
+        
+        [Test]
+        public void VB_op_Multiplication() =>
+            TestBinaryOp("Multiply", "*");
+
+        [Test]
+        public void VB_op_Modulus() =>
+            TestBinaryOp("Modulus", "Mod");
+
+        [Test]
+        public void VB_op_BitwiseAnd() =>
+            TestBinaryOp("BitwiseAnd", "And");
+
+        [Test]
+        public void VB_op_BitwiseOr() =>
+            TestBinaryOp("BitwiseOr", "Or");
+
+        [Test]
+        public void VB_op_ExclusiveOr() =>
+            TestBinaryOp("ExclusiveOr", "Xor");
+
+        [Test]
+        public void VB_op_LeftShift() =>
+            TestBinaryOp("LeftShift", "<<", secondType: "Integer");
+
+        [Test]
+        public void VB_op_RightShift() =>
+            TestBinaryOp("RightShift", ">>", secondType: "Integer");
+
+        [Test]
+        public void VB_op_UnaryPlus() =>
+            TestUnaryOp("UnaryPlus", "+");
+
+        [Test]
+        public void VB_op_UnaryNegation() =>
+            TestUnaryOp("UnaryNegation", "-");
+
+        [Test]
+        public void VB_op_LogicalNot() =>
+            TestUnaryOp("LogicalNot", "Not");
+
+        [Test]
+        public void VB_op_OnesComplement() =>
+            TestUnaryOp("OnesComplement", "Not");
+        
+        [Test]
+        public void VB_op_True() =>
+            TestUnaryOp("True", "IsTrue", returnType: "Boolean");
+
+        [Test]
+        public void VB_op_False() =>
+            TestUnaryOp("False", "IsFalse", returnType: "Boolean");
+
+        [Test]
+        public void VB_op_Equality() =>
+            TestComparisonOp("Equality", "==");
+
+        [Test]
+        public void VB_op_Inequality() =>
+            TestComparisonOp("Inequality", "!=");
+
+        [Test]
+        public void VB_op_LessThan() =>
+            TestComparisonOp("LessThan", "<");
+
+        [Test]
+        public void VB_op_GreaterThan() =>
+            TestComparisonOp("GreaterThan", ">");
+
+        [Test]
+        public void VB_op_LessThanOrEqual() =>
+            TestComparisonOp("LessThanOrEqual", "<=");
+
+        [Test]
+        public void VB_op_GreaterThanOrEqual() =>
+            TestComparisonOp("GreaterThanOrEqual", ">=");
+
+        [Test]
+        public void VB_op_Implicit() =>
+            TestConversionOp("Implicit", "Widening", "TestClass", "TestClassTwo");
+
+        [Test]
+        public void VB_op_Implicit_inverse() =>
+            TestConversionOp("Implicit", "Widening", "TestClassTwo", "TestClass");
+
+        [Test]
+        public void VB_op_Explicit() =>
+            TestConversionOp("Explicit", "Narrowing", "Integer", "TestClass");
+
+        [Test]
+        public void VB_op_Explicit_inverse() =>
+            TestConversionOp("Explicit", "Narrowing", "TestClass", "Integer");
+        
+        
+        [Test]
+        public void Params()
+        {
+            var member = GetMethod<TestClass>(m => m.Name == "DoSomethingWithParams");
+            var formatter = new VBMemberFormatter();
+            var sig = formatter.GetDeclaration(member);
+            Assert.AreEqual("Public Sub DoSomethingWithParams (ParamArray values As Integer())", sig);
+        }
+
+        #region Helper Methods
+        string RealTypeName(string name)
+        {
+            switch (name)
+            {
+                case "Integer": return "Int32";
+                default: return name;
+            }
+        }
+
+        void TestConversionOp(string name, string type, string leftType, string rightType)
+        {
+            TestOp(name, $"Public Shared {type} Operator CType (c1 As {rightType}) As {leftType}", argCount: 1, returnType: leftType);
+        }
+
+        void TestComparisonOp(string name, string op)
+        {
+            TestOp(name, $"Public Shared Operator {op} (c1 As TestClass, c2 As TestClass) As Boolean", argCount: 2, returnType: "Boolean");
+        }
+
+        void TestUnaryOp(string name, string op, string returnType = "TestClass")
+        {
+            TestOp(name, $"Public Shared Operator {op} (c1 As TestClass) As {returnType}", argCount: 1, returnType: returnType);
+        }
+
+        void TestBinaryOp(string name, string op, string returnType = "TestClass", string secondType = "TestClass")
+        {
+            TestOp(name, $"Public Shared Operator {op} (c1 As TestClass, c2 As {secondType}) As {returnType}", argCount: 2, returnType: returnType);
+        }
+
+        void TestOp(string name, string expectedSig, int argCount, string returnType = "TestClass")
+        {
+            var member = GetMethod<TestClass>(m => m.Name == $"op_{name}" && m.Parameters.Count == argCount && m.ReturnType.Name == RealTypeName(returnType));
+            var formatter = new VBMemberFormatter();
+            var sig = formatter.GetDeclaration(member);
+            Assert.AreEqual(expectedSig, sig);
+        }
+
+        MethodDefinition GetMethod<T>(Func<MethodDefinition, bool> query)
+        {
+            var type = typeof(T);
+            var moduleName = type.Module.FullyQualifiedName;
+            return GetMethod(GetType(moduleName, type.FullName), query);
+        }
+
+        MethodDefinition GetMethod(TypeDefinition testclass, Func<MethodDefinition, bool> query)
+        {
+            var methods = testclass.Methods;
+            var member = methods.FirstOrDefault(query).Resolve();
+            if (member == null)
+                throw new Exception("Did not find the member in the test class");
+            return member;
+        }
+
+        TypeDefinition GetType(string filepath, string classname)
+        {
+            var module = ModuleDefinition.ReadModule(filepath);
+            var types = module.GetTypes();
+            var testclass = types
+                .SingleOrDefault(t => t.FullName == classname);
+            if (testclass == null)
+            {
+                throw new Exception($"Test was unable to find type {classname}");
+            }
+            return testclass.Resolve();
+        }
+        #endregion
+    }
+}

--- a/mdoc/mdoc.Test/mdoc.Test.csproj
+++ b/mdoc/mdoc.Test/mdoc.Test.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -29,7 +29,7 @@
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+        <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Mono.Cecil.0.10.0-beta5\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
@@ -47,7 +47,7 @@
     <Compile Include="SampleClasses\TestClass.cs" />
     <Compile Include="SampleClasses\TestPrivateClass.cs" />
     <Compile Include="SampleClasses\TestClassTwo.cs" />
-    <Compile Include="StatisticsTests.cs" />
+    <Compile Include="VBFormatterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/mdoc/mdoc.csproj
+++ b/mdoc/mdoc.csproj
@@ -55,6 +55,8 @@
     <Compile Include="Mono.Documentation\Updater\Formatters\StandardFlagsEnumFormatter.cs" />
     <Compile Include="Mono.Documentation\Updater\Formatters\DefaultAttributeValueFormatter.cs" />
     <Compile Include="Mono.Documentation\Updater\Formatters\AttributeValueFormatter.cs" />
+    <Compile Include="Mono.Documentation\Updater\Formatters\VBFullMemberFormatter.cs" />
+    <Compile Include="Mono.Documentation\Updater\Formatters\VBMemberFormatter.cs" />
     <Compile Include="Mono.Documentation\Updater\ResolvedTypeInfo.cs" />
     <Compile Include="Mono.Documentation\Updater\Formatters\FileNameMemberFormatter.cs" />
     <Compile Include="Mono.Documentation\Updater\Formatters\SlashDocMemberFormatter.cs" />


### PR DESCRIPTION
Added VBFullMemberFormatter and VBMemberFormatter.
Support for -lang CLI parameter (vb.net, docid are available now).
IsSupported virtual methods for TypeReference and MemberReference in MemberFormatter. If they return false, sygnature is not added to XML file.
Closes #131