### PR TITLE
mdoc: updates for WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,18 @@ If you want to compile in debug mode: `make all CONFIGURATION=Debug`
 
 ### WSL
 
-On the windows subsystem for linux, there is unfortunately a defect that causes difficulty making https calls, which in turn doesn't allow the `prepare` make target to complete (nuget fails). You will see an error that says:
+Make sure you are at least on 16.04 (Xenial). You can check which version is currently installed by running the command `lsb_release -a`.
 
-```
-Unable to load the service index for source https://api.nuget.org/v3/index.json.
-  An error occurred while sending the request
-  Error: ConnectFailure (Value does not fall within the expected range.)
-  Value does not fall within the expected range.
-```
+If you are running an older version (for example, if you originally installed WSL before the creator's update) and need to upgrade, you can run the following commands:
 
-[this mono issue](https://github.com/mono/mono/pull/5003) Seems to indicate that the issue is resolved in newer insider builds of WSL.
+- `sudo do-release-upgrade` ... this updates the version of Ubuntu. _Please note_, this will likely disable any external package sources, such as the one added when installing Mono.
+- Once you're done with that, then you just need to update `apt-get`
+    - Add back Mono's package repository source, as described in [the download instructions](www.mono-project.com/download/#download-lin-ubuntu).
+    - `sudo apt-get update`
+    - `sudo apt-get upgrade`
+    - `sudo apt-get dist-upgrade`
+
+With that run ... you should be able to run the build locally.
 
 ### Linux
 

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -389,9 +389,11 @@ check-monodocer-fx-statistics-remove:
 	mkdir Test/fx-import
 	mkdir Test/fx-import/one
 	cp Test/fx-statistics-remove-configuration.xml Test/fx-import/frameworks.xml
+	rm -Rf Test/DocTest-DropNS-unified-deletetest.dll
 	$(MAKE) Test/DocTest-DropNS-unified-deletetest.dll
 	cp Test/DocTest-DropNS-unified-deletetest.dll Test/fx-import/one/DocTest.dll
 	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/fx-import
+	rm -Rf Test/DocTest-DropNS-unified.dll
 	$(MAKE) Test/DocTest-DropNS-unified.dll
 	rm -rf Test/fx-import/one/DocTest.dll
 	cp Test/DocTest-DropNS-unified.dll Test/fx-import/one/DocTest.dll

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -381,7 +381,7 @@ check-monodocer-import-fx-work: Test/DocTest.dll-v1 Test/DocTest-DropNS-classic-
 	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/fx-import -statistics Test/actual_statistics.txt
 	$(DIFF) Test/expected_statistics.txt Test/actual_statistics.txt
 	
-	
+.PHONY: check-monodocer-fx-statistics-remove	
 check-monodocer-fx-statistics-remove:
 	rm -Rf Test/en.actual
 	rm -Rf Test/fx-import
@@ -494,7 +494,7 @@ check-mdoc-validate:
 check-overwrite-attribute: 
 	rm -Rf Test/en.actual
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -target:library Test/test-overwrite-attribute/SomeClass.cs -doc:Test/test-overwrite-attribute/SomeClass.xml
-	$(MONO) $(PROGRAM) update Test/test-overwrite-attribute/Someclass.dll -o Test/en.actual/ -import Test/test-overwrite-attribute/SomeClass.xml
+	$(MONO) $(PROGRAM) update Test/test-overwrite-attribute/SomeClass.dll -o Test/en.actual/ -import Test/test-overwrite-attribute/SomeClass.xml
 	cp Test/test-overwrite-attribute/Input_SomeClass.xml Test/en.actual/SomeClass.xml
 	$(MONO) $(PROGRAM) update Test/test-overwrite-attribute/SomeClass.dll -o Test/en.actual/ -import Test/test-overwrite-attribute/SomeClass.xml
 	$(DIFF) Test/test-overwrite-attribute/Expected_SomeClass.xml Test/en.actual/SomeClass.xml

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -238,7 +238,7 @@ namespace Mono.Documentation
                     configPath = Path.Combine (configPath, "frameworks.xml");
                 else
                     frameworksDir = Path.GetDirectoryName (configPath);
-
+                Console.WriteLine($"Opening frameworks file '{configPath}'");
                 var fxconfig = XDocument.Load (configPath);
                 var fxd = fxconfig.Root
                                   .Elements ("Framework")
@@ -281,6 +281,7 @@ namespace Mono.Documentation
                 ));
                 this.assemblies.AddRange (sets);
                 assemblyPaths.AddRange (sets.SelectMany (s => s.AssemblyPaths));
+                Console.WriteLine($"Frameworks Configuration contains {assemblyPaths.Count} assemblies");
 
                 // Create a cache of all frameworks, so we can look up 
                 // members that may exist only other frameworks before deleting them

--- a/mdoc/Test/expected_fx_remove_statistics.txt
+++ b/mdoc/Test/expected_fx_remove_statistics.txt
@@ -1,7 +1,7 @@
-Framework: One
+Framework: one
 --------
 Types Added: 0
-Types Removed: 1
+Types Removed: 2
 Types Total: 2
 
 Namespaces Added: 0

--- a/mdoc/Test/fx-statistics-remove-configuration.xml
+++ b/mdoc/Test/fx-statistics-remove-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Frameworks>
-  <Framework Name="One" Source="One">
-    <assemblySearchPath>One</assemblySearchPath>
+  <Framework Name="One" Source="one">
+    <assemblySearchPath>one</assemblySearchPath>
   </Framework>
 </Frameworks>


### PR DESCRIPTION
With these changes, you can now run the make build on windows, via WSL. I've made some small changes to the tests to account for path case sensitivity, updated the README with information on upgrading to the latest version of WSL, and lastly, just added some additional informative output to help in troubleshooting the loading of frameworks.