### PR TITLE
mdoc: C# formatter is not outputting "protected internal"

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -204,8 +204,10 @@ namespace Mono.Documentation.Updater
                     return "public";
 
                 case TypeAttributes.NestedFamily:
-                case TypeAttributes.NestedFamORAssem:
                     return "protected";
+
+                case TypeAttributes.NestedFamORAssem:
+                    return "protected internal";
 
                 default:
                     return null;
@@ -385,8 +387,10 @@ namespace Mono.Documentation.Updater
                 return buf;
             if (method.IsPublic)
                 return buf.Append ("public");
-            if (method.IsFamily || method.IsFamilyOrAssembly)
+            if (method.IsFamily)
                 return buf.Append ("protected");
+            if (method.IsFamilyOrAssembly)
+                return buf.Append("protected internal");
             return buf;
         }
 
@@ -605,9 +609,13 @@ namespace Mono.Documentation.Updater
                 buf.Append("public");
                 return;
             }
-            if (field.IsFamily || field.IsFamilyOrAssembly)
+            if (field.IsFamily) 
             {
                 buf.Append("protected");
+            }
+            if ( field.IsFamilyOrAssembly)
+            {
+                buf.Append("protected internal");
             }
         }
 

--- a/mdoc/Mono.Documentation/Updater/Formatters/VBFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/VBFullMemberFormatter.cs
@@ -195,8 +195,9 @@ namespace Mono.Documentation.Updater
                     return "Public";
 
                 case TypeAttributes.NestedFamily:
-                case TypeAttributes.NestedFamORAssem:
                     return "Protected";
+                case TypeAttributes.NestedFamORAssem:
+                    return "Protected Friend";
 
                 default:
                     return null;
@@ -463,8 +464,10 @@ namespace Mono.Documentation.Updater
                 return buf;
             if (method.IsPublic)
                 return buf.Append("Public");
-            if (method.IsFamily || method.IsFamilyOrAssembly)
+            if (method.IsFamily)
                 return buf.Append("Protected");
+            if (method.IsFamilyOrAssembly)
+                return buf.Append("Protected Friend");
             return buf;
         }
 
@@ -691,9 +694,13 @@ namespace Mono.Documentation.Updater
                 buf.Append("Public");
                 return;
             }
-            if (field.IsFamily || field.IsFamilyOrAssembly)
+            if (field.IsFamily)
             {
                 buf.Append("Protected");
+            }
+            if (field.IsFamilyOrAssembly)
+            {
+                buf.Append("Protected Friend");
             }
         }
 

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
@@ -1,5 +1,5 @@
 <Type Name="GenericBase&lt;U&gt;+NestedCollection+Enumerator" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator">
-  <TypeSignature Language="C#" Value="protected struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
+  <TypeSignature Language="C#" Value="protected internal struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
   <TypeSignature Language="ILAsm" Value=".class nested protected sequential ansi sealed beforefieldinit GenericBase`1/NestedCollection/Enumerator&lt;U&gt; extends System.ValueType" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+Direction.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+Direction.xml
@@ -1,5 +1,5 @@
 <Type Name="Widget+Direction" FullName="Mono.DocTest.Widget+Direction">
-  <TypeSignature Language="C#" Value="protected enum Widget.Direction" />
+  <TypeSignature Language="C#" Value="protected internal enum Widget.Direction" />
   <TypeSignature Language="ILAsm" Value=".class nested protected auto ansi sealed Widget/Direction extends System.Enum" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget.xml
@@ -723,7 +723,7 @@
       </Docs>
     </Member>
     <Member MemberName="monthlyAverage">
-      <MemberSignature Language="C#" Value="protected readonly double monthlyAverage;" />
+      <MemberSignature Language="C#" Value="protected internal readonly double monthlyAverage;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly initonly float64 monthlyAverage" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
@@ -867,7 +867,7 @@
       </Docs>
     </Member>
     <Member MemberName="PI">
-      <MemberSignature Language="C#" Value="protected const double PI = 3.14159;" />
+      <MemberSignature Language="C#" Value="protected internal const double PI = 3.14159;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly static literal float64 PI = (3.14159)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
@@ -931,7 +931,7 @@
       </Docs>
     </Member>
     <Member MemberName="X">
-      <MemberSignature Language="C#" Value="protected short X { set; }" />
+      <MemberSignature Language="C#" Value="protected internal short X { set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance int16 X" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
@@ -949,7 +949,7 @@
       </Docs>
     </Member>
     <Member MemberName="Y">
-      <MemberSignature Language="C#" Value="protected double Y { get; set; }" />
+      <MemberSignature Language="C#" Value="protected internal double Y { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance float64 Y" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
@@ -1,7 +1,7 @@
 <Type Name="GenericBase&lt;U&gt;+NestedCollection+Enumerator" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator">
-  <TypeSignature Language="C#" Value="protected struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
+  <TypeSignature Language="C#" Value="protected internal struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
   <TypeSignature Language="ILAsm" Value=".class nested protected sequential ansi sealed beforefieldinit GenericBase`1/NestedCollection/Enumerator&lt;U&gt; extends System.ValueType" />
-  <TypeSignature Language="VB.NET" Value="Protected Structure GenericBase(Of U).NestedCollection.Enumerator" />
+  <TypeSignature Language="VB.NET" Value="Protected Friend Structure GenericBase(Of U).NestedCollection.Enumerator" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+Direction.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget+Direction.xml
@@ -1,7 +1,7 @@
 <Type Name="Widget+Direction" FullName="Mono.DocTest.Widget+Direction">
-  <TypeSignature Language="C#" Value="protected enum Widget.Direction" />
+  <TypeSignature Language="C#" Value="protected internal enum Widget.Direction" />
   <TypeSignature Language="ILAsm" Value=".class nested protected auto ansi sealed Widget/Direction extends System.Enum" />
-  <TypeSignature Language="VB.NET" Value="Protected Enum Widget.Direction" />
+  <TypeSignature Language="VB.NET" Value="Protected Friend Enum Widget.Direction" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest/Widget.xml
@@ -670,9 +670,9 @@
       </Docs>
     </Member>
     <Member MemberName="monthlyAverage">
-      <MemberSignature Language="C#" Value="protected readonly double monthlyAverage;" />
+      <MemberSignature Language="C#" Value="protected internal readonly double monthlyAverage;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly initonly float64 monthlyAverage" />
-      <MemberSignature Language="VB.NET" Value="Protected ReadOnly monthlyAverage As Double " />
+      <MemberSignature Language="VB.NET" Value="Protected Friend ReadOnly monthlyAverage As Double " />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -803,9 +803,9 @@
       </Docs>
     </Member>
     <Member MemberName="PI">
-      <MemberSignature Language="C#" Value="protected const double PI = 3.14159;" />
+      <MemberSignature Language="C#" Value="protected internal const double PI = 3.14159;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly static literal float64 PI = (3.14159)" />
-      <MemberSignature Language="VB.NET" Value="Protected Const PI As Double  = 3.14159" />
+      <MemberSignature Language="VB.NET" Value="Protected Friend Const PI As Double  = 3.14159" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -863,9 +863,9 @@
       </Docs>
     </Member>
     <Member MemberName="X">
-      <MemberSignature Language="C#" Value="protected short X { set; }" />
+      <MemberSignature Language="C#" Value="protected internal short X { set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance int16 X" />
-      <MemberSignature Language="VB.NET" Value="Protected Property X As Short" />
+      <MemberSignature Language="VB.NET" Value="Protected Friend Property X As Short" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -880,9 +880,9 @@
       </Docs>
     </Member>
     <Member MemberName="Y">
-      <MemberSignature Language="C#" Value="protected double Y { get; set; }" />
+      <MemberSignature Language="C#" Value="protected internal double Y { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance float64 Y" />
-      <MemberSignature Language="VB.NET" Value="Protected Property Y As Double" />
+      <MemberSignature Language="VB.NET" Value="Protected Friend Property Y As Double" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected.delete/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
+++ b/mdoc/Test/en.expected.delete/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
@@ -1,5 +1,5 @@
 <Type Name="GenericBase&lt;U&gt;+NestedCollection+Enumerator" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator">
-  <TypeSignature Language="C#" Value="protected struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
+  <TypeSignature Language="C#" Value="protected internal struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
   <TypeSignature Language="ILAsm" Value=".class nested protected sequential ansi sealed beforefieldinit GenericBase`1/NestedCollection/Enumerator&lt;U&gt; extends System.ValueType" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>

--- a/mdoc/Test/en.expected.delete/Mono.DocTest/Widget+Direction.xml
+++ b/mdoc/Test/en.expected.delete/Mono.DocTest/Widget+Direction.xml
@@ -1,5 +1,5 @@
 <Type Name="Widget+Direction" FullName="Mono.DocTest.Widget+Direction">
-  <TypeSignature Language="C#" Value="protected enum Widget.Direction" />
+  <TypeSignature Language="C#" Value="protected internal enum Widget.Direction" />
   <TypeSignature Language="ILAsm" Value=".class nested protected auto ansi sealed Widget/Direction extends System.Enum" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>

--- a/mdoc/Test/en.expected.delete/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected.delete/Mono.DocTest/Widget.xml
@@ -910,7 +910,7 @@
       </Docs>
     </Member>
     <Member MemberName="monthlyAverage">
-      <MemberSignature Language="C#" Value="protected readonly double monthlyAverage;" />
+      <MemberSignature Language="C#" Value="protected internal readonly double monthlyAverage;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly initonly float64 monthlyAverage" />
       <MemberType>Field</MemberType>
       <ReturnValue>
@@ -1016,7 +1016,7 @@
       </Docs>
     </Member>
     <Member MemberName="PI">
-      <MemberSignature Language="C#" Value="protected const double PI = 3.14159;" />
+      <MemberSignature Language="C#" Value="protected internal const double PI = 3.14159;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly static literal float64 PI = (3.14159)" />
       <MemberType>Field</MemberType>
       <ReturnValue>
@@ -1065,7 +1065,7 @@
       </Docs>
     </Member>
     <Member MemberName="X">
-      <MemberSignature Language="C#" Value="protected short X { set; }" />
+      <MemberSignature Language="C#" Value="protected internal short X { set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance int16 X" />
       <MemberType>Property</MemberType>
       <ReturnValue>
@@ -1078,7 +1078,7 @@
       </Docs>
     </Member>
     <Member MemberName="Y">
-      <MemberSignature Language="C#" Value="protected double Y { get; set; }" />
+      <MemberSignature Language="C#" Value="protected internal double Y { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance float64 Y" />
       <MemberType>Property</MemberType>
       <ReturnValue>

--- a/mdoc/Test/en.expected.importslashdoc/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
+++ b/mdoc/Test/en.expected.importslashdoc/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
@@ -1,5 +1,5 @@
 <Type Name="GenericBase&lt;U&gt;+NestedCollection+Enumerator" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator">
-  <TypeSignature Language="C#" Value="protected struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
+  <TypeSignature Language="C#" Value="protected internal struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
   <TypeSignature Language="ILAsm" Value=".class nested protected sequential ansi sealed beforefieldinit GenericBase`1/NestedCollection/Enumerator&lt;U&gt; extends System.ValueType" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>

--- a/mdoc/Test/en.expected.importslashdoc/Mono.DocTest/Widget+Direction.xml
+++ b/mdoc/Test/en.expected.importslashdoc/Mono.DocTest/Widget+Direction.xml
@@ -1,5 +1,5 @@
 <Type Name="Widget+Direction" FullName="Mono.DocTest.Widget+Direction">
-  <TypeSignature Language="C#" Value="protected enum Widget.Direction" />
+  <TypeSignature Language="C#" Value="protected internal enum Widget.Direction" />
   <TypeSignature Language="ILAsm" Value=".class nested protected auto ansi sealed Widget/Direction extends System.Enum" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>

--- a/mdoc/Test/en.expected.importslashdoc/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected.importslashdoc/Mono.DocTest/Widget.xml
@@ -1056,7 +1056,7 @@
       </Docs>
     </Member>
     <Member MemberName="monthlyAverage">
-      <MemberSignature Language="C#" Value="protected readonly double monthlyAverage;" />
+      <MemberSignature Language="C#" Value="protected internal readonly double monthlyAverage;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly initonly float64 monthlyAverage" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
@@ -1193,7 +1193,7 @@
       </Docs>
     </Member>
     <Member MemberName="PI">
-      <MemberSignature Language="C#" Value="protected const double PI = 3.14159;" />
+      <MemberSignature Language="C#" Value="protected internal const double PI = 3.14159;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly static literal float64 PI = (3.14159)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
@@ -1254,7 +1254,7 @@
       </Docs>
     </Member>
     <Member MemberName="X">
-      <MemberSignature Language="C#" Value="protected short X { set; }" />
+      <MemberSignature Language="C#" Value="protected internal short X { set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance int16 X" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
@@ -1271,7 +1271,7 @@
       </Docs>
     </Member>
     <Member MemberName="Y">
-      <MemberSignature Language="C#" Value="protected double Y { get; set; }" />
+      <MemberSignature Language="C#" Value="protected internal double Y { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance float64 Y" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected.since/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
+++ b/mdoc/Test/en.expected.since/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
@@ -1,5 +1,5 @@
 <Type Name="GenericBase&lt;U&gt;+NestedCollection+Enumerator" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator">
-  <TypeSignature Language="C#" Value="protected struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
+  <TypeSignature Language="C#" Value="protected internal struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
   <TypeSignature Language="ILAsm" Value=".class nested protected sequential ansi sealed beforefieldinit GenericBase`1/NestedCollection/Enumerator&lt;U&gt; extends System.ValueType" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>

--- a/mdoc/Test/en.expected.since/Mono.DocTest/Widget+Direction.xml
+++ b/mdoc/Test/en.expected.since/Mono.DocTest/Widget+Direction.xml
@@ -1,5 +1,5 @@
 <Type Name="Widget+Direction" FullName="Mono.DocTest.Widget+Direction">
-  <TypeSignature Language="C#" Value="protected enum Widget.Direction" />
+  <TypeSignature Language="C#" Value="protected internal enum Widget.Direction" />
   <TypeSignature Language="ILAsm" Value=".class nested protected auto ansi sealed Widget/Direction extends System.Enum" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>

--- a/mdoc/Test/en.expected.since/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected.since/Mono.DocTest/Widget.xml
@@ -1036,7 +1036,7 @@
       </Docs>
     </Member>
     <Member MemberName="monthlyAverage">
-      <MemberSignature Language="C#" Value="protected readonly double monthlyAverage;" />
+      <MemberSignature Language="C#" Value="protected internal readonly double monthlyAverage;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly initonly float64 monthlyAverage" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
@@ -1170,7 +1170,7 @@
       </Docs>
     </Member>
     <Member MemberName="PI">
-      <MemberSignature Language="C#" Value="protected const double PI = 3.14159;" />
+      <MemberSignature Language="C#" Value="protected internal const double PI = 3.14159;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly static literal float64 PI = (3.14159)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
@@ -1231,7 +1231,7 @@
       </Docs>
     </Member>
     <Member MemberName="X">
-      <MemberSignature Language="C#" Value="protected short X { set; }" />
+      <MemberSignature Language="C#" Value="protected internal short X { set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance int16 X" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
@@ -1248,7 +1248,7 @@
       </Docs>
     </Member>
     <Member MemberName="Y">
-      <MemberSignature Language="C#" Value="protected double Y { get; set; }" />
+      <MemberSignature Language="C#" Value="protected internal double Y { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance float64 Y" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.xml
@@ -1,5 +1,5 @@
 <Type Name="GenericBase&lt;U&gt;+NestedCollection+Enumerator" FullName="Mono.DocTest.Generic.GenericBase&lt;U&gt;+NestedCollection+Enumerator">
-  <TypeSignature Language="C#" Value="protected struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
+  <TypeSignature Language="C#" Value="protected internal struct GenericBase&lt;U&gt;.NestedCollection.Enumerator" />
   <TypeSignature Language="ILAsm" Value=".class nested protected sequential ansi sealed beforefieldinit GenericBase`1/NestedCollection/Enumerator&lt;U&gt; extends System.ValueType" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget+Direction.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget+Direction.xml
@@ -1,5 +1,5 @@
 <Type Name="Widget+Direction" FullName="Mono.DocTest.Widget+Direction">
-  <TypeSignature Language="C#" Value="protected enum Widget.Direction" />
+  <TypeSignature Language="C#" Value="protected internal enum Widget.Direction" />
   <TypeSignature Language="ILAsm" Value=".class nested protected auto ansi sealed Widget/Direction extends System.Enum" />
   <AssemblyInfo>
     <AssemblyName>DocTest</AssemblyName>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
@@ -1004,7 +1004,7 @@
       </Docs>
     </Member>
     <Member MemberName="monthlyAverage">
-      <MemberSignature Language="C#" Value="protected readonly double monthlyAverage;" />
+      <MemberSignature Language="C#" Value="protected internal readonly double monthlyAverage;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly initonly float64 monthlyAverage" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
@@ -1131,7 +1131,7 @@
       </Docs>
     </Member>
     <Member MemberName="PI">
-      <MemberSignature Language="C#" Value="protected const double PI = 3.14159;" />
+      <MemberSignature Language="C#" Value="protected internal const double PI = 3.14159;" />
       <MemberSignature Language="ILAsm" Value=".field familyorassembly static literal float64 PI = (3.14159)" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
@@ -1189,7 +1189,7 @@
       </Docs>
     </Member>
     <Member MemberName="X">
-      <MemberSignature Language="C#" Value="protected short X { set; }" />
+      <MemberSignature Language="C#" Value="protected internal short X { set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance int16 X" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
@@ -1205,7 +1205,7 @@
       </Docs>
     </Member>
     <Member MemberName="Y">
-      <MemberSignature Language="C#" Value="protected double Y { get; set; }" />
+      <MemberSignature Language="C#" Value="protected internal double Y { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance float64 Y" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>

--- a/mdoc/Test/html.expected-with-array-extension/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.html
+++ b/mdoc/Test/html.expected-with-array-extension/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.html
@@ -211,7 +211,7 @@
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Signature">protected struct  <b>GenericBase&lt;U&gt;.NestedCollection.Enumerator</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Signature">protected internal struct  <b>GenericBase&lt;U&gt;.NestedCollection.Enumerator</b></div>
     </div>
     <div class="Remarks" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Docs">
       <h2 class="Section">Remarks</h2>

--- a/mdoc/Test/html.expected-with-array-extension/Mono.DocTest/Widget+Direction.html
+++ b/mdoc/Test/html.expected-with-array-extension/Mono.DocTest/Widget+Direction.html
@@ -211,7 +211,7 @@
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Widget.Direction:Signature">[System.Flags]<br />protected enum <b>Widget.Direction</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Widget.Direction:Signature">[System.Flags]<br />protected internal enum <b>Widget.Direction</b></div>
     </div>
     <div class="Remarks" id="T:Mono.DocTest.Widget.Direction:Docs">
       <h2 class="Section">Remarks</h2>

--- a/mdoc/Test/html.expected-with-array-extension/Mono.DocTest/Widget.html
+++ b/mdoc/Test/html.expected-with-array-extension/Mono.DocTest/Widget.html
@@ -1864,7 +1864,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">protected readonly <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>monthlyAverage</b> </div>
+          <div class="Signature">protected internal readonly <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>monthlyAverage</b> </div>
           <h2 class="Section">Remarks</h2>
           <div class="SectionBox" id="F:Mono.DocTest.Widget.monthlyAverage:Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
@@ -2044,7 +2044,7 @@
           <p>
             <b>Value: </b>3.14159</p>
           <h2>Syntax</h2>
-          <div class="Signature">protected const <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>PI</b> </div>
+          <div class="Signature">protected internal const <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>PI</b> </div>
           <h2 class="Section">Remarks</h2>
           <div class="SectionBox" id="F:Mono.DocTest.Widget.PI:Remarks">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
@@ -2096,7 +2096,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">protected <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int16">short</a> <b>X</b>  { set; }</div>
+          <div class="Signature">protected internal <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int16">short</a> <b>X</b>  { set; }</div>
           <h4 class="Subsection">Value</h4>
           <blockquote class="SubsectionBox" id="P:Mono.DocTest.Widget.X:Value">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
@@ -2116,7 +2116,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">protected <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>Y</b>  { get; set; }</div>
+          <div class="Signature">protected internal <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>Y</b>  { get; set; }</div>
           <h4 class="Subsection">Value</h4>
           <blockquote class="SubsectionBox" id="P:Mono.DocTest.Widget.Y:Value">
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>

--- a/mdoc/Test/html.expected/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.html
+++ b/mdoc/Test/html.expected/Mono.DocTest.Generic/GenericBase`1+NestedCollection+Enumerator.html
@@ -211,7 +211,7 @@
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Signature">protected struct  <b>GenericBase&lt;U&gt;.NestedCollection.Enumerator</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Signature">protected internal struct  <b>GenericBase&lt;U&gt;.NestedCollection.Enumerator</b></div>
     </div>
     <div class="Remarks" id="T:Mono.DocTest.Generic.GenericBase`1.NestedCollection.Enumerator:Docs">
       <h2 class="Section">Remarks</h2>

--- a/mdoc/Test/html.expected/Mono.DocTest/Widget+Direction.html
+++ b/mdoc/Test/html.expected/Mono.DocTest/Widget+Direction.html
@@ -211,7 +211,7 @@
     </p>
     <div>
       <h2>Syntax</h2>
-      <div class="Signature" id="T:Mono.DocTest.Widget.Direction:Signature">[System.Flags]<br />protected enum <b>Widget.Direction</b></div>
+      <div class="Signature" id="T:Mono.DocTest.Widget.Direction:Signature">[System.Flags]<br />protected internal enum <b>Widget.Direction</b></div>
     </div>
     <div class="Remarks" id="T:Mono.DocTest.Widget.Direction:Docs">
       <h2 class="Section">Remarks</h2>

--- a/mdoc/Test/html.expected/Mono.DocTest/Widget.html
+++ b/mdoc/Test/html.expected/Mono.DocTest/Widget.html
@@ -1818,7 +1818,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">protected readonly <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>monthlyAverage</b> </div>
+          <div class="Signature">protected internal readonly <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>monthlyAverage</b> </div>
           <h2 class="Section">Remarks</h2>
           <div class="SectionBox" id="F:Mono.DocTest.Widget.monthlyAverage:Remarks">
             <tt>F:Mono.DocTest.Widget.monthlyAverage</tt>.</div>
@@ -1977,7 +1977,7 @@
           <p>
             <b>Value: </b>3.14159</p>
           <h2>Syntax</h2>
-          <div class="Signature">protected const <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>PI</b> </div>
+          <div class="Signature">protected internal const <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>PI</b> </div>
           <h2 class="Section">Remarks</h2>
           <div class="SectionBox" id="F:Mono.DocTest.Widget.PI:Remarks">
             <tt>F:Mono.DocTest.Widget.PI</tt>.</div>
@@ -2024,7 +2024,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">protected <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int16">short</a> <b>X</b>  { set; }</div>
+          <div class="Signature">protected internal <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int16">short</a> <b>X</b>  { set; }</div>
           <h4 class="Subsection">Value</h4>
           <blockquote class="SubsectionBox" id="P:Mono.DocTest.Widget.X:Value">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Int16">short</a> value...</blockquote>
           <h2 class="Section">Remarks</h2>
@@ -2041,7 +2041,7 @@
             <span class="NotEntered">Documentation for this section has not yet been entered.</span>
           </div>
           <h2>Syntax</h2>
-          <div class="Signature">protected <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>Y</b>  { get; set; }</div>
+          <div class="Signature">protected internal <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> <b>Y</b>  { get; set; }</div>
           <h4 class="Subsection">Value</h4>
           <blockquote class="SubsectionBox" id="P:Mono.DocTest.Widget.Y:Value">A <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Double">double</a> value...</blockquote>
           <h2 class="Section">Remarks</h2>


### PR DESCRIPTION
Corrected  VB and C# formatters
Edited integration tests
Closes #137