### PR TITLE
mdoc: Support for attached events

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -11,5 +11,9 @@ namespace Mono.Documentation
 		public const string FSharp = "F#";
 		public const string FSharpLowCase = "f#";
 		public const string Tab = "    ";
+
+		public const string DependencyPropertyFullName = "System.Windows.DependencyProperty";
+		public const string DependencyObjectFullName = "System.Windows.DependencyObject";
+		public const string VoidFullName = "System.Void";
 	}
 }

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -441,6 +441,12 @@ check-monodocer-import-fx-update: check-monodocer-import-fx-work
 	rm -Rf Test/en.expected-fx-import
 	mv Test/en.actual Test/en.expected-fx-import
 
+check-monodocer-attached-entities:
+	-rm -Rf Test/en.actual
+	msbuild ../mdoc/Test/AttachedEventsAndProperties/AttachedEventsAndProperties.csproj -property:Configuration=Release
+	$(MONO) $(PROGRAM) update -o Test/en.actual Test/AttachedEventsAndProperties/bin/Release/AttachedEventsAndProperties.dll -lang docid
+	$(DIFF) Test/en.expected-attached-entities Test/en.actual
+	
 Test/TestClass.dll:
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ mdoc.Test/SampleClasses/Test*.cs
 
@@ -567,6 +573,7 @@ check-doc-tools: check-monodocer-since \
 	check-monodocer-vbnet2 \
 	check-monodocer-frameworks-with-nuget\
 	check-monodocer-fsharp \
+	check-monodocer-attached-entities \
 
 
 check-doc-tools-update: check-monodocer-since-update \

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -3194,6 +3194,8 @@ namespace Mono.Documentation
             }
             else if (mi is FieldDefinition) return;
             else if (mi is EventDefinition) return;
+            else if (mi is AttachedEventReference) return;
+            else if (mi is AttachedPropertyReference) return;
             else throw new ArgumentException ();
         }
 
@@ -3233,6 +3235,10 @@ namespace Mono.Documentation
                 MakeReturnValue (root, ((FieldDefinition)mi).FieldType, null, shouldDuplicateWithNew);
             else if (mi is EventDefinition)
                 MakeReturnValue (root, ((EventDefinition)mi).EventType, null, shouldDuplicateWithNew);
+            else if (mi is AttachedEventReference)
+                return;
+            else if (mi is AttachedPropertyReference)
+                return;
             else
                 throw new ArgumentException (mi + " is a " + mi.GetType ().FullName);
         }
@@ -3322,6 +3328,10 @@ namespace Mono.Documentation
                 return "Field";
             if (mi is EventDefinition)
                 return "Event";
+            if (mi is AttachedEventReference)
+                return "AttachedEvent";
+            if (mi is AttachedPropertyReference)
+                return "AttachedProperty";
             throw new ArgumentException ();
         }
 

--- a/mdoc/Mono.Documentation/Updater/Formatters/DocIdFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/DocIdFormatter.cs
@@ -1,6 +1,7 @@
 ﻿
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
+using Mono.Documentation.Util;
 
 namespace Mono.Documentation.Updater
 {
@@ -8,12 +9,18 @@ namespace Mono.Documentation.Updater
     {
         public override string Language => Consts.DocId;
 
+        private SlashDocMemberFormatter slashDocMemberFormatter = new SlashDocMemberFormatter();
+
         public override string GetDeclaration (TypeReference tref)
         {
             return DocCommentId.GetDocCommentId (tref.Resolve ());
         }
         public override string GetDeclaration (MemberReference mreference)
         {
+            if (mreference is AttachedEventReference || mreference is AttachedPropertyReference)
+            {
+                return slashDocMemberFormatter.GetDeclaration(mreference);
+            }
             return DocCommentId.GetDocCommentId (mreference.Resolve ());
         }
     }

--- a/mdoc/Mono.Documentation/Updater/Formatters/MemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/MemberFormatter.cs
@@ -323,6 +323,12 @@ namespace Mono.Documentation.Updater
             EventDefinition e = member as EventDefinition;
             if (e != null)
                 return GetEventDeclaration (e);
+            AttachedEventDefinition ae = member as AttachedEventDefinition;
+            if (ae != null)
+                return GetAttachedEventDeclaration (ae);
+            AttachedPropertyDefinition ap = member as AttachedPropertyDefinition;
+            if (ap != null)
+                return GetAttachedPropertyDeclaration (ap);
             throw new NotSupportedException ("Can't handle: " + member.GetType ().ToString ());
         }
 
@@ -420,6 +426,16 @@ namespace Mono.Documentation.Updater
         protected virtual string GetEventDeclaration (EventDefinition e)
         {
             return GetEventName (e);
+        }
+
+        protected virtual string GetAttachedEventDeclaration(AttachedEventDefinition e)
+        {
+            return $"see Add{e.Name}Handler, and Remove{e.Name}Handler";
+        }
+
+        protected virtual string GetAttachedPropertyDeclaration(AttachedPropertyDefinition a)
+        {
+            return $"see Get{a.Name}, and Set{a.Name}";
         }
 
         public virtual bool IsSupported(TypeReference tref) => true;

--- a/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
@@ -317,5 +317,21 @@ namespace Mono.Documentation.Updater
                 return null;
             return "E:" + name;
         }
+
+        protected override string GetAttachedEventDeclaration(AttachedEventDefinition e)
+        {
+            string name = GetName(e);
+            if (name == null)
+                return null;
+            return "E:" + name;
+        }
+
+        protected override string GetAttachedPropertyDeclaration(AttachedPropertyDefinition a)
+        {
+            string name = GetName(a);
+            if (name == null)
+                return null;
+            return "P:" + name;
+        }
     }
 }

--- a/mdoc/Mono.Documentation/Util/AttachedEntitiesHelper.cs
+++ b/mdoc/Mono.Documentation/Util/AttachedEntitiesHelper.cs
@@ -1,0 +1,179 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Collections.Generic;
+using Mono.Documentation.Updater;
+
+namespace Mono.Documentation.Util
+{
+    public static class AttachedEntitiesHelper
+    {
+        private const string PropertyConst = "Property";
+        private const string EventConst = "Event";
+        
+        private static readonly int EventLength = EventConst.Length;
+        private static readonly int PropertyLength = PropertyConst.Length;
+
+        public static string GetEventName(string fieldDefinitionName)
+        {
+            return fieldDefinitionName.Substring(0, fieldDefinitionName.Length - EventLength);
+        }
+
+        public static string GetPropertyName(string fieldDefinitionName)
+        {
+            return fieldDefinitionName.Substring(0, fieldDefinitionName.Length - PropertyLength);
+        }
+
+        public static IEnumerable<MemberReference> GetAttachedEntities(TypeDefinition type)
+        {
+            var methodsLookUpTable = GetMethodsLookUpTable(type);
+            foreach (var attachedEventReference in GetAttachedEvents(type, methodsLookUpTable))
+            {
+                yield return attachedEventReference;
+            }
+            foreach (var attachedEventProperty in GetAttachedProperties(type, methodsLookUpTable))
+            {
+                yield return attachedEventProperty;
+            }
+        }
+
+        private static Dictionary<string, IEnumerable<MethodDefinition>> GetMethodsLookUpTable(TypeDefinition type)
+        {
+            return type.Methods.GroupBy(i => i.Name, i => i).ToDictionary(i => i.Key, i => i.AsEnumerable());
+        }
+
+        #region Attached Events
+        private static IEnumerable<AttachedEventReference> GetAttachedEvents(TypeDefinition type, Dictionary<string, IEnumerable<MethodDefinition>> methods)
+        {
+            foreach (var field in type.Fields)
+            {
+                if (IsAttachedEvent(field, methods))
+                    yield return new AttachedEventReference(field);
+            }
+        }
+
+        private static bool IsAttachedEvent(FieldDefinition field, Dictionary<string, IEnumerable<MethodDefinition>> methods)
+        {
+            // https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/attached-events-overview
+            if (!field.FieldType.Name.EndsWith(EventConst))
+                return false;
+            var addMethodName = $"Add{GetEventName(field.Name)}Handler";
+            var removeMethodName = $"Remove{GetEventName(field.Name)}Handler";
+            return
+                // WPF implements attached events as routed events; the identifier to use for an event (RoutedEvent) is already defined by the WPF event system
+                IsAssignableTo(field.FieldType, "System.Windows.RoutedEvent")
+                && field.IsPublic
+                && field.IsStatic
+                && field.IsInitOnly
+
+                // Has a method Add*Handler with two parameters. 
+                // Has a method Remove*Handler with two parameters. 
+                && methods.ContainsKey(addMethodName)
+                && methods.ContainsKey(removeMethodName)
+                && methods[addMethodName].Any(IsAttachedEventMethod)
+                && methods[removeMethodName].Any(IsAttachedEventMethod);
+        }
+
+        private static bool IsAttachedEventMethod(MethodDefinition method)
+        {
+            // The method must be public and static, with no return value.
+            return method.IsPublic
+                && method.IsStatic
+                && method.ReturnType.FullName == Consts.VoidFullName
+                && AreAttachedEventMethodParameters(method.Parameters);
+        }
+
+        private static bool AreAttachedEventMethodParameters(Collection<ParameterDefinition> parameters)
+        {
+            if (parameters.Count != 2)
+                return false;
+            return
+                // The first parameter is DependencyObject
+                IsAssignableTo(parameters[0].ParameterType, "System.Windows.DependencyObject")
+                
+                // The second parameter is the handler to add/remove
+                && IsAttachedEventHandler(parameters[1].ParameterType);
+        }
+
+        private static bool IsAttachedEventHandler(TypeReference typeReference)
+        {
+            var type = typeReference.Resolve();
+            if (!DocUtils.IsDelegate(type))
+                return false;
+            MethodDefinition invoke = type.GetMethod("Invoke");
+            return invoke.Parameters.Count == 2;
+        }
+        #endregion
+
+        #region Attached Properties
+        private static IEnumerable<AttachedPropertyReference> GetAttachedProperties(TypeDefinition type, Dictionary<string, IEnumerable<MethodDefinition>> methods)
+        {
+            foreach (var field in type.Fields)
+            {
+                if (IsAttachedProperty(field, methods))
+                    yield return new AttachedPropertyReference(field);
+            }
+        }
+
+        private static bool IsAttachedProperty(FieldDefinition field, Dictionary<string, IEnumerable<MethodDefinition>> methods)
+        {
+            // https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/attached-properties-overview
+            // https://github.com/mono/api-doc-tools/issues/63#issuecomment-328995418
+            if (!field.Name.EndsWith(PropertyConst))
+                return false;
+            var propertyName = GetPropertyName(field.Name);
+            var getMethodName = $"Get{propertyName}";
+            var setMethodName = $"Set{propertyName}";
+            return
+                // Class X has a static field of type DependencyProperty [Name]Property
+                field.FieldType.FullName == Consts.DependencyPropertyFullName
+                && field.IsPublic
+                && field.IsStatic
+                && field.IsInitOnly
+
+                // Class X also has static methods with the following names: Get[Name] and Set[Name]
+                && methods.ContainsKey(getMethodName)
+                && methods.ContainsKey(setMethodName)
+                && methods[getMethodName].Any(IsAttachedPropertyGetMethod)
+                && methods[setMethodName].Any(IsAttachedPropertySetMethod);
+
+        }
+
+        private static bool IsAttachedPropertyGetMethod(MethodDefinition method)
+        {
+            return method.Parameters.Count == 1
+
+                   // returns a value of type dp.PropertyType (or IsAssignableTo…), where dp is the value of the static field.
+                   // && IsAssignableTo(method.ReturnType, "");
+
+                   // The Get method takes one argument of type DependencyObject(or something IsAssignableTo(DependencyObject), 
+                   && IsAssignableTo(method.Parameters[0].ParameterType, Consts.DependencyObjectFullName);
+        }
+
+        private static bool IsAttachedPropertySetMethod(MethodDefinition method)
+        {
+            return method.Parameters.Count == 2// The Set method takes two arguments.
+                   
+                   // The first has type DependencyObject(or IsAssignableTo…), 
+                   && IsAssignableTo(method.Parameters[0].ParameterType, Consts.DependencyObjectFullName)
+
+                   // the second has type dp.PropertyType (or IsAssignableTo…).
+                   // && IsAssignableTo(method.Parameters[1].ParameterType, "")
+
+                   // It returns void.
+                   && method.ReturnType.FullName == Consts.VoidFullName;
+        }
+        #endregion
+        
+        private static bool IsAssignableTo(TypeReference type, string targetTypeName)
+        {
+            if (type == null)
+                return false;
+            var typeDefenition = type.Resolve();
+            if (typeDefenition == null || typeDefenition.IsSealed)
+                return type.FullName == targetTypeName;
+
+            return type.FullName == targetTypeName || IsAssignableTo(typeDefenition.BaseType, targetTypeName);
+        }
+    }
+}

--- a/mdoc/Mono.Documentation/Util/AttachedEventDefinition.cs
+++ b/mdoc/Mono.Documentation/Util/AttachedEventDefinition.cs
@@ -1,0 +1,38 @@
+using Mono.Cecil;
+using Mono.Collections.Generic;
+
+namespace Mono.Documentation.Util
+{
+    public class AttachedEventDefinition : AttachedEventReference, IMemberDefinition
+    {
+        private readonly FieldDefinition fieldDefinition;
+
+        public AttachedEventDefinition(FieldDefinition fieldDefinition, MetadataToken metadataToken)
+            : base(fieldDefinition)
+        {
+            this.fieldDefinition = fieldDefinition;
+            MetadataToken = metadataToken;
+        }
+
+        public Collection<CustomAttribute> CustomAttributes => fieldDefinition.CustomAttributes;
+        public bool HasCustomAttributes => fieldDefinition.HasCustomAttributes;
+
+        public bool IsSpecialName
+        {
+            get { return fieldDefinition.IsSpecialName; }
+            set { fieldDefinition.IsSpecialName = value; }
+        }
+
+        public bool IsRuntimeSpecialName
+        {
+            get { return fieldDefinition.IsRuntimeSpecialName; }
+            set { fieldDefinition.IsRuntimeSpecialName = value; }
+        }
+
+        public new TypeDefinition DeclaringType
+        {
+            get { return fieldDefinition.DeclaringType; }
+            set { fieldDefinition.DeclaringType = value; }
+        }
+    }
+}

--- a/mdoc/Mono.Documentation/Util/AttachedEventReference.cs
+++ b/mdoc/Mono.Documentation/Util/AttachedEventReference.cs
@@ -1,0 +1,21 @@
+using Mono.Cecil;
+
+namespace Mono.Documentation.Util
+{
+    public class AttachedEventReference : FieldReference
+    {
+        private readonly FieldDefinition fieldDefinition;
+        private AttachedEventDefinition definition;
+
+        public AttachedEventReference(FieldDefinition fieldDefinition) : base(AttachedEntitiesHelper.GetEventName(fieldDefinition.Name), fieldDefinition.FieldType, fieldDefinition.DeclaringType)
+        {
+            this.fieldDefinition = fieldDefinition;
+        }
+
+        protected override IMemberDefinition ResolveDefinition()
+        {
+            return definition ??
+                   (definition = new AttachedEventDefinition(fieldDefinition, MetadataToken));
+        }
+    }
+}

--- a/mdoc/Mono.Documentation/Util/AttachedPropertyDefinition.cs
+++ b/mdoc/Mono.Documentation/Util/AttachedPropertyDefinition.cs
@@ -1,0 +1,37 @@
+using Mono.Cecil;
+using Mono.Collections.Generic;
+
+namespace Mono.Documentation.Util
+{
+    public class AttachedPropertyDefinition : AttachedPropertyReference, IMemberDefinition
+    {
+        private readonly FieldDefinition fieldDefinition;
+
+        public AttachedPropertyDefinition(FieldDefinition fieldDefinition, MetadataToken metadataToken): base(fieldDefinition)
+        {
+            this.fieldDefinition = fieldDefinition;
+            MetadataToken = metadataToken;
+        }
+
+        public Collection<CustomAttribute> CustomAttributes => fieldDefinition.CustomAttributes;
+        public bool HasCustomAttributes => fieldDefinition.HasCustomAttributes;
+
+        public bool IsSpecialName
+        {
+            get { return fieldDefinition.IsSpecialName; }
+            set { fieldDefinition.IsSpecialName = value; }
+        }
+
+        public bool IsRuntimeSpecialName
+        {
+            get { return fieldDefinition.IsRuntimeSpecialName; }
+            set { fieldDefinition.IsRuntimeSpecialName = value; }
+        }
+
+        public new TypeDefinition DeclaringType
+        {
+            get { return fieldDefinition.DeclaringType; }
+            set { fieldDefinition.DeclaringType = value; }
+        }
+    }
+}

--- a/mdoc/Mono.Documentation/Util/AttachedPropertyReference.cs
+++ b/mdoc/Mono.Documentation/Util/AttachedPropertyReference.cs
@@ -1,0 +1,21 @@
+using Mono.Cecil;
+
+namespace Mono.Documentation.Util
+{
+    public class AttachedPropertyReference : FieldReference
+    {
+        private readonly FieldDefinition fieldDefinition;
+        private AttachedPropertyDefinition definition;
+
+        public AttachedPropertyReference(FieldDefinition fieldDefinition) : base(AttachedEntitiesHelper.GetPropertyName(fieldDefinition.Name), fieldDefinition.FieldType, fieldDefinition.DeclaringType)
+        {
+            this.fieldDefinition = fieldDefinition;
+        }
+
+        protected override IMemberDefinition ResolveDefinition()
+        {
+            return definition ??
+                   (definition = new AttachedPropertyDefinition(fieldDefinition, MetadataToken));
+        }
+    }
+}

--- a/mdoc/Mono.Documentation/Util/CecilExtensions.cs
+++ b/mdoc/Mono.Documentation/Util/CecilExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Mono.Cecil;
 
 namespace Mono.Documentation.Util
@@ -31,6 +30,8 @@ namespace Mono.Documentation.Util
                 yield return (MemberReference)t;
             foreach (var p in type.Properties)
                 yield return (MemberReference)p;
+            foreach (var a in type.AttachedEntities())
+                yield return (MemberReference)a;
         }
 
         public static IEnumerable<MemberReference> GetMembers (this TypeDefinition type, string member)
@@ -115,6 +116,11 @@ namespace Mono.Documentation.Util
 
             foreach (var type in self.NestedTypes.SelectMany (t => t.GetAllTypes ()))
                 yield return type;
+        }
+
+        public static IEnumerable<MemberReference> AttachedEntities(this TypeDefinition type)
+        {
+            return AttachedEntitiesHelper.GetAttachedEntities(type);
         }
     }
 }

--- a/mdoc/Test/AttachedEventsAndProperties/AquariumFilter.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/AquariumFilter.cs
@@ -1,0 +1,9 @@
+﻿using System.Windows;
+
+namespace AttachedEventsAndProperties
+{
+    public class AquariumFilter
+    {
+        public static RoutedEvent NeedsCleaningEvent { get; set; }
+    }
+}

--- a/mdoc/Test/AttachedEventsAndProperties/AquariumObject.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/AquariumObject.cs
@@ -1,0 +1,6 @@
+namespace AttachedEventsAndProperties
+{
+    public class AquariumObject
+    {
+    }
+}

--- a/mdoc/Test/AttachedEventsAndProperties/AttachedEventExample.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/AttachedEventExample.cs
@@ -1,0 +1,81 @@
+﻿using System.Windows;
+
+namespace AttachedEventsAndProperties
+{
+    public class AttachedEventExample
+    {
+        #region WPF decompiled example:
+
+        public static readonly RoutedEvent DragOverEvent;
+
+        public static void AddDragOverHandler(DependencyObject element, DragEventHandler handler)
+        {
+        }
+
+        public static void RemoveDragOverHandler(DependencyObject element, DragEventHandler handler)
+        {
+        }
+        #endregion 
+
+        #region docs.microsoft.com example
+        public static readonly RoutedEvent NeedsCleaningEvent;
+        public static void AddNeedsCleaningHandler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+
+        public static void RemoveNeedsCleaningHandler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+        #endregion 
+
+        #region Negative example (no RemoveNeedsCleaning2Handler)
+        public static readonly RoutedEvent NeedsCleaning2Event;
+        public static void AddNeedsCleaning2Handler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+        #endregion
+
+        #region Negative example (no AddNeedsCleaning3Handler)
+        public static readonly RoutedEvent NeedsCleaning3Event;
+        public static void RemoveNeedsCleaning3Handler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+        #endregion
+
+        #region Negative example (protected methods)
+
+        public static readonly RoutedEvent NeedsCleaning4Event;
+
+        protected static void AddNeedsCleaning4Handler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+
+        protected static void RemoveNeedsCleaning4Handler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+        #endregion
+
+        #region Negative example (non static)
+        public readonly RoutedEvent NeedsCleaning5Event;
+
+        public void AddNeedsCleaning5Handler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+
+        public void RemoveNeedsCleaning5Handler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+        #endregion
+
+
+        #region Negative example (field's name doesn't end with "Event")
+        public static readonly RoutedEvent NeedsCleaning6Event6;
+        public static void AddNeedsCleaning6Handler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+        public static void RemoveNeedsCleaning6Handler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+        #endregion 
+    }
+}

--- a/mdoc/Test/AttachedEventsAndProperties/AttachedEventsAndProperties.csproj
+++ b/mdoc/Test/AttachedEventsAndProperties/AttachedEventsAndProperties.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{304FC0FD-45EF-46ED-A05D-42907B55C123}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AttachedEventsAndProperties</RootNamespace>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AquariumFilter.cs" />
+    <Compile Include="AquariumObject.cs" />
+    <Compile Include="AttachedEventExample.cs" />
+    <Compile Include="AttachedPropertyExample.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RoutedEvent.cs" />
+    <Compile Include="System.Windows\DragEventArgs.cs" />
+    <Compile Include="System.Windows\DragEventHandler.cs" />
+    <Compile Include="System.Windows\RoutedEventArgs.cs" />
+    <Compile Include="System.Windows\RoutedEventHandler.cs" />
+    <Compile Include="System.Windows\UIElement.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/mdoc/Test/AttachedEventsAndProperties/AttachedPropertyExample.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/AttachedPropertyExample.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Windows;
+
+namespace AttachedEventsAndProperties
+{
+    public static class AttachedPropertyExample
+    {
+        #region modified docs.microsoft.com example
+
+        public static readonly DependencyProperty IsBubbleSourceProperty = DependencyProperty.RegisterAttached(
+  "IsBubbleSource",
+  typeof(Boolean),
+  typeof(AquariumObject),
+  null
+);
+
+        public static void SetIsBubbleSource(UIElement element, Boolean value)
+        {
+            element.SetValue(IsBubbleSourceProperty, value);
+        }
+
+        public static Boolean GetIsBubbleSource(UIElement element)
+        {
+            return (Boolean)element.GetValue(IsBubbleSourceProperty);
+        }
+        #endregion
+
+        #region negative example (no get method)
+
+        public static readonly DependencyProperty IsBubbleSource2Property = DependencyProperty.RegisterAttached(
+  "IsBubbleSource2",
+  typeof(Boolean),
+  typeof(AquariumObject),
+  null
+);
+
+        public static void SetIsBubbleSource2(UIElement element, Boolean value)
+        {
+            element.SetValue(IsBubbleSourceProperty, value);
+        }
+        #endregion
+    }
+
+}

--- a/mdoc/Test/AttachedEventsAndProperties/Properties/AssemblyInfo.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AttachedEventsAndProperties")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("EPAM Systems")]
+[assembly: AssemblyProduct("AttachedEventsAndProperties")]
+[assembly: AssemblyCopyright("Copyright © EPAM Systems 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("304fc0fd-45ef-46ed-a05d-42907b55c123")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/mdoc/Test/AttachedEventsAndProperties/RoutedEvent.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/RoutedEvent.cs
@@ -1,0 +1,6 @@
+﻿namespace System.Windows
+{
+    public class RoutedEvent
+    {
+    }
+}

--- a/mdoc/Test/AttachedEventsAndProperties/System.Windows/DragEventArgs.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/System.Windows/DragEventArgs.cs
@@ -1,0 +1,7 @@
+namespace System.Windows
+{
+    public sealed class DragEventArgs : RoutedEventArgs
+    {
+        
+    }
+}

--- a/mdoc/Test/AttachedEventsAndProperties/System.Windows/DragEventHandler.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/System.Windows/DragEventHandler.cs
@@ -1,0 +1,4 @@
+namespace System.Windows
+{
+    public delegate void DragEventHandler(object sender, DragEventArgs e);
+}

--- a/mdoc/Test/AttachedEventsAndProperties/System.Windows/RoutedEventArgs.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/System.Windows/RoutedEventArgs.cs
@@ -1,0 +1,6 @@
+namespace System.Windows
+{
+    public class RoutedEventArgs : EventArgs
+    {
+    }
+}

--- a/mdoc/Test/AttachedEventsAndProperties/System.Windows/RoutedEventHandler.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/System.Windows/RoutedEventHandler.cs
@@ -1,0 +1,4 @@
+namespace System.Windows
+{
+    public delegate void RoutedEventHandler(object sender, RoutedEventArgs e);
+}

--- a/mdoc/Test/AttachedEventsAndProperties/System.Windows/UIElement.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/System.Windows/UIElement.cs
@@ -1,0 +1,6 @@
+namespace System.Windows
+{
+    public class UIElement : DependencyObject
+    {
+    }
+}

--- a/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AquariumFilter.xml
+++ b/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AquariumFilter.xml
@@ -1,0 +1,50 @@
+<Type Name="AquariumFilter" FullName="AttachedEventsAndProperties.AquariumFilter">
+  <TypeSignature Language="C#" Value="public class AquariumFilter" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit AquariumFilter extends System.Object" />
+  <TypeSignature Language="DocId" Value="T:AttachedEventsAndProperties.AquariumFilter" />
+  <AssemblyInfo>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public AquariumFilter ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AquariumFilter.#ctor" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NeedsCleaningEvent">
+      <MemberSignature Language="C#" Value="public static System.Windows.RoutedEvent NeedsCleaningEvent { get; set; }" />
+      <MemberSignature Language="ILAsm" Value=".property class System.Windows.RoutedEvent NeedsCleaningEvent" />
+      <MemberSignature Language="DocId" Value="P:AttachedEventsAndProperties.AquariumFilter.NeedsCleaningEvent" />
+      <MemberType>Property</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.RoutedEvent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <value>To be added.</value>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AquariumObject.xml
+++ b/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AquariumObject.xml
@@ -1,0 +1,33 @@
+<Type Name="AquariumObject" FullName="AttachedEventsAndProperties.AquariumObject">
+  <TypeSignature Language="C#" Value="public class AquariumObject" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit AquariumObject extends System.Object" />
+  <TypeSignature Language="DocId" Value="T:AttachedEventsAndProperties.AquariumObject" />
+  <AssemblyInfo>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public AquariumObject ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AquariumObject.#ctor" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AttachedEventExample.xml
+++ b/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AttachedEventExample.xml
@@ -1,0 +1,435 @@
+<Type Name="AttachedEventExample" FullName="AttachedEventsAndProperties.AttachedEventExample">
+  <TypeSignature Language="C#" Value="public class AttachedEventExample" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit AttachedEventExample extends System.Object" />
+  <TypeSignature Language="DocId" Value="T:AttachedEventsAndProperties.AttachedEventExample" />
+  <AssemblyInfo>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public AttachedEventExample ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.#ctor" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AddDragOverHandler">
+      <MemberSignature Language="C#" Value="public static void AddDragOverHandler (System.Windows.DependencyObject element, System.Windows.DragEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void AddDragOverHandler(class System.Windows.DependencyObject element, class System.Windows.DragEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.AddDragOverHandler(System.Windows.DependencyObject,System.Windows.DragEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.DragEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AddNeedsCleaning2Handler">
+      <MemberSignature Language="C#" Value="public static void AddNeedsCleaning2Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void AddNeedsCleaning2Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.AddNeedsCleaning2Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AddNeedsCleaning4Handler">
+      <MemberSignature Language="C#" Value="protected static void AddNeedsCleaning4Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method familystatic hidebysig void AddNeedsCleaning4Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.AddNeedsCleaning4Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AddNeedsCleaning5Handler">
+      <MemberSignature Language="C#" Value="public void AddNeedsCleaning5Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void AddNeedsCleaning5Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.AddNeedsCleaning5Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AddNeedsCleaning6Handler">
+      <MemberSignature Language="C#" Value="public static void AddNeedsCleaning6Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void AddNeedsCleaning6Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.AddNeedsCleaning6Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="AddNeedsCleaningHandler">
+      <MemberSignature Language="C#" Value="public static void AddNeedsCleaningHandler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void AddNeedsCleaningHandler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.AddNeedsCleaningHandler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DragOver">
+      <MemberSignature Language="C#" Value="see AddDragOverHandler, and RemoveDragOverHandler" />
+      <MemberSignature Language="ILAsm" Value="see AddDragOverHandler, and RemoveDragOverHandler" />
+      <MemberSignature Language="DocId" Value="E:AttachedEventsAndProperties.AttachedEventExample.DragOver" />
+      <MemberType>AttachedEvent</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="DragOverEvent">
+      <MemberSignature Language="C#" Value="public static readonly System.Windows.RoutedEvent DragOverEvent;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.RoutedEvent DragOverEvent" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedEventExample.DragOverEvent" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.RoutedEvent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NeedsCleaning">
+      <MemberSignature Language="C#" Value="see AddNeedsCleaningHandler, and RemoveNeedsCleaningHandler" />
+      <MemberSignature Language="ILAsm" Value="see AddNeedsCleaningHandler, and RemoveNeedsCleaningHandler" />
+      <MemberSignature Language="DocId" Value="E:AttachedEventsAndProperties.AttachedEventExample.NeedsCleaning" />
+      <MemberType>AttachedEvent</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NeedsCleaning2Event">
+      <MemberSignature Language="C#" Value="public static readonly System.Windows.RoutedEvent NeedsCleaning2Event;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.RoutedEvent NeedsCleaning2Event" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedEventExample.NeedsCleaning2Event" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.RoutedEvent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NeedsCleaning3Event">
+      <MemberSignature Language="C#" Value="public static readonly System.Windows.RoutedEvent NeedsCleaning3Event;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.RoutedEvent NeedsCleaning3Event" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedEventExample.NeedsCleaning3Event" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.RoutedEvent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NeedsCleaning4Event">
+      <MemberSignature Language="C#" Value="public static readonly System.Windows.RoutedEvent NeedsCleaning4Event;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.RoutedEvent NeedsCleaning4Event" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedEventExample.NeedsCleaning4Event" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.RoutedEvent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NeedsCleaning5Event">
+      <MemberSignature Language="C#" Value="public readonly System.Windows.RoutedEvent NeedsCleaning5Event;" />
+      <MemberSignature Language="ILAsm" Value=".field public initonly class System.Windows.RoutedEvent NeedsCleaning5Event" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedEventExample.NeedsCleaning5Event" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.RoutedEvent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NeedsCleaning6Event6">
+      <MemberSignature Language="C#" Value="public static readonly System.Windows.RoutedEvent NeedsCleaning6Event6;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.RoutedEvent NeedsCleaning6Event6" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedEventExample.NeedsCleaning6Event6" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.RoutedEvent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="NeedsCleaningEvent">
+      <MemberSignature Language="C#" Value="public static readonly System.Windows.RoutedEvent NeedsCleaningEvent;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.RoutedEvent NeedsCleaningEvent" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedEventExample.NeedsCleaningEvent" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.RoutedEvent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RemoveDragOverHandler">
+      <MemberSignature Language="C#" Value="public static void RemoveDragOverHandler (System.Windows.DependencyObject element, System.Windows.DragEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void RemoveDragOverHandler(class System.Windows.DependencyObject element, class System.Windows.DragEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.RemoveDragOverHandler(System.Windows.DependencyObject,System.Windows.DragEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.DragEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RemoveNeedsCleaning3Handler">
+      <MemberSignature Language="C#" Value="public static void RemoveNeedsCleaning3Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void RemoveNeedsCleaning3Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.RemoveNeedsCleaning3Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RemoveNeedsCleaning4Handler">
+      <MemberSignature Language="C#" Value="protected static void RemoveNeedsCleaning4Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method familystatic hidebysig void RemoveNeedsCleaning4Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.RemoveNeedsCleaning4Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RemoveNeedsCleaning5Handler">
+      <MemberSignature Language="C#" Value="public void RemoveNeedsCleaning5Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void RemoveNeedsCleaning5Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.RemoveNeedsCleaning5Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RemoveNeedsCleaning6Handler">
+      <MemberSignature Language="C#" Value="public static void RemoveNeedsCleaning6Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void RemoveNeedsCleaning6Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.RemoveNeedsCleaning6Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RemoveNeedsCleaningHandler">
+      <MemberSignature Language="C#" Value="public static void RemoveNeedsCleaningHandler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void RemoveNeedsCleaningHandler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.RemoveNeedsCleaningHandler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AttachedPropertyExample.xml
+++ b/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AttachedPropertyExample.xml
@@ -1,0 +1,129 @@
+<Type Name="AttachedPropertyExample" FullName="AttachedEventsAndProperties.AttachedPropertyExample">
+  <TypeSignature Language="C#" Value="public static class AttachedPropertyExample" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi abstract sealed beforefieldinit AttachedPropertyExample extends System.Object" />
+  <TypeSignature Language="DocId" Value="T:AttachedEventsAndProperties.AttachedPropertyExample" />
+  <AssemblyInfo>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="GetIsBubbleSource">
+      <MemberSignature Language="C#" Value="public static bool GetIsBubbleSource (System.Windows.UIElement element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetIsBubbleSource(class System.Windows.UIElement element) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedPropertyExample.GetIsBubbleSource(System.Windows.UIElement)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="System.Windows.UIElement" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsBubbleSource">
+      <MemberSignature Language="C#" Value="see GetIsBubbleSource, and SetIsBubbleSource" />
+      <MemberSignature Language="ILAsm" Value="see GetIsBubbleSource, and SetIsBubbleSource" />
+      <MemberSignature Language="DocId" Value="P:AttachedEventsAndProperties.AttachedPropertyExample.IsBubbleSource" />
+      <MemberType>AttachedProperty</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsBubbleSource2Property">
+      <MemberSignature Language="C#" Value="public static readonly System.Windows.DependencyProperty IsBubbleSource2Property;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.DependencyProperty IsBubbleSource2Property" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedPropertyExample.IsBubbleSource2Property" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.DependencyProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsBubbleSourceProperty">
+      <MemberSignature Language="C#" Value="public static readonly System.Windows.DependencyProperty IsBubbleSourceProperty;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.DependencyProperty IsBubbleSourceProperty" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedPropertyExample.IsBubbleSourceProperty" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.DependencyProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetIsBubbleSource">
+      <MemberSignature Language="C#" Value="public static void SetIsBubbleSource (System.Windows.UIElement element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetIsBubbleSource(class System.Windows.UIElement element, bool value) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedPropertyExample.SetIsBubbleSource(System.Windows.UIElement,System.Boolean)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="System.Windows.UIElement" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetIsBubbleSource2">
+      <MemberSignature Language="C#" Value="public static void SetIsBubbleSource2 (System.Windows.UIElement element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetIsBubbleSource2(class System.Windows.UIElement element, bool value) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedPropertyExample.SetIsBubbleSource2(System.Windows.UIElement,System.Boolean)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="System.Windows.UIElement" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-attached-entities/System.Windows/DragEventArgs.xml
+++ b/mdoc/Test/en.expected-attached-entities/System.Windows/DragEventArgs.xml
@@ -1,0 +1,33 @@
+<Type Name="DragEventArgs" FullName="System.Windows.DragEventArgs">
+  <TypeSignature Language="C#" Value="public sealed class DragEventArgs : System.Windows.RoutedEventArgs" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed beforefieldinit DragEventArgs extends System.Windows.RoutedEventArgs" />
+  <TypeSignature Language="DocId" Value="T:System.Windows.DragEventArgs" />
+  <AssemblyInfo>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Windows.RoutedEventArgs</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public DragEventArgs ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="DocId" Value="M:System.Windows.DragEventArgs.#ctor" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-attached-entities/System.Windows/DragEventHandler.xml
+++ b/mdoc/Test/en.expected-attached-entities/System.Windows/DragEventHandler.xml
@@ -1,0 +1,25 @@
+<Type Name="DragEventHandler" FullName="System.Windows.DragEventHandler">
+  <TypeSignature Language="C#" Value="public delegate void DragEventHandler(object sender, DragEventArgs e);" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed DragEventHandler extends System.MulticastDelegate" />
+  <TypeSignature Language="DocId" Value="T:System.Windows.DragEventHandler" />
+  <AssemblyInfo>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="sender" Type="System.Object" />
+    <Parameter Name="e" Type="System.Windows.DragEventArgs" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Void</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <param name="sender">To be added.</param>
+    <param name="e">To be added.</param>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-attached-entities/System.Windows/RoutedEvent.xml
+++ b/mdoc/Test/en.expected-attached-entities/System.Windows/RoutedEvent.xml
@@ -1,0 +1,33 @@
+<Type Name="RoutedEvent" FullName="System.Windows.RoutedEvent">
+  <TypeSignature Language="C#" Value="public class RoutedEvent" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit RoutedEvent extends System.Object" />
+  <TypeSignature Language="DocId" Value="T:System.Windows.RoutedEvent" />
+  <AssemblyInfo>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public RoutedEvent ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="DocId" Value="M:System.Windows.RoutedEvent.#ctor" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-attached-entities/System.Windows/RoutedEventArgs.xml
+++ b/mdoc/Test/en.expected-attached-entities/System.Windows/RoutedEventArgs.xml
@@ -1,0 +1,33 @@
+<Type Name="RoutedEventArgs" FullName="System.Windows.RoutedEventArgs">
+  <TypeSignature Language="C#" Value="public class RoutedEventArgs : EventArgs" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit RoutedEventArgs extends System.EventArgs" />
+  <TypeSignature Language="DocId" Value="T:System.Windows.RoutedEventArgs" />
+  <AssemblyInfo>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.EventArgs</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public RoutedEventArgs ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="DocId" Value="M:System.Windows.RoutedEventArgs.#ctor" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-attached-entities/System.Windows/RoutedEventHandler.xml
+++ b/mdoc/Test/en.expected-attached-entities/System.Windows/RoutedEventHandler.xml
@@ -1,0 +1,25 @@
+<Type Name="RoutedEventHandler" FullName="System.Windows.RoutedEventHandler">
+  <TypeSignature Language="C#" Value="public delegate void RoutedEventHandler(object sender, RoutedEventArgs e);" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi sealed RoutedEventHandler extends System.MulticastDelegate" />
+  <TypeSignature Language="DocId" Value="T:System.Windows.RoutedEventHandler" />
+  <AssemblyInfo>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters>
+    <Parameter Name="sender" Type="System.Object" />
+    <Parameter Name="e" Type="System.Windows.RoutedEventArgs" />
+  </Parameters>
+  <ReturnValue>
+    <ReturnType>System.Void</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <param name="sender">To be added.</param>
+    <param name="e">To be added.</param>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-attached-entities/System.Windows/UIElement.xml
+++ b/mdoc/Test/en.expected-attached-entities/System.Windows/UIElement.xml
@@ -1,0 +1,33 @@
+<Type Name="UIElement" FullName="System.Windows.UIElement">
+  <TypeSignature Language="C#" Value="public class UIElement : System.Windows.DependencyObject" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit UIElement extends System.Windows.DependencyObject" />
+  <TypeSignature Language="DocId" Value="T:System.Windows.UIElement" />
+  <AssemblyInfo>
+    <AssemblyName>AttachedEventsAndProperties</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Windows.DependencyObject</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public UIElement ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberSignature Language="DocId" Value="M:System.Windows.UIElement.#ctor" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-attached-entities/index.xml
+++ b/mdoc/Test/en.expected-attached-entities/index.xml
@@ -1,0 +1,69 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="AttachedEventsAndProperties" Version="1.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Reflection.AssemblyCompany("EPAM Systems")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Reflection.AssemblyConfiguration("")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Reflection.AssemblyCopyright("Copyright © EPAM Systems 2017")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Reflection.AssemblyDescription("")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Reflection.AssemblyFileVersion("1.0.0.0")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Reflection.AssemblyProduct("AttachedEventsAndProperties")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Reflection.AssemblyTitle("AttachedEventsAndProperties")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Reflection.AssemblyTrademark("")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.CompilationRelaxations(8)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.InteropServices.ComVisible(false)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.InteropServices.Guid("304fc0fd-45ef-46ed-a05d-42907b55c123")</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="AttachedEventsAndProperties">
+      <Type Name="AquariumFilter" Kind="Class" />
+      <Type Name="AquariumObject" Kind="Class" />
+      <Type Name="AttachedEventExample" Kind="Class" />
+      <Type Name="AttachedPropertyExample" Kind="Class" />
+    </Namespace>
+    <Namespace Name="System.Windows">
+      <Type Name="DragEventArgs" Kind="Class" />
+      <Type Name="DragEventHandler" Kind="Delegate" />
+      <Type Name="RoutedEvent" Kind="Class" />
+      <Type Name="RoutedEventArgs" Kind="Class" />
+      <Type Name="RoutedEventHandler" Kind="Delegate" />
+      <Type Name="UIElement" Kind="Class" />
+    </Namespace>
+  </Types>
+  <Title>AttachedEventsAndProperties</Title>
+</Overview>

--- a/mdoc/Test/en.expected-attached-entities/ns-AttachedEventsAndProperties.xml
+++ b/mdoc/Test/en.expected-attached-entities/ns-AttachedEventsAndProperties.xml
@@ -1,0 +1,6 @@
+<Namespace Name="AttachedEventsAndProperties">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-attached-entities/ns-System.Windows.xml
+++ b/mdoc/Test/en.expected-attached-entities/ns-System.Windows.xml
@@ -1,0 +1,6 @@
+<Namespace Name="System.Windows">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/mdoc.csproj
+++ b/mdoc/mdoc.csproj
@@ -91,6 +91,11 @@
     <Compile Include="Mono.Documentation\Updater\Statistics\StatisticsStorage.cs" />
     <Compile Include="Mono.Documentation\Util\ApiStyle.cs" />
     <Compile Include="Mono.Documentation\Updater\DocUtils.cs" />
+    <Compile Include="Mono.Documentation\Util\AttachedEventDefinition.cs" />
+    <Compile Include="Mono.Documentation\Util\AttachedEntitiesHelper.cs" />
+    <Compile Include="Mono.Documentation\Util\AttachedEventReference.cs" />
+    <Compile Include="Mono.Documentation\Util\AttachedPropertyDefinition.cs" />
+    <Compile Include="Mono.Documentation\Util\AttachedPropertyReference.cs" />
     <Compile Include="Mono.Documentation\Util\CecilExtensions.cs" />
     <Compile Include="Mono.Documentation\Util\NativeTypeManager.cs" />
     <Compile Include="Mono.Rocks\ObjectRocks.cs" />


### PR DESCRIPTION
Added AttachedEventReference, AttachedEventDefinition, AttachedPropertyReference, AttachedPropertyDefinition (equivalents of Cecil entities)
They are processed as any other Cecil entities
Added check-monodocer-attached-entities integration test
Closes #63