### PR TITLE
Fix check of ignored members

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -24,5 +24,7 @@ namespace Mono.Documentation
 		public const string DependencyObjectFullName = "System.Windows.DependencyObject";
 		public const string VoidFullName = "System.Void";
 		public const string RefTypeObsoleteString = "Types with embedded references are not supported in this version of your compiler.";
+		public const string CompilerGeneratedAttribute = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
+		public const string CompilationMappingAttribute = "Microsoft.FSharp.Core.CompilationMappingAttribute";
     }
 }

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -64,7 +64,7 @@ namespace Mono.Documentation
 
         private readonly List<string> CustomAttributeNamesToSkip = new List<string>()
         {
-            "System.Runtime.CompilerServices.CompilerGeneratedAttribute",
+            Consts.CompilerGeneratedAttribute,
             "System.Runtime.InteropServices.TypeIdentifierAttribute"
         };
 
@@ -313,7 +313,6 @@ namespace Mono.Documentation
                 // members that may exist only other frameworks before deleting them
                 Console.Write ("Creating frameworks cache: ");
                 FrameworkIndex cacheIndex = new FrameworkIndex (FrameworksPath);
-                string[] prefixesToAvoid = { "get_", "set_", "add_", "remove_", "raise_" };
                 foreach (var assemblySet in this.assemblies)
                 {
                     using (assemblySet)
@@ -325,7 +324,7 @@ namespace Mono.Documentation
                             foreach (var type in assembly.GetTypes ())
                             {
                                 var t = a.ProcessType (type);
-                                foreach (var member in type.GetMembers ().Where (m => !prefixesToAvoid.Any (pre => m.Name.StartsWith (pre, StringComparison.Ordinal))))
+                                foreach (var member in type.GetMembers ().Where (i => !DocUtils.IsIgnored(i)))
                                     t.ProcessMember (member);
                             }
                         }
@@ -3203,7 +3202,7 @@ namespace Mono.Documentation
 		// for decimal constants
 		"System.Runtime.CompilerServices.DecimalConstantAttribute",
 		// compiler generated code
-		"System.Runtime.CompilerServices.CompilerGeneratedAttribute",
+		Consts.CompilerGeneratedAttribute,
 		// more compiler generated code, e.g. iterator methods
 		"System.Diagnostics.DebuggerHiddenAttribute",
         "System.Runtime.CompilerServices.FixedBufferAttribute",

--- a/mdoc/Mono.Documentation/Updater/DocUtils.cs
+++ b/mdoc/Mono.Documentation/Updater/DocUtils.cs
@@ -12,7 +12,7 @@ using Mono.Documentation.Util;
 
 namespace Mono.Documentation.Updater
 {
-    static class DocUtils
+    public static class DocUtils
     {
         public static bool DoesNotHaveApiStyle (this XmlElement element, ApiStyle style)
         {
@@ -358,12 +358,26 @@ namespace Mono.Documentation.Updater
         /// </summary>
         public static bool IsIgnored(MemberReference mi)
         {
-            if (mi.Name.StartsWith("get_", StringComparison.Ordinal)) return true;
-            if (mi.Name.StartsWith("set_", StringComparison.Ordinal)) return true;
-            if (mi.Name.StartsWith("add_", StringComparison.Ordinal)) return true;
-            if (mi.Name.StartsWith("remove_", StringComparison.Ordinal)) return true;
-            if (mi.Name.StartsWith("raise_", StringComparison.Ordinal)) return true;
+            if (IsCompilerGenerated(mi))
+            {
+                if (mi.Name.StartsWith("get_", StringComparison.Ordinal)) return true;
+                if (mi.Name.StartsWith("set_", StringComparison.Ordinal)) return true;
+                if (mi.Name.StartsWith("add_", StringComparison.Ordinal)) return true;
+                if (mi.Name.StartsWith("remove_", StringComparison.Ordinal)) return true;
+                if (mi.Name.StartsWith("raise_", StringComparison.Ordinal)) return true;
+            }
+
             return false;
+        }
+
+        private static bool IsCompilerGenerated(MemberReference mi)
+        {
+            IMemberDefinition memberDefinition = mi.Resolve();
+            return memberDefinition.IsSpecialName
+                   || memberDefinition.CustomAttributes.Any(i =>
+                       i.AttributeType.FullName == Consts.CompilerGeneratedAttribute
+                       || i.AttributeType.FullName == Consts.CompilationMappingAttribute
+                   );
         }
 
         public static bool IsAvailablePropertyMethod(MethodDefinition method)

--- a/mdoc/Mono.Documentation/Updater/Formatters/FSharpFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/FSharpFormatter.cs
@@ -1012,7 +1012,7 @@ namespace Mono.Documentation.Updater
                                  ca => ca.GetDeclaringType() ==
                                        "System.Diagnostics.Contracts.ContractInvariantMethodAttribute"
                                        || ca.GetDeclaringType() ==
-                                       "System.Runtime.CompilerServices.CompilerGeneratedAttribute"))
+                                       Consts.CompilerGeneratedAttribute))
                             && AppendVisibility(new StringBuilder(), method) != null;
             }
 

--- a/mdoc/Mono.Documentation/Updater/Formatters/VBFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/VBFullMemberFormatter.cs
@@ -712,7 +712,7 @@ namespace Mono.Documentation.Updater
             }
             AppendModifiers(buf, e.AddMethod);
             if (e.AddMethod.CustomAttributes.All(
-                i => i.AttributeType.FullName != "System.Runtime.CompilerServices.CompilerGeneratedAttribute")
+                i => i.AttributeType.FullName != Consts.CompilerGeneratedAttribute)
                 && !e.DeclaringType.IsInterface)// There is no 'Custom' modifier in interfaces
             {
                 if (buf.Length > 0)

--- a/mdoc/Mono.Documentation/Util/ApiStyle.cs
+++ b/mdoc/Mono.Documentation/Util/ApiStyle.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mono.Documentation.Util
 {
-    enum ApiStyle
+    public enum ApiStyle
     {
         Classic,
         Unified

--- a/mdoc/Test/en.expected-fsharp/Functions.xml
+++ b/mdoc/Test/en.expected-fsharp/Functions.xml
@@ -433,6 +433,27 @@
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <Member MemberName="get_function">
+      <MemberSignature Language="C#" Value="public static int get_function (int x);" />
+      <MemberSignature Language="ILAsm" Value=".method public static int32 get_function(int32 x) cil managed" />
+      <MemberSignature Language="F#" Value="Functions.get_function : int -&gt; int" Usage="Functions.get_function x" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Int32</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name="x" Type="System.Int32" />
+      </Parameters>
+      <Docs>
+        <param name="x">To be added.</param>
+        <summary>To be added.</summary>
+        <returns>To be added.</returns>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
     <Member MemberName="h">
       <MemberSignature Language="C#" Value="public static Microsoft.FSharp.Core.FSharpFunc&lt;int,int&gt; h { get; }" />
       <MemberSignature Language="ILAsm" Value=".property class Microsoft.FSharp.Core.FSharpFunc`2&lt;int32, int32&gt; h" />

--- a/mdoc/mdoc.Test/BasicFormatterTests.cs
+++ b/mdoc/mdoc.Test/BasicFormatterTests.cs
@@ -10,20 +10,6 @@ namespace mdoc.Test
     {
         protected abstract T formatter { get; }
 
-        protected MethodDefinition GetMethod(Type type, Func<MethodDefinition, bool> query)
-        {
-            return GetMethod(GetType(type), query);
-        }
-
-        protected MethodDefinition GetMethod(TypeDefinition testclass, Func<MethodDefinition, bool> query)
-        {
-            var methods = testclass.Methods;
-            var member = methods.FirstOrDefault(query)?.Resolve();
-            if (member == null)
-                throw new Exception("Did not find the member in the test class");
-            return member;
-        }
-
         protected MethodDefinition GetProperty(TypeDefinition testclass, Func<MethodDefinition, bool> query)
         {
             var methods = testclass.Methods;

--- a/mdoc/mdoc.Test/BasicTests.cs
+++ b/mdoc/mdoc.Test/BasicTests.cs
@@ -41,5 +41,24 @@ namespace mdoc.Test
             var moduleName = type.Module.FullyQualifiedName;
             return GetType(moduleName, type.FullName);
         }
+
+        protected MethodDefinition GetMethod(TypeDefinition testclass, Func<MethodDefinition, bool> query)
+        {
+            var methods = testclass.Methods;
+            var member = methods.FirstOrDefault(query)?.Resolve();
+            if (member == null)
+                throw new Exception("Did not find the member in the test class");
+            return member;
+        }
+
+        protected MethodDefinition GetMethod(Type type, Func<MethodDefinition, bool> query)
+        {
+            return GetMethod(GetType(type), query);
+        }
+
+        protected MethodDefinition GetMethod(Type type, string name)
+        {
+            return GetMethod(GetType(type), i => i.Name == name);
+        }
     }
 }

--- a/mdoc/mdoc.Test/DocUtilsFSharpTests.cs
+++ b/mdoc/mdoc.Test/DocUtilsFSharpTests.cs
@@ -1,0 +1,44 @@
+﻿using Mono.Documentation.Updater;
+using NUnit.Framework;
+
+namespace mdoc.Test
+{
+    [TestFixture]
+    public class DocUtilsFSharpTests : BasicFSharpFormatterTests<FSharpFormatter>
+    {
+        protected override FSharpFormatter formatter { get; }
+        
+        [Test]
+        public void IsIgnored_GetMethodIsGeneratedByProperty_IsIgnoredTrue()
+        {
+            var method = GetMethod(typeof(DiscriminatedUnions.Shape.Circle),
+                "get_" + nameof(DiscriminatedUnions.Shape.Circle.radius));
+
+            var isIgnoredPropertyGeneratedMethod = DocUtils.IsIgnored(method);
+
+            Assert.IsTrue(isIgnoredPropertyGeneratedMethod);
+        }
+
+        [Test]
+        public void IsIgnored_GetMethodIsGeneratedByProperty2_IsIgnoredTrue()
+        {
+            var method = GetMethod(typeof(DiscriminatedUnions.SizeUnion),
+                "get_" + nameof(DiscriminatedUnions.SizeUnion.Large));
+
+            var isIgnoredPropertyGeneratedMethod = DocUtils.IsIgnored(method);
+
+            Assert.IsTrue(isIgnoredPropertyGeneratedMethod);
+        }
+
+        [Test]
+        public void IsIgnored_GetMethodIsNotGeneratedByProperty_IsIgnoredFalse()
+        {
+            var method = GetMethod(typeof(Functions),
+                nameof(Functions.get_function));
+
+            var isIgnoredPropertyGeneratedMethod = DocUtils.IsIgnored(method);
+
+            Assert.IsFalse(isIgnoredPropertyGeneratedMethod);
+        }
+    }
+}

--- a/mdoc/mdoc.Test/DocUtilsTests.cs
+++ b/mdoc/mdoc.Test/DocUtilsTests.cs
@@ -1,0 +1,50 @@
+﻿using mdoc.Test.SampleClasses;
+using Mono.Documentation.Updater;
+using NUnit.Framework;
+
+namespace mdoc.Test
+{
+    [TestFixture]
+    public class DocUtilsTests : BasicTests
+    {
+        [Test]
+        public void IsIgnored_MethodGeneratedByProperty_IsIgnoredTrue()
+        {
+            var method = GetMethod(typeof(SomeClass), "get_" + nameof(SomeClass.Property));
+
+            var isIgnoredPropertyGeneratedMethod = DocUtils.IsIgnored(method);
+
+            Assert.True(isIgnoredPropertyGeneratedMethod);
+        }
+
+        [Test]
+        public void IsIgnored_GetMethodIsNotGeneratedByProperty_IsIgnoredFalse()
+        {
+            var method = GetMethod(typeof(SomeClass), nameof(SomeClass.get_Method));
+
+            var isIgnoredPropertyGeneratedMethod = DocUtils.IsIgnored(method);
+
+            Assert.False(isIgnoredPropertyGeneratedMethod);
+        }
+
+        [Test]
+        public void IsIgnored_GetMethodInIterfaceIsGeneratedByProperty_IsIgnoredTrue()
+        {
+            var method = GetMethod(typeof(SomeInterface), "get_B");
+
+            var isIgnoredPropertyGeneratedMethod = DocUtils.IsIgnored(method);
+
+            Assert.IsTrue(isIgnoredPropertyGeneratedMethod);
+        }
+
+        [Test]
+        public void IsIgnored_SetMethodIsGeneratedByProperty_IsIgnoredTrue()
+        {
+            var method = GetMethod(typeof(SomeClass), "set_" +nameof(SomeClass.Property4));
+
+            var isIgnoredPropertyGeneratedMethod = DocUtils.IsIgnored(method);
+
+            Assert.IsTrue(isIgnoredPropertyGeneratedMethod);
+        }
+    }
+}

--- a/mdoc/mdoc.Test/SampleClasses/SomeClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/SomeClass.cs
@@ -89,6 +89,10 @@ namespace mdoc.Test.SampleClasses
         {
         }
 
+        public void get_Method()
+        {
+        }
+
         public event EventHandler<object> AppMemoryUsageIncreased;
         public static event EventHandler<object> StaticEvent;
         private static event EventHandler<object> PrivateEvent;

--- a/mdoc/mdoc.Test/SampleClasses/SomeInterface.cs
+++ b/mdoc/mdoc.Test/SampleClasses/SomeInterface.cs
@@ -1,0 +1,7 @@
+﻿namespace mdoc.Test.SampleClasses
+{
+    public interface SomeInterface
+    {
+        int B { get; set; }
+    }
+}

--- a/mdoc/mdoc.Test/mdoc.Test.FSharp/Functions.fs
+++ b/mdoc/mdoc.Test/mdoc.Test.FSharp/Functions.fs
@@ -21,6 +21,8 @@ let function11<'a> (x, y, z) (a, b) = ()
 let function12<'a> x (a, b, c, d, e) = ()
 let function13<'a> (a:'a) = ()
 
+let get_function x = x + 1
+
 let h = function1 >> function2
 let result5 = h 100
 

--- a/mdoc/mdoc.Test/mdoc.Test.csproj
+++ b/mdoc/mdoc.Test/mdoc.Test.csproj
@@ -69,6 +69,8 @@
     <Compile Include="BasicTests.cs" />
     <Compile Include="CppWinRtMembersTests.cs" />
     <Compile Include="CppWinRtFormatterTests.cs" />
+    <Compile Include="DocUtilsFSharpTests.cs" />
+    <Compile Include="DocUtilsTests.cs" />
     <Compile Include="FSharp\BasicFSharpFormatterTests.cs" />
     <Compile Include="CppCxFormatterMembersTests.cs" />
     <Compile Include="CppFormatterTests.cs" />
@@ -81,6 +83,7 @@
     <Compile Include="JsUsageFormatterTests.cs" />
     <Compile Include="MDocUpdaterTests.cs" />
     <Compile Include="SampleClasses\SomeDelegate.cs" />
+    <Compile Include="SampleClasses\SomeInterface.cs" />
     <Compile Include="SampleClasses\Span.cs" />
     <Compile Include="SampleClasses\TestClass.cs" />
     <Compile Include="SampleClasses\SomeGenericClass.cs" />


### PR DESCRIPTION
In `DocUtils.IsIgnored`, check if member is generated by a compiler before checking of prefixes

Closes #199