### PR TITLE
mdoc: AttachedProperty is no longer generated if a 'real' property exists

### DIFF
--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -452,6 +452,11 @@ check-monodocer-attached-entities:
 	msbuild ../mdoc/Test/AttachedEventsAndProperties/AttachedEventsAndProperties.csproj -property:Configuration=Release
 	$(MONO) $(PROGRAM) update -o Test/en.actual Test/AttachedEventsAndProperties/bin/Release/AttachedEventsAndProperties.dll -lang docid -lang vb.net -lang fsharp
 	$(DIFF) Test/en.expected-attached-entities Test/en.actual
+
+	# now make sure it will delete a previously run/duplicated attachedproperty/property
+	cp Test/AttachedEventsAndProperties/AttachedPropertyExample.xml Test/en.actual/AttachedEventsAndProperties/
+	$(MONO) $(PROGRAM) update -o Test/en.actual Test/AttachedEventsAndProperties/bin/Release/AttachedEventsAndProperties.dll -lang docid -lang vb.net -lang fsharp
+	$(DIFF) Test/en.expected-attached-entities Test/en.actual
 	
 Test/TestClass.dll:
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ mdoc.Test/SampleClasses/Test*.cs

--- a/mdoc/Mono.Documentation/Util/AttachedEntitiesHelper.cs
+++ b/mdoc/Mono.Documentation/Util/AttachedEntitiesHelper.cs
@@ -124,7 +124,10 @@ namespace Mono.Documentation.Util
             var propertyName = GetPropertyName(field.Name);
             var getMethodName = $"Get{propertyName}";
             var setMethodName = $"Set{propertyName}";
-            return
+
+            var hasExistingProperty = field.DeclaringType.Properties.Any (p => p.Name.Equals (propertyName, System.StringComparison.Ordinal));
+
+            return !hasExistingProperty &&
                 // Class X has a static field of type DependencyProperty [Name]Property
                 field.FieldType.FullName == Consts.DependencyPropertyFullName
                 && field.IsPublic

--- a/mdoc/Test/AttachedEventsAndProperties/AttachedPropertyExample.cs
+++ b/mdoc/Test/AttachedEventsAndProperties/AttachedPropertyExample.cs
@@ -23,6 +23,26 @@ namespace AttachedEventsAndProperties
         {
             return (Boolean)element.GetValue(IsBubbleSourceProperty);
         }
+
+
+        public static readonly DependencyProperty IsDuplicatedProperty = DependencyProperty.RegisterAttached(
+  "IsDuplicated",
+  typeof(Boolean),
+  typeof(AquariumObject),
+  null
+);
+
+        public static void SetIsDuplicated(UIElement element, Boolean value)
+        {
+            element.SetValue(IsDuplicatedProperty, value);
+        }
+
+        public static Boolean GetIsDuplicated(UIElement element)
+        {
+            return (Boolean)element.GetValue(IsDuplicatedProperty);
+        }
+        public static bool IsDuplicated {get;set;}
+        
         #endregion
 
         #region negative example (no get method)

--- a/mdoc/Test/AttachedEventsAndProperties/AttachedPropertyExample.xml
+++ b/mdoc/Test/AttachedEventsAndProperties/AttachedPropertyExample.xml
@@ -138,6 +138,21 @@
       </Docs>
     </Member>
     <Member MemberName="IsDuplicated">
+      <MemberSignature Language="C#" Value="see GetIsDuplicated, and SetIsDuplicated" />
+      <MemberSignature Language="ILAsm" Value="see GetIsDuplicated, and SetIsDuplicated" />
+      <MemberSignature Language="DocId" Value="P:AttachedEventsAndProperties.AttachedPropertyExample.IsDuplicated" />
+      <MemberSignature Language="VB.NET" Value="see GetIsDuplicated, and SetIsDuplicated" />
+      <MemberSignature Language="F#" Value="see GetIsDuplicated, and SetIsDuplicated" Usage="see GetIsDuplicated, and SetIsDuplicated" />
+      <MemberType>AttachedProperty</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+    <Member MemberName="IsDuplicated">
       <MemberSignature Language="C#" Value="public static bool IsDuplicated { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property bool IsDuplicated" />
       <MemberSignature Language="DocId" Value="P:AttachedEventsAndProperties.AttachedPropertyExample.IsDuplicated" />


### PR DESCRIPTION
This is due to the fact that the DocID would be duplicated. Closes #193