### PR TITLE
mdoc: Fixed tuple class incorrect representation

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Formatters/FSharpFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/FSharpFormatter.cs
@@ -229,7 +229,8 @@ namespace Mono.Documentation.Updater
             foreach (var interfaceImplementation in type.Interfaces)
             {
                 if (type.IsValueType
-                    && ignoredValueTypeInterfaces.Any(i => interfaceImplementation.InterfaceType.FullName.StartsWith(i)))
+                    && ignoredValueTypeInterfaces.Any(i => interfaceImplementation.InterfaceType.FullName.StartsWith(i))
+                    || interfaceImplementation.InterfaceType.Resolve().IsNotPublic)
                     continue;
                 buf.Append($"{GetLineEnding()}{Consts.Tab}interface ");
                 AppendTypeName(buf, GetTypeName(interfaceImplementation.InterfaceType));
@@ -318,7 +319,10 @@ namespace Mono.Documentation.Updater
                 }
                 insertNested = true;
 
-                bool isTuple = IsTuple(type);
+                bool isTuple = IsTuple(type)
+                               // If this is a declaration of `Tuple` type
+                               // treat it as an ordinary type
+                               && !(type is TypeDefinition);
                 bool isFSharpFunction = IsFSharpFunction(type);
                 if (!isTuple && !isFSharpFunction)
                     AppendTypeName(buf, declDef, context);

--- a/mdoc/mdoc.Test/FSharp/FSharpFormatterTests.cs
+++ b/mdoc/mdoc.Test/FSharp/FSharpFormatterTests.cs
@@ -252,7 +252,17 @@ namespace mdoc.Test
         public void TypeSignature_Delegate_12() =>
             TestTypeSignature(typeof(Delegates.Delegate13),
                 @"type Delegates.Delegate13 = delegate of (int -> char -> string -> decimal) -> double");
-
+        
+        [Test]
+        [Category("Types")]
+        [Category("Tuples")]
+        public void TypeSignature_Tuple() =>
+            TestTypeSignature(typeof(Tuple<,,,>),
+                @"type Tuple<'T1, 'T2, 'T3, 'T4> = class
+    interface IStructuralEquatable
+    interface IStructuralComparable
+    interface IComparable
+    interface ITuple");
         #endregion
 
         #region Functions


### PR DESCRIPTION
Added: if this is a declaration of Tuple class, treat it as an ordinary type (don't skip name)
Added a unit test for Tupple class declaration
Added skip of not public interfaces

Closes #206