### PR TITLE
[mdoc] fix breaks with a key not found exception under when a class…

### DIFF
--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -2143,7 +2143,7 @@ namespace Mono.Documentation
             bool isExplicitlyImplemented = DocUtils.IsExplicitlyImplemented(mi);
 
             var fingerprint = DocUtils.GetFingerprint(mi);
-            if (!allImplementedMembers.ContainsKey(fingerprint) && !isExplicitlyImplemented)
+            if (!allImplementedMembers.ContainsKey(fingerprint))
             {
                 ClearElement(root, "Implements");
                 return;

--- a/mdoc/Test/TestInterfaceImplementation/Class6.cs
+++ b/mdoc/Test/TestInterfaceImplementation/Class6.cs
@@ -26,5 +26,7 @@ namespace TestInterfaceImplementation
         {
             throw new System.NotImplementedException();
         }
+
+        ~Class6() { }
     }
 }

--- a/mdoc/Test/en.expected.members-implementation/TestInterfaceImplementation/Class6`1.xml
+++ b/mdoc/Test/en.expected.members-implementation/TestInterfaceImplementation/Class6`1.xml
@@ -35,6 +35,22 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="Finalize">
+      <MemberSignature Language="C#" Value="~Class6`1 ();" />
+      <MemberSignature Language="ILAsm" Value=".method familyhidebysig virtual instance void Finalize() cil managed" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="Method1&lt;PPP&gt;">
       <MemberSignature Language="C#" Value="public int Method1&lt;PPP&gt; (F t, PPP p);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance int32 Method1&lt;PPP&gt;(!F t, !!PPP p) cil managed" />


### PR DESCRIPTION
…implements a destructor

Removed `!isExplicitlyImplemented` when we check if there is a fingerprint among implemented interfaces members:
```
            if (!allImplementedMembers.ContainsKey(fingerprint))
            {
                ClearElement(root, "Implements");
                return;
            }
```
Now explicitly implemented members have signatures in `allImplementedMembers` too.
Added a destructor method to Class6 in the integration test `check-monodocer-members-implementation`

Closes #158