### PR TITLE
PR - fix integration tests

### DIFF
--- a/mdoc/mdoc.Test/FSharp/FSharpFormatterTests.cs
+++ b/mdoc/mdoc.Test/FSharp/FSharpFormatterTests.cs
@@ -640,6 +640,8 @@ override this.Rotate : double -> unit",
         public void TypeSignature_Map() =>
             TestTypeSignature(typeof(FSharpMap<,>),
 @"type Map<'Key, 'Value> = class
+    interface IReadOnlyDictionary<'Key, 'Value>
+    interface IReadOnlyCollection<KeyValuePair<'Key, 'Value>>
     interface IComparable
     interface ICollection<KeyValuePair<'Key, 'Value>>
     interface IDictionary<'Key, 'Value>

--- a/mdoc/mdoc.Test/mdoc.Test.FSharp/mdoc.Test.FSharp.fsproj
+++ b/mdoc/mdoc.Test/mdoc.Test.FSharp/mdoc.Test.FSharp.fsproj
@@ -94,12 +94,10 @@
     <Compile Include="Library1.fs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib" />
     <Reference Include="FSharp.Core">
-      <Name>FSharp.Core</Name>
-      <AssemblyName>FSharp.Core.dll</AssemblyName>
-      <HintPath>$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\$(TargetFSharpCoreVersion)\FSharp.Core.dll</HintPath>
+      <HintPath>..\..\..\packages\FSharp.Core.4.3.4\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/mdoc/mdoc.Test/mdoc.Test.FSharp/packages.config
+++ b/mdoc/mdoc.Test/mdoc.Test.FSharp/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FSharp.Core" version="4.3.4" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.3.1" targetFramework="net461" />
 </packages>

--- a/mdoc/mdoc.Test/mdoc.Test.csproj
+++ b/mdoc/mdoc.Test/mdoc.Test.csproj
@@ -28,7 +28,10 @@
     <RunPostBuildEvent>Always</RunPostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core, Version=4.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="FSharp.Core, Version=4.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FSharp.Core.4.3.4\lib\net45\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mdoc.Test.Cplusplus, Version=1.0.6544.28971, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\external\Test\mdoc.Test.Cplusplus.dll</HintPath>
@@ -92,7 +95,9 @@
     <Compile Include="XmlUpdateTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="cppcli\cppcli\cppcli.h">
       <Link>SampleClasses\cppcli.h</Link>
     </None>
@@ -111,7 +116,9 @@
       <Name>mdoc.Test.FSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup />
   <ItemGroup>
     <Content Include="cppcli\Debug\cppcli.dll">

--- a/mdoc/mdoc.Test/packages.config
+++ b/mdoc/mdoc.Test/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net461" />
+  <package id="FSharp.Core" version="4.3.4" targetFramework="net461" />
   <package id="Mono.Cecil" version="0.10.0-beta5" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
We met some issue with running integration tests - with a newer version of Docker, a newer version of Ubuntu is installed (currently we have VERSION="16.04.4 LTS (Xenial Xerus)").
On this version, there are troubles with Fsharp library restore. This is the reason for failed integration tests.

We looked for some solutions and found one - grab F-sharp lib from Nuget. This helped us and for now, all integration tests are passed.

@joelmartinez could you please review the fix and merge it?