### PR TITLE
Fixed unit test that failed on mac.

### DIFF
--- a/mdoc/Test/en.expected-fsharp/Collections+MDocInterface`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Collections+MDocInterface`1.xml
@@ -1,0 +1,24 @@
+<Type Name="Collections+MDocInterface&lt;key&gt;" FullName="Collections+MDocInterface&lt;key&gt;">
+  <TypeSignature Language="C#" Value="public interface Collections.MDocInterface&lt;key&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class nested public interface auto ansi abstract serializable Collections/MDocInterface`1&lt;key&gt;" />
+  <TypeSignature Language="F#" Value="type Collections.MDocInterface&lt;'key&gt; = interface" />
+  <AssemblyInfo>
+    <AssemblyName>mdoc.Test.FSharp</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="key" />
+  </TypeParameters>
+  <Interfaces />
+  <Attributes>
+    <Attribute>
+      <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <typeparam name="key">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members />
+</Type>

--- a/mdoc/Test/en.expected-fsharp/Collections+MDocTestMap`2.xml
+++ b/mdoc/Test/en.expected-fsharp/Collections+MDocTestMap`2.xml
@@ -1,0 +1,33 @@
+<Type Name="Collections+MDocTestMap&lt;Key,Value&gt;" FullName="Collections+MDocTestMap&lt;Key,Value&gt;">
+  <TypeSignature Language="C#" Value="public class Collections.MDocTestMap&lt;Key,Value&gt; : Collections.MDocInterface&lt;System.Collections.Generic.KeyValuePair&lt;Key,Value&gt;&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi serializable beforefieldinit Collections/MDocTestMap`2&lt;Key, Value&gt; extends System.Object implements Collections/MDocInterface`1&lt;valuetype System.Collections.Generic.KeyValuePair`2&lt;!Key, !Value&gt;&gt;" />
+  <TypeSignature Language="F#" Value="type Collections.MDocTestMap&lt;'Key, 'Value&gt; = class&#xA;    interface Collections.MDocInterface&lt;KeyValuePair&lt;'Key, 'Value&gt;&gt;" />
+  <AssemblyInfo>
+    <AssemblyName>mdoc.Test.FSharp</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name="Key" />
+    <TypeParameter Name="Value" />
+  </TypeParameters>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces>
+    <Interface>
+      <InterfaceName>Collections+MDocInterface&lt;System.Collections.Generic.KeyValuePair&lt;Key,Value&gt;&gt;</InterfaceName>
+    </Interface>
+  </Interfaces>
+  <Attributes>
+    <Attribute>
+      <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
+    </Attribute>
+  </Attributes>
+  <Docs>
+    <typeparam name="Key">To be added.</typeparam>
+    <typeparam name="Value">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members />
+</Type>

--- a/mdoc/Test/en.expected-fsharp/index.xml
+++ b/mdoc/Test/en.expected-fsharp/index.xml
@@ -72,6 +72,8 @@
       <Type Name="ClassMembers" Kind="Class" />
       <Type Name="ClassMembers+PointWithCounter" Kind="Class" />
       <Type Name="Collections" Kind="Class" />
+      <Type Name="Collections+MDocInterface`1" DisplayName="Collections+MDocInterface&lt;key&gt;" Kind="Interface" />
+      <Type Name="Collections+MDocTestMap`2" DisplayName="Collections+MDocTestMap&lt;Key,Value&gt;" Kind="Class" />
       <Type Name="Constraints" Kind="Class" />
       <Type Name="Constraints+Class1`1" DisplayName="Constraints+Class1&lt;T&gt;" Kind="Class" />
       <Type Name="Constraints+Class10`1" DisplayName="Constraints+Class10&lt;T&gt;" Kind="Class" />

--- a/mdoc/mdoc.Test/FSharp/FSharpFormatterTests.cs
+++ b/mdoc/mdoc.Test/FSharp/FSharpFormatterTests.cs
@@ -648,15 +648,9 @@ override this.Rotate : double -> unit",
         [Category("Types")]
         [Category("FSharpCore")]
         public void TypeSignature_Map() =>
-            TestTypeSignature(typeof(FSharpMap<,>),
-@"type Map<'Key, 'Value> = class
-    interface IReadOnlyDictionary<'Key, 'Value>
-    interface IReadOnlyCollection<KeyValuePair<'Key, 'Value>>
-    interface IComparable
-    interface ICollection<KeyValuePair<'Key, 'Value>>
-    interface IDictionary<'Key, 'Value>
-    interface IEnumerable
-    interface seq<KeyValuePair<'Key, 'Value>>");
+        TestTypeSignature(typeof(Collections.MDocTestMap<,>),
+                              @"type Collections.MDocTestMap<'Key, 'Value> = class
+    interface Collections.MDocInterface<KeyValuePair<'Key, 'Value>>");
 
         [Test]
         [Category("Types")]

--- a/mdoc/mdoc.Test/mdoc.Test.FSharp/Collections.fs
+++ b/mdoc/mdoc.Test/mdoc.Test.FSharp/Collections.fs
@@ -1,6 +1,18 @@
 ﻿module Collections
 open FSharp.Collections
+open System
+open System.Collections
+open System.Collections.Generic
 
 let f (x:Map<int, int>) = 0
 
 let f2 (x:seq<int>) = 0
+
+type MDocInterface<'key> = interface
+end
+
+type MDocTestMap<'Key, 'Value> = class
+    interface MDocInterface<KeyValuePair<'Key, 'Value>>
+
+
+end


### PR DESCRIPTION
Unit test was using FSharpMap, but the list of interfaces being implemented were different on my local install. So to avoid depending on the locally installed SDK, just added a test class that will be consistent to test against.