### PR TITLE
mdoc: Preserving remarks created post-factum on import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ obj
 *.metagen
 *.pdb
 mdoc/Test/actual_statistics.txt
+mdoc/Test/test-overwrite-attribute/SomeClass.xml
+mdoc/Test/test-overwrite-attribute/SomeClass.dll

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -490,7 +490,14 @@ check-mdoc-validate:
 	$(MONO) $(PROGRAM) validate -f ecma Test/en.expected.since 2>&1 | \
 		sed 's#file://$(my_abs_top_srcdir)/##g' | \
 		$(DIFF_QUIET) - Test/validate.check.monodocer.since
-
+		
+check-overwrite-attribute: 
+	rm -Rf Test/en.actual
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -target:library Test/test-overwrite-attribute/SomeClass.cs -doc:Test/test-overwrite-attribute/SomeClass.xml
+	$(MONO) $(PROGRAM) update Test/test-overwrite-attribute/Someclass.dll -o Test/en.actual/ -import Test/test-overwrite-attribute/SomeClass.xml
+	cp Test/test-overwrite-attribute/Input_SomeClass.xml Test/en.actual/SomeClass.xml
+	$(MONO) $(PROGRAM) update Test/test-overwrite-attribute/SomeClass.dll -o Test/en.actual/ -import Test/test-overwrite-attribute/SomeClass.xml
+	$(DIFF) Test/test-overwrite-attribute/Expected_SomeClass.xml Test/en.actual/SomeClass.xml
 run-test-local: check-doc-tools
 
 run-test-update : check-doc-tools-update
@@ -520,7 +527,8 @@ check-doc-tools: check-monodocer-since \
 	check-monodocer-frameworks-inheritance \
 	check-monodocer-docid \
 	check-monodocer-operators \
-	check-monodocer-fx-statistics-remove
+	check-monodocer-fx-statistics-remove \
+	check-overwrite-attribute
 
 check-doc-tools-update: check-monodocer-since-update \
 	check-monodocer-importecmadoc-update \

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -2541,8 +2541,10 @@ namespace Mono.Documentation
             }
             else
             {
-                ClearElement (e, "returns");
-                ClearElement (e, "value");
+                if (DocUtils.NeedsOverwrite(e["returns"]))
+                    ClearElement(e, "returns");
+                if (DocUtils.NeedsOverwrite(e["value"]))
+                    ClearElement(e, "value");
             }
 
             if (addremarks)

--- a/mdoc/Mono.Documentation/Updater/DocUtils.cs
+++ b/mdoc/Mono.Documentation/Updater/DocUtils.cs
@@ -200,6 +200,13 @@ namespace Mono.Documentation.Updater
                     baseRef.FullName == "System.MulticastDelegate";
         }
 
+        public static bool NeedsOverwrite(XmlElement element)
+        {
+            return element != null &&
+                   !(element.HasAttribute("overwrite") &&
+                    element.Attributes["overwrite"].Value.Equals("false", StringComparison.InvariantCultureIgnoreCase));
+        }
+
         public static List<TypeReference> GetDeclaringTypes (TypeReference type)
         {
             List<TypeReference> decls = new List<TypeReference> ();

--- a/mdoc/Resources/monodoc-ecma.xsd
+++ b/mdoc/Resources/monodoc-ecma.xsd
@@ -48,6 +48,7 @@ add masterdoc support?
   <xs:attribute name="type" type="xs:string" />
   <xs:attribute name="Type" type="xs:string" />
   <xs:attribute name="TypeParamName" type="xs:string" />
+  <xs:attribute name="overwrite" type ="xs:boolean" />
 
   <!-- define simple elements -->
   <xs:element name="AssemblyName" type="xs:string" />
@@ -346,6 +347,7 @@ add masterdoc support?
         <xs:element ref="typeparamref" />
       </xs:choice>
       <xs:attribute ref="cref" />
+      <xs:attribute ref="overwrite" />
     </xs:complexType>
   </xs:element>
 
@@ -587,6 +589,7 @@ add masterdoc support?
       </xs:choice>
       <xs:attribute ref="preserve-mono" />
       <xs:attribute ref="name" use="required" />
+      <xs:attribute ref="overwrite" />
     </xs:complexType>
   </xs:element>
 
@@ -626,6 +629,7 @@ add masterdoc support?
         <xs:element ref="typeparamref" />
       </xs:choice>
       <xs:attribute ref="cref" />
+      <xs:attribute ref="overwrite" />
     </xs:complexType>
   </xs:element>
 
@@ -657,6 +661,7 @@ add masterdoc support?
         <xs:element ref="attribution" />
       </xs:choice>
       <xs:attribute ref="preserve-mono" />
+      <xs:attribute ref="overwrite" />
     </xs:complexType>
   </xs:element>
 
@@ -687,6 +692,7 @@ add masterdoc support?
         <xs:element ref="attribution" />
       </xs:choice>
       <xs:attribute ref="preserve-mono" />
+      <xs:attribute ref="overwrite" />
     </xs:complexType>
   </xs:element>
 
@@ -779,6 +785,7 @@ add masterdoc support?
         <xs:element ref="attribution" />
       </xs:choice>
       <xs:attribute ref="preserve-mono" />
+      <xs:attribute ref="overwrite" />
     </xs:complexType>
   </xs:element>
 
@@ -891,6 +898,7 @@ add masterdoc support?
         <xs:element ref="typeparamref" />
       </xs:choice>
       <xs:attribute ref="name" use="required" />
+      <xs:attribute ref="overwrite" />
     </xs:complexType>
   </xs:element>
 
@@ -957,6 +965,7 @@ add masterdoc support?
         <xs:element ref="example" />
         <xs:element ref="list" />
       </xs:choice>
+      <xs:attribute ref="overwrite" />
     </xs:complexType>
   </xs:element>
 

--- a/mdoc/Test/test-overwrite-attribute/Expected_SomeClass.xml
+++ b/mdoc/Test/test-overwrite-attribute/Expected_SomeClass.xml
@@ -1,0 +1,86 @@
+<Type Name="SomeClass" FullName="SomeClass">
+  <TypeSignature Language="C#" Value="public class SomeClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit SomeClass extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>SomeClass</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary overwrite="false">Preserved summary</summary>
+    <remarks>New remark</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public SomeClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DoSomething">
+      <MemberSignature Language="C#" Value="public void DoSomething ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void DoSomething() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>New Returns something</returns>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.Exception">New exception</exception>
+      </Docs>
+    </Member>
+    <Member MemberName="SomeMethod">
+      <MemberSignature Language="C#" Value="public void SomeMethod (int a, int b);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void SomeMethod(int32 a, int32 b) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="System.Int32" />
+        <Parameter Name="b" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="a" overwrite="false">Preserved First Parameter</param>
+        <param name="b">New Second Parameter</param>
+        <summary>New summary</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SomeProperty">
+      <MemberSignature Language="C#" Value="public string SomeProperty { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string SomeProperty" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value overwrite="false">Preserved Value for Property</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/test-overwrite-attribute/Input_SomeClass.xml
+++ b/mdoc/Test/test-overwrite-attribute/Input_SomeClass.xml
@@ -1,0 +1,86 @@
+<Type Name="SomeClass" FullName="SomeClass">
+  <TypeSignature Language="C#" Value="public class SomeClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit SomeClass extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>SomeClass</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary overwrite="false">Preserved summary</summary>
+    <remarks>Old remark</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public SomeClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DoSomething">
+      <MemberSignature Language="C#" Value="public void DoSomething ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void DoSomething() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <returns>Old Returns something</returns>
+        <remarks>To be added.</remarks>
+        <exception cref="T:System.Exception">Old exception</exception>
+      </Docs>
+    </Member>
+    <Member MemberName="SomeMethod">
+      <MemberSignature Language="C#" Value="public void SomeMethod (int a, int b);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void SomeMethod(int32 a, int32 b) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="a" Type="System.Int32" />
+        <Parameter Name="b" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="a" overwrite="false">Preserved First Parameter</param>
+        <param name="b" overwrite="AnyOtherValue">Old Second Parameter</param>
+        <summary>Old summary</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SomeProperty">
+      <MemberSignature Language="C#" Value="public string SomeProperty { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property instance string SomeProperty" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.String</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value overwrite="false">Preserved Value for Property</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/test-overwrite-attribute/SomeClass.cs
+++ b/mdoc/Test/test-overwrite-attribute/SomeClass.cs
@@ -1,0 +1,20 @@
+﻿///<summary>Ignored summary</summary>
+///<remarks>New remark</remarks>
+public class SomeClass
+{
+	///<summary>New summary</summary>
+	///<param name="a">Ignored First Parameter</param>  
+	///<param name="b">New Second Parameter</param>
+	public void SomeMethod(int a, int b)
+	{
+
+	}
+	/// <exception cref="System.Exception">New exception</exception>
+	/// <returns>New Returns something</returns>
+	public void DoSomething()
+	{
+
+	}
+	/// <value>Ignored Value for Property</value>
+	public string SomeProperty { get; set; }
+}


### PR DESCRIPTION
Added attribute "overwrite" for the following elements: remarks, summary, value, returns, param, typeparam, altmember, exception, permission
Closes #97