### PR TITLE
mdoc: C# interface event signature no longer prints modifier.

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -619,6 +619,8 @@ namespace Mono.Documentation.Updater
             {
                 return null;
             }
+            if (e.DeclaringType.IsInterface)
+                buf.Clear ();
 
             AppendModifiers (buf, e.AddMethod);
 

--- a/mdoc/Test/en.expected-internal-interface/MyNamespace/MyPublicInterface.xml
+++ b/mdoc/Test/en.expected-internal-interface/MyNamespace/MyPublicInterface.xml
@@ -13,7 +13,7 @@
   </Docs>
   <Members>
     <Member MemberName="PublicEvent">
-      <MemberSignature Language="C#" Value="public event EventHandler&lt;string&gt; PublicEvent;" />
+      <MemberSignature Language="C#" Value="event EventHandler&lt;string&gt; PublicEvent;" />
       <MemberSignature Language="ILAsm" Value=".event class System.EventHandler`1&lt;string&gt; PublicEvent" />
       <MemberSignature Language="VB.NET" Value="Event PublicEvent As EventHandler(Of String) " />
       <MemberType>Event</MemberType>


### PR DESCRIPTION
special thanks to @mpMelnikov for [noticing this](https://github.com/mono/api-doc-tools/pull/142#issuecomment-340477080)