### PR TITLE
mdoc improvements

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.6.3";
+		public static string MonoVersion = "5.6.4";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -2879,7 +2879,6 @@ namespace Mono.Documentation
             ReorderNodes (docs, children, DocsNodeOrder);
         }
 
-
         private void UpdateParameters (XmlElement e, string element, string[] values)
         {
             string parentElement = element == "typeparam" ? "TypeParameter" : "Parameter";
@@ -2891,13 +2890,6 @@ namespace Mono.Documentation
                 foreach (XmlElement paramnode in e.SelectNodes (element))
                 {
                     paramnode.SetAttribute ("name", paramnode.GetAttribute ("name").Trim ());
-                }
-
-                // If a member has only one parameter, we can track changes to
-                // the name of the parameter easily.
-                if (values.Length == 1 && e.SelectNodes (element).Count == 1)
-                {
-                    UpdateParameterName (e, (XmlElement)e.SelectSingleNode (element), values[0]);
                 }
 
                 bool reinsert = false;

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1234,6 +1234,10 @@ namespace Mono.Documentation
                         XmlDocument doc = new XmlDocument ();
                         doc.Load (typefile.FullName);
                         XmlElement e = doc.SelectSingleNode ("/Type") as XmlElement;
+                        if (e == null) {
+                            Warning ($"{typefile.FullName} is not an EcmaXML type file.");
+                            continue;
+                        }
                         var typeFullName = e.GetAttribute("FullName");
                         var assemblyNameNode = doc.SelectSingleNode ("/Type/AssemblyInfo/AssemblyName");
                         if (assemblyNameNode == null)

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.6.3</version>
+    <version>5.6.4</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
This PR fixes two issues:

- An issue caused by non-EcmaXML metadata being stored in the same directory ... mdoc no longer crashes on the presence of those files.
- #222, an issue where a `FrameworkAlternate` on a single parameter method, didn't show the alternate `param`