### PR TITLE
Special treatment of ref-like structs to not produce Obsolete attribute

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -23,5 +23,6 @@ namespace Mono.Documentation
 		public const string DependencyPropertyFullName = "System.Windows.DependencyProperty";
 		public const string DependencyObjectFullName = "System.Windows.DependencyObject";
 		public const string VoidFullName = "System.Void";
+		public const string RefTypeObsoleteString = "Types with embedded references are not supported in this version of your compiler.";
     }
 }

--- a/mdoc/mdoc.Test/BasicFormatterTests.cs
+++ b/mdoc/mdoc.Test/BasicFormatterTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
 using Mono.Documentation.Updater;
@@ -7,11 +6,8 @@ using NUnit.Framework;
 
 namespace mdoc.Test
 {
-    public abstract class BasicFormatterTests<T> where T : MemberFormatter
+    public abstract class BasicFormatterTests<T> : BasicTests where T : MemberFormatter
     {
-        protected Dictionary<string, ModuleDefinition> moduleCash = new Dictionary<string, ModuleDefinition>();
-        protected Dictionary<string, TypeDefinition> typesCash = new Dictionary<string, TypeDefinition>();
-
         protected abstract T formatter { get; }
 
         protected MethodDefinition GetMethod(Type type, Func<MethodDefinition, bool> query)
@@ -35,38 +31,6 @@ namespace mdoc.Test
             if (member == null)
                 throw new Exception("Did not find the member in the test class");
             return member;
-        }
-
-        protected TypeDefinition GetType(string filepath, string classname)
-        {
-            if (typesCash.ContainsKey(classname))
-                return typesCash[classname];
-            
-
-            if (!moduleCash.ContainsKey(filepath))
-            {
-                var readModule = ModuleDefinition.ReadModule(filepath);
-                moduleCash.Add(filepath, readModule);
-            }
-
-            var module = moduleCash[filepath];
-            var types = module.GetTypes();
-            var testclass = types
-                .SingleOrDefault(t => t.FullName == classname);
-            if (testclass == null)
-            {
-                throw new Exception($"Test was unable to find type {classname}");
-            }
-
-            var typeDef = testclass.Resolve();
-            typesCash.Add(classname, typeDef);
-            return typeDef;
-        }
-
-        protected virtual TypeDefinition GetType(Type type)
-        {
-            var moduleName = type.Module.FullyQualifiedName;
-            return GetType(moduleName, type.FullName);
         }
 
         protected MemberReference GetProperty(TypeDefinition type, string memberName)
@@ -204,5 +168,4 @@ namespace mdoc.Test
             return s?.Replace("\r\n", MemberFormatter.GetLineEnding());
         }
     }
-
 }

--- a/mdoc/mdoc.Test/BasicTests.cs
+++ b/mdoc/mdoc.Test/BasicTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+
+namespace mdoc.Test
+{
+    public class BasicTests
+    {
+        protected Dictionary<string, ModuleDefinition> moduleCash = new Dictionary<string, ModuleDefinition>();
+        protected Dictionary<string, TypeDefinition> typesCash = new Dictionary<string, TypeDefinition>();
+
+        protected TypeDefinition GetType(string filepath, string classname)
+        {
+            if (typesCash.ContainsKey(classname))
+                return typesCash[classname];
+
+
+            if (!moduleCash.ContainsKey(filepath))
+            {
+                var readModule = ModuleDefinition.ReadModule(filepath);
+                moduleCash.Add(filepath, readModule);
+            }
+
+            var module = moduleCash[filepath];
+            var types = module.GetTypes();
+            var testclass = types
+                .SingleOrDefault(t => t.FullName == classname);
+            if (testclass == null)
+            {
+                throw new Exception($"Test was unable to find type {classname}");
+            }
+
+            var typeDef = testclass.Resolve();
+            typesCash.Add(classname, typeDef);
+            return typeDef;
+        }
+
+        protected virtual TypeDefinition GetType(Type type)
+        {
+            var moduleName = type.Module.FullyQualifiedName;
+            return GetType(moduleName, type.FullName);
+        }
+    }
+}

--- a/mdoc/mdoc.Test/MDocUpdaterTests.cs
+++ b/mdoc/mdoc.Test/MDocUpdaterTests.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using Mono.Cecil;
+using Mono.Collections.Generic;
+using Mono.Documentation;
+using NUnit.Framework;
+
+namespace mdoc.Test
+{
+    [TestFixture]
+    public class MDocUpdaterTests : BasicTests
+    {
+        readonly MDocUpdater updater = new MDocUpdater();
+
+        [Test]
+        public void Test_GetCustomAttributes_IgnoredObsoleteAttribute()
+        {
+            TypeDefinition testType = GetType(typeof(MDocUpdaterTests).Module.FullyQualifiedName, "System.Span`1");
+            Collection<CustomAttribute> attributes = testType.CustomAttributes;
+
+            IEnumerable<string> customAttributes = updater.GetCustomAttributes(attributes, "");
+
+            Assert.AreEqual(1, attributes.Count);
+            Assert.IsEmpty(customAttributes);
+        }
+    }
+}

--- a/mdoc/mdoc.Test/SampleClasses/Span.cs
+++ b/mdoc/mdoc.Test/SampleClasses/Span.cs
@@ -1,0 +1,9 @@
+﻿using Mono.Documentation;
+
+namespace System
+{
+    [Obsolete(Consts.RefTypeObsoleteString, true)]
+    public struct Span<T>
+    {
+    }
+}

--- a/mdoc/mdoc.Test/mdoc.Test.csproj
+++ b/mdoc/mdoc.Test/mdoc.Test.csproj
@@ -66,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicFormatterTests.cs" />
+    <Compile Include="BasicTests.cs" />
     <Compile Include="CppWinRtMembersTests.cs" />
     <Compile Include="CppWinRtFormatterTests.cs" />
     <Compile Include="FSharp\BasicFSharpFormatterTests.cs" />
@@ -78,7 +79,9 @@
     <Compile Include="FSharp\FSharpUsageFormatterTests.cs" />
     <Compile Include="JsMemberFormatterTests.cs" />
     <Compile Include="JsUsageFormatterTests.cs" />
+    <Compile Include="MDocUpdaterTests.cs" />
     <Compile Include="SampleClasses\SomeDelegate.cs" />
+    <Compile Include="SampleClasses\Span.cs" />
     <Compile Include="SampleClasses\TestClass.cs" />
     <Compile Include="SampleClasses\SomeGenericClass.cs" />
     <Compile Include="SampleClasses\WebHostHiddenTestClass.cs" />
@@ -90,6 +93,7 @@
     <Compile Include="SampleClasses\TestClassTwo.cs" />
     <Compile Include="SampleClasses\SomeStruct.cs" />
     <Compile Include="SampleClasses\WebHostHiddenAttribute.cs" />
+    <Compile Include="StatisticsTests.cs" />
     <Compile Include="VBFormatterTests.cs" />
     <Compile Include="FrameworkAlternateTests.cs" />
     <Compile Include="XmlUpdateTests.cs" />


### PR DESCRIPTION
Added a unit test for MDocUpdater.GetCustomAttributes
Added logic to skip the attribute `Obsolete`
Changed test classes hierarchy

Closes #225