### PR TITLE
[mdoc] Fixed StackOverflow in F# and exception in members implementations

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Formatters/FSharpFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/FSharpFormatter.cs
@@ -397,6 +397,8 @@ namespace Mono.Documentation.Updater
 
         private void AppendConstraints(StringBuilder buf, IList<GenericParameter> genArgs)
         {
+            var origMemberFormatterState = MemberFormatterState;
+            MemberFormatterState = MemberFormatterState.WithinGenericTypeParameters;
             List<string> constraintStrings = new List<string>();
 
             foreach (GenericParameter genArg in genArgs.Where(i => !IsFlexibleType(i)))
@@ -440,6 +442,7 @@ namespace Mono.Documentation.Updater
             {
                 buf.Append($" (requires {string.Join(" and ", constraintStrings)})");
             }
+            MemberFormatterState = origMemberFormatterState;
         }
 
         protected override string GetConstructorDeclaration(MethodDefinition constructor)

--- a/mdoc/Test/TestInterfaceImplementation/IScorable.cs
+++ b/mdoc/Test/TestInterfaceImplementation/IScorable.cs
@@ -1,0 +1,7 @@
+namespace TestInterfaceImplementation
+{
+    public interface IScorable<Item, Score>
+    {
+        Score GetScore(Item item, object state);
+    }
+}

--- a/mdoc/Test/TestInterfaceImplementation/ScorableBase.cs
+++ b/mdoc/Test/TestInterfaceImplementation/ScorableBase.cs
@@ -1,0 +1,11 @@
+namespace TestInterfaceImplementation
+{
+    public class ScorableBase<Item, State, Score> : IScorable<Item, Score>
+    {
+        Score IScorable<Item, Score>.GetScore(Item item, object opaque)
+        {
+            throw new System.NotImplementedException();
+        }
+
+    }
+}

--- a/mdoc/Test/TestInterfaceImplementation/TestInterfaceImplementation.csproj
+++ b/mdoc/Test/TestInterfaceImplementation/TestInterfaceImplementation.csproj
@@ -55,7 +55,9 @@
     <Compile Include="Interface5.cs" />
     <Compile Include="Interface6.cs" />
     <Compile Include="Interface7.cs" />
+    <Compile Include="IScorable.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ScorableBase.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class2_2`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class2_2`1.xml
@@ -1,0 +1,46 @@
+<Type Name="Constraints+Class2_2&lt;T&gt;" FullName="Constraints+Class2_2&lt;T&gt;">
+  <TypeSignature Language="C#" Value="public class Constraints.Class2_2&lt;T&gt; where T : IComparable, IEnumerable&lt;T&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi serializable beforefieldinit Constraints/Class2_2`1&lt;(class System.IComparable, class System.Collections.Generic.IEnumerable`1&lt;!T&gt;) T&gt; extends System.Object" />
+  <TypeSignature Language="F#" Value="type Constraints.Class2_2&lt;'T (requires 'T :&gt; IComparable and 'T :&gt; seq&lt;'T&gt;)&gt; = class" />
+  <AssemblyInfo>
+    <AssemblyName>mdoc.Test.FSharp</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="T">
+      <Constraints>
+        <InterfaceName>System.IComparable</InterfaceName>
+        <InterfaceName>System.Collections.Generic.IEnumerable&lt;T&gt;</InterfaceName>
+      </Constraints>
+    </TypeParameter>
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <typeparam name="T">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Class2_2 ();" />
+      <MemberSignature Language="ILAsm" Value=".method public specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-fsharp/index.xml
+++ b/mdoc/Test/en.expected-fsharp/index.xml
@@ -84,6 +84,7 @@
       <Type Name="Constraints+Class17" Kind="Class" />
       <Type Name="Constraints+Class18" Kind="Class" />
       <Type Name="Constraints+Class2_1`1" DisplayName="Constraints+Class2_1&lt;T&gt;" Kind="Class" />
+      <Type Name="Constraints+Class2_2`1" DisplayName="Constraints+Class2_2&lt;T&gt;" Kind="Class" />
       <Type Name="Constraints+Class2`1" DisplayName="Constraints+Class2&lt;T&gt;" Kind="Class" />
       <Type Name="Constraints+Class3`1" DisplayName="Constraints+Class3&lt;T&gt;" Kind="Class" />
       <Type Name="Constraints+Class4`1" DisplayName="Constraints+Class4&lt;T&gt;" Kind="Class" />

--- a/mdoc/Test/en.expected.members-implementation/TestInterfaceImplementation/IScorable`2.xml
+++ b/mdoc/Test/en.expected.members-implementation/TestInterfaceImplementation/IScorable`2.xml
@@ -1,0 +1,43 @@
+<Type Name="IScorable&lt;Item,Score&gt;" FullName="TestInterfaceImplementation.IScorable&lt;Item,Score&gt;">
+  <TypeSignature Language="C#" Value="public interface IScorable&lt;Item,Score&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public interface auto ansi abstract IScorable`2&lt;Item, Score&gt;" />
+  <AssemblyInfo>
+    <AssemblyName>TestInterfaceImplementation</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="Item" />
+    <TypeParameter Name="Score" />
+  </TypeParameters>
+  <Interfaces />
+  <Docs>
+    <typeparam name="Item">To be added.</typeparam>
+    <typeparam name="Score">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="GetScore">
+      <MemberSignature Language="C#" Value="public Score GetScore (Item item, object state);" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance !Score GetScore(!Item item, object state) cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Score</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="Item" />
+        <Parameter Name="state" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="item">To be added.</param>
+        <param name="state">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected.members-implementation/TestInterfaceImplementation/ScorableBase`3.xml
+++ b/mdoc/Test/en.expected.members-implementation/TestInterfaceImplementation/ScorableBase`3.xml
@@ -1,0 +1,68 @@
+<Type Name="ScorableBase&lt;Item,State,Score&gt;" FullName="TestInterfaceImplementation.ScorableBase&lt;Item,State,Score&gt;">
+  <TypeSignature Language="C#" Value="public class ScorableBase&lt;Item,State,Score&gt; : TestInterfaceImplementation.IScorable&lt;Item,Score&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit ScorableBase`3&lt;Item, State, Score&gt; extends System.Object implements class TestInterfaceImplementation.IScorable`2&lt;!Item, !Score&gt;" />
+  <AssemblyInfo>
+    <AssemblyName>TestInterfaceImplementation</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="Item" />
+    <TypeParameter Name="State" />
+    <TypeParameter Name="Score" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>TestInterfaceImplementation.IScorable&lt;Item,Score&gt;</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Docs>
+    <typeparam name="Item">To be added.</typeparam>
+    <typeparam name="State">To be added.</typeparam>
+    <typeparam name="Score">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public ScorableBase ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="TestInterfaceImplementation.IScorable&lt;Item,Score&gt;.GetScore">
+      <MemberSignature Language="C#" Value="Score IScorable&lt;Item,Score&gt;.GetScore (Item item, object opaque);" />
+      <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance !Score TestInterfaceImplementation.IScorable&lt;Item,Score&gt;.GetScore(!Item item, object opaque) cil managed" />
+      <MemberType>Method</MemberType>
+      <Implements>
+        <InterfaceMember>M:TestInterfaceImplementation.IScorable`2.GetScore(`0,System.Object)</InterfaceMember>
+      </Implements>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>Score</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="item" Type="Item" />
+        <Parameter Name="opaque" Type="System.Object" />
+      </Parameters>
+      <Docs>
+        <param name="item">To be added.</param>
+        <param name="opaque">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected.members-implementation/index.xml
+++ b/mdoc/Test/en.expected.members-implementation/index.xml
@@ -66,6 +66,8 @@
       <Type Name="Interface5" Kind="Interface" />
       <Type Name="Interface6" Kind="Interface" />
       <Type Name="Interface7`1" DisplayName="Interface7&lt;T&gt;" Kind="Interface" />
+      <Type Name="IScorable`2" DisplayName="IScorable&lt;Item,Score&gt;" Kind="Interface" />
+      <Type Name="ScorableBase`3" DisplayName="ScorableBase&lt;Item,State,Score&gt;" Kind="Class" />
     </Namespace>
   </Types>
   <Title>TestInterfaceImplementation</Title>

--- a/mdoc/mdoc.Test/FSharp/FSharpFormatterTests.cs
+++ b/mdoc/mdoc.Test/FSharp/FSharpFormatterTests.cs
@@ -693,6 +693,12 @@ override this.Rotate : double -> unit",
 
         [Test]
         [Category("Constraints")]
+        public void TestConstraints_2_2() => 
+            TestTypeSignature(typeof(Constraints.Class2_2<>),
+                "type Constraints.Class2_2<'T (requires 'T :> IComparable and 'T :> seq<'T>)> = class");
+
+        [Test]
+        [Category("Constraints")]
         [Ignore("No constraint info in IL code")]
         public void TestConstraints_3() => 
             TestTypeSignature(typeof(Constraints.Class3<>),

--- a/mdoc/mdoc.Test/mdoc.Test.FSharp/Constraints.fs
+++ b/mdoc/mdoc.Test/mdoc.Test.FSharp/Constraints.fs
@@ -12,6 +12,10 @@ type Class2<'T when 'T :> System.IComparable>() =
 type Class2_1<'T when 'T :> System.IComparable and 'T :> System.Exception>() = 
     class end
 
+// Interface Type Constraint with recursion
+type Class2_2<'T when 'T :> System.IComparable and 'T :> seq<'T>>() = 
+    class end
+
 // Null constraint
 type Class3<'T when 'T : null>() =
     class end


### PR DESCRIPTION
StackOverflow in F# was caused by generic types constrained recursively by themselves (`'T :> seq<'T>`)
Added `TestConstraints_2_2` unit test

For members implementations generation, we shouldn't count on order of type generic arguments because they can be passed to interface reordered. Slightly remade generation of fingerprints.
Extended `check-monodocer-members-implementation` integration test with `IScrollable` and `ScrollableBase` classes