### PR TITLE
mdoc: importer can now handle xml comments.

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.3.0.0";
+		public static string MonoVersion = "5.3.1.0";
 		public const string DocId = "DocId";
 		public const string VbNet = "VB.NET";
 		public const string DocIdLowCase = "docid";

--- a/mdoc/Mono.Documentation/Updater/MsxdocDocumentationImporter.cs
+++ b/mdoc/Mono.Documentation/Updater/MsxdocDocumentationImporter.cs
@@ -125,14 +125,18 @@ namespace Mono.Documentation.Updater
                         }
                     default:
                         {
-                            bool add = true;
-                            if (child.NodeType == XmlNodeType.Element &&
-                                e.SelectNodes (child.Name).Cast<XmlElement> ().Any (n => n.OuterXml == child.OuterXml))
-                                add = false;
-                            if (add)
+                            var targetNodes = e.ChildNodes.Cast<XmlNode> ()
+                                .Where (n => n.Name == child.Name)
+                                .Select (n => new
+                                {
+                                    Xml = n.OuterXml,
+                                    Overwrite = n.Attributes["overwrite"]
+                                });
+                            string sourceXml = child.OuterXml;
+
+                            if (!targetNodes.Any (n => sourceXml.Equals (n.Xml) || n.Overwrite?.Value == "false"))
                             {
-                                if (child.NodeType == XmlNodeType.Text || e.SelectSingleNode(child.Name) == null)
-                                    MDocUpdater.CopyNode(child, e);
+                                MDocUpdater.CopyNode(child, e);
                             }
                             break;
                         }

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.3.0.0</version>
+    <version>5.3.1.0</version>
     <title>mdoc</title>
     <authors>Joel Martinez</authors>
     <owners>Xamarin</owners>


### PR DESCRIPTION
Bump to v5.3.1. Closes #159 and Closes #97.