### PR TITLE
mdoc: fixed breaks in frameworks mode

### DIFF
--- a/mdoc/Mono.Documentation/Util/AttachedEntitiesHelper.cs
+++ b/mdoc/Mono.Documentation/Util/AttachedEntitiesHelper.cs
@@ -55,7 +55,7 @@ namespace Mono.Documentation.Util
         private static bool IsAttachedEvent(FieldDefinition field, Dictionary<string, IEnumerable<MethodDefinition>> methods)
         {
             // https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/attached-events-overview
-            if (!field.FieldType.Name.EndsWith(EventConst))
+            if (!field.Name.EndsWith(EventConst))
                 return false;
             var addMethodName = $"Add{GetEventName(field.Name)}Handler";
             var removeMethodName = $"Remove{GetEventName(field.Name)}Handler";

--- a/mdoc/Test/AttachedEventsAndProperties/AttachedEventExample.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/AttachedEventExample.cs
@@ -77,5 +77,15 @@ namespace AttachedEventsAndProperties
         {
         }
         #endregion 
+
+        #region Negative example (the event type ends with "Event", but the name doesn't)
+        public static readonly RoutedEvent E;
+        public static void AddNeedsCleaning7Handler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+        public static void RemoveNeedsCleaning7Handler(DependencyObject d, RoutedEventHandler handler)
+        {
+        }
+        #endregion 
     }
 }

--- a/mdoc/Test/AttachedEventsAndProperties/AttachedPropertyExample.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/AttachedPropertyExample.cs
@@ -39,6 +39,27 @@ namespace AttachedEventsAndProperties
             element.SetValue(IsBubbleSourceProperty, value);
         }
         #endregion
+
+        #region Negative example (the property type ends with "Event", but the name doesn't)
+
+        public static readonly DependencyProperty P = DependencyProperty.RegisterAttached(
+  "IsBubbleSource3",
+  typeof(Boolean),
+  typeof(AquariumObject),
+  null
+);
+
+        public static void SetIsBubbleSource3(UIElement element, Boolean value)
+        {
+            element.SetValue(IsBubbleSourceProperty, value);
+        }
+
+        public static Boolean GetIsBubbleSource3(UIElement element)
+        {
+            return (Boolean)element.GetValue(IsBubbleSourceProperty);
+        }
+
+        #endregion
     }
 
 }

--- a/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AttachedEventExample.xml
+++ b/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AttachedEventExample.xml
@@ -139,6 +139,28 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="AddNeedsCleaning7Handler">
+      <MemberSignature Language="C#" Value="public static void AddNeedsCleaning7Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void AddNeedsCleaning7Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.AddNeedsCleaning7Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="AddNeedsCleaningHandler">
       <MemberSignature Language="C#" Value="public static void AddNeedsCleaningHandler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void AddNeedsCleaningHandler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
@@ -178,6 +200,22 @@
       <MemberSignature Language="C#" Value="public static readonly System.Windows.RoutedEvent DragOverEvent;" />
       <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.RoutedEvent DragOverEvent" />
       <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedEventExample.DragOverEvent" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.RoutedEvent</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="E">
+      <MemberSignature Language="C#" Value="public static readonly System.Windows.RoutedEvent E;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.RoutedEvent E" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedEventExample.E" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -391,6 +429,28 @@
       <MemberSignature Language="C#" Value="public static void RemoveNeedsCleaning6Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void RemoveNeedsCleaning6Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
       <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.RemoveNeedsCleaning6Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="d" Type="System.Windows.DependencyObject" />
+        <Parameter Name="handler" Type="System.Windows.RoutedEventHandler" />
+      </Parameters>
+      <Docs>
+        <param name="d">To be added.</param>
+        <param name="handler">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="RemoveNeedsCleaning7Handler">
+      <MemberSignature Language="C#" Value="public static void RemoveNeedsCleaning7Handler (System.Windows.DependencyObject d, System.Windows.RoutedEventHandler handler);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void RemoveNeedsCleaning7Handler(class System.Windows.DependencyObject d, class System.Windows.RoutedEventHandler handler) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedEventExample.RemoveNeedsCleaning7Handler(System.Windows.DependencyObject,System.Windows.RoutedEventHandler)" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AttachedPropertyExample.xml
+++ b/mdoc/Test/en.expected-attached-entities/AttachedEventsAndProperties/AttachedPropertyExample.xml
@@ -36,6 +36,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="GetIsBubbleSource3">
+      <MemberSignature Language="C#" Value="public static bool GetIsBubbleSource3 (System.Windows.UIElement element);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig bool GetIsBubbleSource3(class System.Windows.UIElement element) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedPropertyExample.GetIsBubbleSource3(System.Windows.UIElement)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Boolean</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="System.Windows.UIElement" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="IsBubbleSource">
       <MemberSignature Language="C#" Value="see GetIsBubbleSource, and SetIsBubbleSource" />
       <MemberSignature Language="ILAsm" Value="see GetIsBubbleSource, and SetIsBubbleSource" />
@@ -81,6 +102,22 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="P">
+      <MemberSignature Language="C#" Value="public static readonly System.Windows.DependencyProperty P;" />
+      <MemberSignature Language="ILAsm" Value=".field public static initonly class System.Windows.DependencyProperty P" />
+      <MemberSignature Language="DocId" Value="F:AttachedEventsAndProperties.AttachedPropertyExample.P" />
+      <MemberType>Field</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Windows.DependencyProperty</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="SetIsBubbleSource">
       <MemberSignature Language="C#" Value="public static void SetIsBubbleSource (System.Windows.UIElement element, bool value);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetIsBubbleSource(class System.Windows.UIElement element, bool value) cil managed" />
@@ -107,6 +144,28 @@
       <MemberSignature Language="C#" Value="public static void SetIsBubbleSource2 (System.Windows.UIElement element, bool value);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetIsBubbleSource2(class System.Windows.UIElement element, bool value) cil managed" />
       <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedPropertyExample.SetIsBubbleSource2(System.Windows.UIElement,System.Boolean)" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="element" Type="System.Windows.UIElement" />
+        <Parameter Name="value" Type="System.Boolean" />
+      </Parameters>
+      <Docs>
+        <param name="element">To be added.</param>
+        <param name="value">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="SetIsBubbleSource3">
+      <MemberSignature Language="C#" Value="public static void SetIsBubbleSource3 (System.Windows.UIElement element, bool value);" />
+      <MemberSignature Language="ILAsm" Value=".method public static hidebysig void SetIsBubbleSource3(class System.Windows.UIElement element, bool value) cil managed" />
+      <MemberSignature Language="DocId" Value="M:AttachedEventsAndProperties.AttachedPropertyExample.SetIsBubbleSource3(System.Windows.UIElement,System.Boolean)" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>


### PR DESCRIPTION
On the first phase of attached event check, we had to check name, not type
Added integration test on this case

Closes #174