### PR TITLE
mdoc: fixed incorrect analytics test.

### DIFF
--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -389,9 +389,11 @@ check-monodocer-fx-statistics-remove:
 	mkdir Test/fx-import
 	mkdir Test/fx-import/one
 	cp Test/fx-statistics-remove-configuration.xml Test/fx-import/frameworks.xml
+	rm -Rf Test/DocTest-DropNS-unified-deletetest.dll
 	$(MAKE) Test/DocTest-DropNS-unified-deletetest.dll
 	cp Test/DocTest-DropNS-unified-deletetest.dll Test/fx-import/one/DocTest.dll
 	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/fx-import
+	rm -Rf Test/DocTest-DropNS-unified.dll
 	$(MAKE) Test/DocTest-DropNS-unified.dll
 	rm -rf Test/fx-import/one/DocTest.dll
 	cp Test/DocTest-DropNS-unified.dll Test/fx-import/one/DocTest.dll

--- a/mdoc/Test/expected_fx_remove_statistics.txt
+++ b/mdoc/Test/expected_fx_remove_statistics.txt
@@ -1,7 +1,7 @@
 Framework: One
 --------
 Types Added: 0
-Types Removed: 1
+Types Removed: 2
 Types Total: 2
 
 Namespaces Added: 0


### PR DESCRIPTION
Changed expected results expected_fx_remove_statistics.txt.
Addeded removing dll files before build them in check-monodocer-fx-statistics-remove test. Earlier it didn't refresh the dll: `make[2]: 'Test/DocTest-DropNS-unified-deletetest.dll' is up to date.`
That's why the test worked with the version compiled with /define:V2 flag. There was one type less on start:
```
 #if DELETETEST && !V2
 public class WillDelete {
  public string Name {get;set;}
 }
 #endif
```