### PR TITLE
Attributes -> FrameworkAlternate support

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.0.1";
+		public static string MonoVersion = "5.7.1";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/Updater/Frameworks/AssemblySet.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/AssemblySet.cs
@@ -10,7 +10,7 @@ namespace Mono.Documentation.Updater.Frameworks
     /// <summary>
     /// Represents a set of assemblies that we want to document
     /// </summary>
-    class AssemblySet : IDisposable
+    public class AssemblySet : IDisposable
     {
         static readonly BaseAssemblyResolver resolver = new Frameworks.MDocResolver ();
         static IAssemblyResolver cachedResolver;
@@ -22,6 +22,23 @@ namespace Mono.Documentation.Updater.Frameworks
         HashSet<string> forwardedTypes = new HashSet<string> ();
         IEnumerable<string> importPaths;
         public IEnumerable<DocumentationImporter> Importers { get; private set; }
+
+		FrameworkEntry fx;
+        public FrameworkEntry Framework 
+		{
+			get => fx;
+            set 
+			{
+				fx = value;
+                fx.AddAssemblySet (this);
+			}
+		}
+
+        /// <summary>This is meant only for unit test access</summary>
+        public IDictionary<string, bool> AssemblyMapsPath
+        {
+            get => assemblyPathsMap;
+        }
 
         public AssemblySet (IEnumerable<string> paths) : this ("Default", paths, new string[0]) { }
 

--- a/mdoc/Mono.Documentation/Updater/Frameworks/FXUtils.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FXUtils.cs
@@ -7,20 +7,36 @@ namespace Mono.Documentation.Updater.Frameworks
     {
         public static string AddFXToList (string existingValue, string newFX)
         {
+            var cachedValue = GetCache (existingValue, newFX, CacheAction.Add);
+            if (!string.IsNullOrWhiteSpace (cachedValue))
+                return cachedValue;
+
             var splitValue = SplitList (existingValue);
             if (!splitValue.Contains (newFX)) splitValue.Add (newFX);
-            return JoinList (splitValue);
+            var returnVal = JoinList (splitValue);
+
+            SetCache (existingValue, newFX, returnVal, CacheAction.Add);
+
+            return returnVal;
         }
 
         public static string RemoveFXFromList (string existingValue, string FXToRemove)
         {
+            var cachedValue = GetCache (existingValue, FXToRemove, CacheAction.Remove);
+            if (!string.IsNullOrWhiteSpace (cachedValue))
+                return cachedValue;
+
             var splitValue = SplitList (existingValue);
             splitValue.Remove (FXToRemove);
-            return JoinList (splitValue);
+            var returnVal = JoinList (splitValue);
+
+            SetCache (existingValue, FXToRemove, returnVal, CacheAction.Remove);
+
+            return returnVal;
         }
 
         /// <summary>Returns a list of all previously processed frameworks (not including the current)</summary>
-        internal static string PreviouslyProcessedFXString (FrameworkTypeEntry typeEntry) 
+        internal static string PreviouslyProcessedFXString (FrameworkTypeEntry typeEntry)
         {
             if (typeEntry == null)
                 return string.Empty;
@@ -31,7 +47,7 @@ namespace Mono.Documentation.Updater.Frameworks
                 .Where (n => !string.IsNullOrWhiteSpace (n))
                 .ToArray ());
         }
-        
+
 
         static List<string> SplitList (string existingValue)
         {
@@ -44,5 +60,59 @@ namespace Mono.Documentation.Updater.Frameworks
         {
             return string.Join (";", splitValue.ToArray ());
         }
+
+        #region Framework String Cache Stuff
+
+        /// <summary>Cache for modified framework strings</summary>
+        static Dictionary<string, ValueTuple<Dictionary<string, string>, Dictionary<string, string>>> map = new Dictionary<string, ValueTuple<Dictionary<string, string>, Dictionary<string, string>>> ();
+        enum CacheAction { Add, Remove }
+
+        static string GetCache (string currentValue, string value, CacheAction action)
+        {
+            ValueTuple<Dictionary<string, string>, Dictionary<string, string>> cacheKey;
+            if (map.TryGetValue (currentValue, out cacheKey))
+            {
+                string cachedValue = string.Empty;
+                switch (action)
+                {
+                    case CacheAction.Add:
+                        cacheKey.Item1.TryGetValue (value, out cachedValue);
+                        break;
+                    case CacheAction.Remove:
+                        cacheKey.Item2.TryGetValue (value, out cachedValue);
+                        break;
+                }
+                return cachedValue;
+            }
+            return string.Empty;
+        }
+        static void SetCache (string currentValue, string value, string newValue, CacheAction action)
+        {
+            ValueTuple<Dictionary<string, string>, Dictionary<string, string>> outerCacheValue;
+            if (!map.TryGetValue (currentValue, out outerCacheValue))
+            {
+                outerCacheValue = new ValueTuple<Dictionary<string, string>, Dictionary<string, string>> (new Dictionary<string, string> (), new Dictionary<string, string> ());
+                map.Add (currentValue, outerCacheValue);
+            }
+
+            Dictionary<string, string> innerCacheContainer = null;
+            switch (action)
+            {
+                case CacheAction.Add:
+                    innerCacheContainer = outerCacheValue.Item1;
+                    break;
+                case CacheAction.Remove:
+                    innerCacheContainer = outerCacheValue.Item2;
+                    break;
+            }
+
+            if (!innerCacheContainer.ContainsKey (value))
+            {
+                innerCacheContainer.Add (value, newValue);
+            }
+
+        }
+
+        #endregion
     }
 }

--- a/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
@@ -15,10 +15,15 @@ namespace Mono.Documentation.Updater.Frameworks
 		List<FrameworkEntry> frameworks = new List<FrameworkEntry> ();
 		string path;
 
-		public FrameworkIndex (string pathToFrameworks) 
+		public FrameworkIndex (string pathToFrameworks, int fxCount) 
 		{
 			path = pathToFrameworks;
+            FrameworksCount = fxCount;
 		}
+
+        public int FrameworksCount {
+            get; private set;
+        }
 
 		public IList<FrameworkEntry> Frameworks {
 			get {
@@ -26,10 +31,13 @@ namespace Mono.Documentation.Updater.Frameworks
 			}
 		}
 
-        public FrameworkEntry StartProcessingAssembly (AssemblyDefinition assembly, IEnumerable<DocumentationImporter> importers, string Id, string Version) 
+        public FrameworkEntry StartProcessingAssembly (AssemblySet set, AssemblyDefinition assembly, IEnumerable<DocumentationImporter> importers, string Id, string Version) 
 		{
-			if (string.IsNullOrWhiteSpace (this.path))
-				return FrameworkEntry.Empty;
+            if (string.IsNullOrWhiteSpace (this.path))
+            {
+                set.Framework = FrameworkEntry.Empty;
+                return FrameworkEntry.Empty;
+            }
 
 			string assemblyPath = assembly.MainModule.FileName;
 			var frameworksDirectory = this.path.EndsWith ("frameworks.xml", StringComparison.OrdinalIgnoreCase)
@@ -42,9 +50,11 @@ namespace Mono.Documentation.Updater.Frameworks
 
 			var entry = frameworks.FirstOrDefault (f => f.Name.Equals (shortPath));
 			if (entry == null) {
-				entry = new FrameworkEntry (frameworks) { Name = shortPath, Importers = importers, Id = Id, Version = Version};
+                entry = new FrameworkEntry (frameworks, FrameworksCount) { Name = shortPath, Importers = importers, Id = Id, Version = Version};
 				frameworks.Add (entry);
 			}
+
+            set.Framework = entry;
 			return entry;
 		}
 

--- a/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkTypeEntry.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkTypeEntry.cs
@@ -36,7 +36,7 @@ namespace Mono.Documentation.Updater.Frameworks
                     {
                         previouslyProcessedFXTypes = new Lazy<FrameworkTypeEntry[]> (
                            () => this.Framework.Frameworks
-                               .Where (f => f.index < this.Framework.index)
+                               .Where (f => f.Index < this.Framework.Index)
                                 .Select (f => f.FindTypeEntry (this))
                                 .ToArray ()
                         );

--- a/mdoc/Test/DocTest-frameworkalternate.cs
+++ b/mdoc/Test/DocTest-frameworkalternate.cs
@@ -1,12 +1,18 @@
+using System;
+
 namespace Monodoc.Test 
 {
+    public class FirstAttribute : Attribute {}
+    public class SecondAttribute : Attribute {}
     public class MyClass
     {
         #if FXONE
+        [First]
         public void Meth(int a, string b, int c) {}
         #endif
 
         #if FXTWO
+        [First, Second]
         public void Meth(int a, string d, int c) {}
         #endif
     }

--- a/mdoc/Test/en.expected-cppcli/index.xml
+++ b/mdoc/Test/en.expected-cppcli/index.xml
@@ -2,20 +2,20 @@
   <Assemblies>
     <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/Test/en.expected-cppcx/index.xml
+++ b/mdoc/Test/en.expected-cppcx/index.xml
@@ -2,20 +2,20 @@
   <Assemblies>
     <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/Test/en.expected-cppwinrt/index.xml
+++ b/mdoc/Test/en.expected-cppwinrt/index.xml
@@ -2,20 +2,20 @@
   <Assemblies>
     <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/Test/en.expected-docid/index.xml
+++ b/mdoc/Test/en.expected-docid/index.xml
@@ -2,20 +2,20 @@
   <Assemblies>
     <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/Test/en.expected-frameworkalternate-aligned/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-frameworkalternate-aligned/FrameworksIndex/One.xml
@@ -1,9 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="One">
   <Namespace Name="Monodoc.Test">
+    <Type Name="Monodoc.Test.FirstAttribute" Id="T:Monodoc.Test.FirstAttribute">
+      <Member Id="M:Monodoc.Test.FirstAttribute.#ctor" />
+    </Type>
     <Type Name="Monodoc.Test.MyClass" Id="T:Monodoc.Test.MyClass">
       <Member Id="M:Monodoc.Test.MyClass.#ctor" />
       <Member Id="M:Monodoc.Test.MyClass.Meth(System.Int32,System.String,System.Int32)" />
+    </Type>
+    <Type Name="Monodoc.Test.SecondAttribute" Id="T:Monodoc.Test.SecondAttribute">
+      <Member Id="M:Monodoc.Test.SecondAttribute.#ctor" />
     </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-frameworkalternate-aligned/FrameworksIndex/Three.xml
+++ b/mdoc/Test/en.expected-frameworkalternate-aligned/FrameworksIndex/Three.xml
@@ -1,9 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Three">
   <Namespace Name="Monodoc.Test">
+    <Type Name="Monodoc.Test.FirstAttribute" Id="T:Monodoc.Test.FirstAttribute">
+      <Member Id="M:Monodoc.Test.FirstAttribute.#ctor" />
+    </Type>
     <Type Name="Monodoc.Test.MyClass" Id="T:Monodoc.Test.MyClass">
       <Member Id="M:Monodoc.Test.MyClass.#ctor" />
       <Member Id="M:Monodoc.Test.MyClass.Meth(System.Int32,System.String,System.Int32)" />
+    </Type>
+    <Type Name="Monodoc.Test.SecondAttribute" Id="T:Monodoc.Test.SecondAttribute">
+      <Member Id="M:Monodoc.Test.SecondAttribute.#ctor" />
     </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-frameworkalternate-aligned/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-frameworkalternate-aligned/FrameworksIndex/Two.xml
@@ -1,9 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Two">
   <Namespace Name="Monodoc.Test">
+    <Type Name="Monodoc.Test.FirstAttribute" Id="T:Monodoc.Test.FirstAttribute">
+      <Member Id="M:Monodoc.Test.FirstAttribute.#ctor" />
+    </Type>
     <Type Name="Monodoc.Test.MyClass" Id="T:Monodoc.Test.MyClass">
       <Member Id="M:Monodoc.Test.MyClass.#ctor" />
       <Member Id="M:Monodoc.Test.MyClass.Meth(System.Int32,System.String,System.Int32)" />
+    </Type>
+    <Type Name="Monodoc.Test.SecondAttribute" Id="T:Monodoc.Test.SecondAttribute">
+      <Member Id="M:Monodoc.Test.SecondAttribute.#ctor" />
     </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-frameworkalternate-aligned/Monodoc.Test/FirstAttribute.xml
+++ b/mdoc/Test/en.expected-frameworkalternate-aligned/Monodoc.Test/FirstAttribute.xml
@@ -1,0 +1,40 @@
+<Type Name="FirstAttribute" FullName="Monodoc.Test.FirstAttribute">
+  <TypeSignature Language="C#" Value="public class FirstAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FirstAttribute extends System.Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-frameworkalternate-one</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-frameworkalternate-two</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FirstAttribute ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-frameworkalternate-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-frameworkalternate-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-frameworkalternate-aligned/Monodoc.Test/MyClass.xml
+++ b/mdoc/Test/en.expected-frameworkalternate-aligned/Monodoc.Test/MyClass.xml
@@ -48,6 +48,11 @@
         <AssemblyName>DocTest-frameworkalternate-two</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Monodoc.Test.First</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>

--- a/mdoc/Test/en.expected-frameworkalternate-aligned/Monodoc.Test/SecondAttribute.xml
+++ b/mdoc/Test/en.expected-frameworkalternate-aligned/Monodoc.Test/SecondAttribute.xml
@@ -1,0 +1,40 @@
+<Type Name="SecondAttribute" FullName="Monodoc.Test.SecondAttribute">
+  <TypeSignature Language="C#" Value="public class SecondAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit SecondAttribute extends System.Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-frameworkalternate-one</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-frameworkalternate-two</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public SecondAttribute ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-frameworkalternate-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-frameworkalternate-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-frameworkalternate-aligned/index.xml
+++ b/mdoc/Test/en.expected-frameworkalternate-aligned/index.xml
@@ -2,20 +2,20 @@
   <Assemblies>
     <Assembly Name="DocTest-frameworkalternate-one" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="One;Three">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.DisableOptimizations | System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="One;Three">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-frameworkalternate-two" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.DisableOptimizations | System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
@@ -25,7 +25,9 @@
   <Copyright>To be added.</Copyright>
   <Types>
     <Namespace Name="Monodoc.Test">
+      <Type Name="FirstAttribute" Kind="Class" />
       <Type Name="MyClass" Kind="Class" />
+      <Type Name="SecondAttribute" Kind="Class" />
     </Namespace>
   </Types>
   <Title>Untitled</Title>

--- a/mdoc/Test/en.expected-frameworkalternate/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-frameworkalternate/FrameworksIndex/One.xml
@@ -1,9 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="One">
   <Namespace Name="Monodoc.Test">
+    <Type Name="Monodoc.Test.FirstAttribute" Id="T:Monodoc.Test.FirstAttribute">
+      <Member Id="M:Monodoc.Test.FirstAttribute.#ctor" />
+    </Type>
     <Type Name="Monodoc.Test.MyClass" Id="T:Monodoc.Test.MyClass">
       <Member Id="M:Monodoc.Test.MyClass.#ctor" />
       <Member Id="M:Monodoc.Test.MyClass.Meth(System.Int32,System.String,System.Int32)" />
+    </Type>
+    <Type Name="Monodoc.Test.SecondAttribute" Id="T:Monodoc.Test.SecondAttribute">
+      <Member Id="M:Monodoc.Test.SecondAttribute.#ctor" />
     </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-frameworkalternate/FrameworksIndex/Three.xml
+++ b/mdoc/Test/en.expected-frameworkalternate/FrameworksIndex/Three.xml
@@ -1,9 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Three">
   <Namespace Name="Monodoc.Test">
+    <Type Name="Monodoc.Test.FirstAttribute" Id="T:Monodoc.Test.FirstAttribute">
+      <Member Id="M:Monodoc.Test.FirstAttribute.#ctor" />
+    </Type>
     <Type Name="Monodoc.Test.MyClass" Id="T:Monodoc.Test.MyClass">
       <Member Id="M:Monodoc.Test.MyClass.#ctor" />
       <Member Id="M:Monodoc.Test.MyClass.Meth(System.Int32,System.String,System.Int32)" />
+    </Type>
+    <Type Name="Monodoc.Test.SecondAttribute" Id="T:Monodoc.Test.SecondAttribute">
+      <Member Id="M:Monodoc.Test.SecondAttribute.#ctor" />
     </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-frameworkalternate/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-frameworkalternate/FrameworksIndex/Two.xml
@@ -1,9 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Two">
   <Namespace Name="Monodoc.Test">
+    <Type Name="Monodoc.Test.FirstAttribute" Id="T:Monodoc.Test.FirstAttribute">
+      <Member Id="M:Monodoc.Test.FirstAttribute.#ctor" />
+    </Type>
     <Type Name="Monodoc.Test.MyClass" Id="T:Monodoc.Test.MyClass">
       <Member Id="M:Monodoc.Test.MyClass.#ctor" />
       <Member Id="M:Monodoc.Test.MyClass.Meth(System.Int32,System.String,System.Int32)" />
+    </Type>
+    <Type Name="Monodoc.Test.SecondAttribute" Id="T:Monodoc.Test.SecondAttribute">
+      <Member Id="M:Monodoc.Test.SecondAttribute.#ctor" />
     </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-frameworkalternate/Monodoc.Test/FirstAttribute.xml
+++ b/mdoc/Test/en.expected-frameworkalternate/Monodoc.Test/FirstAttribute.xml
@@ -1,0 +1,40 @@
+<Type Name="FirstAttribute" FullName="Monodoc.Test.FirstAttribute">
+  <TypeSignature Language="C#" Value="public class FirstAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit FirstAttribute extends System.Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-frameworkalternate-one</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-frameworkalternate-two</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public FirstAttribute ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-frameworkalternate-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-frameworkalternate-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-frameworkalternate/Monodoc.Test/MyClass.xml
+++ b/mdoc/Test/en.expected-frameworkalternate/Monodoc.Test/MyClass.xml
@@ -50,6 +50,14 @@
         <AssemblyName>DocTest-frameworkalternate-two</AssemblyName>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
+      <Attributes>
+        <Attribute>
+          <AttributeName>Monodoc.Test.First</AttributeName>
+        </Attribute>
+        <Attribute FrameworkAlternate="Two">
+          <AttributeName>Monodoc.Test.Second</AttributeName>
+        </Attribute>
+      </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>

--- a/mdoc/Test/en.expected-frameworkalternate/Monodoc.Test/SecondAttribute.xml
+++ b/mdoc/Test/en.expected-frameworkalternate/Monodoc.Test/SecondAttribute.xml
@@ -1,0 +1,40 @@
+<Type Name="SecondAttribute" FullName="Monodoc.Test.SecondAttribute">
+  <TypeSignature Language="C#" Value="public class SecondAttribute : Attribute" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit SecondAttribute extends System.Attribute" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-frameworkalternate-one</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-frameworkalternate-two</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Attribute</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public SecondAttribute ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-frameworkalternate-one</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-frameworkalternate-two</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-frameworkalternate/index.xml
+++ b/mdoc/Test/en.expected-frameworkalternate/index.xml
@@ -2,20 +2,20 @@
   <Assemblies>
     <Assembly Name="DocTest-frameworkalternate-one" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="One;Three">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.DisableOptimizations | System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="One;Three">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-frameworkalternate-two" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.DisableOptimizations | System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
@@ -25,7 +25,9 @@
   <Copyright>To be added.</Copyright>
   <Types>
     <Namespace Name="Monodoc.Test">
+      <Type Name="FirstAttribute" Kind="Class" />
       <Type Name="MyClass" Kind="Class" />
+      <Type Name="SecondAttribute" Kind="Class" />
     </Namespace>
   </Types>
   <Title>Untitled</Title>

--- a/mdoc/Test/en.expected-frameworks-inheritance/index.xml
+++ b/mdoc/Test/en.expected-frameworks-inheritance/index.xml
@@ -2,20 +2,20 @@
   <Assemblies>
     <Assembly Name="DocTest-framework-inheritance-one" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-framework-inheritance-two" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/Test/en.expected-frameworks/index.xml
+++ b/mdoc/Test/en.expected-frameworks/index.xml
@@ -2,20 +2,20 @@
   <Assemblies>
     <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/Func`2.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/Func`2.xml
@@ -8,7 +8,7 @@
   <TypeParameters>
     <TypeParameter Name="TArg">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>Mono.DocTest.Doc("arg!")</AttributeName>
         </Attribute>
       </Attributes>
@@ -19,7 +19,7 @@
     </TypeParameter>
     <TypeParameter Name="TRet">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>Mono.DocTest.Doc("ret!")</AttributeName>
         </Attribute>
       </Attributes>
@@ -32,14 +32,14 @@
     <BaseTypeName>System.Delegate</BaseTypeName>
   </Base>
   <Attributes>
-    <Attribute>
+    <Attribute FrameworkAlternate="one">
       <AttributeName>Mono.DocTest.Doc("method")</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>
     <Parameter Name="a" Type="TArg">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>Mono.DocTest.Doc("arg-actual")</AttributeName>
         </Attribute>
       </Attributes>
@@ -48,7 +48,7 @@
   <ReturnValue>
     <ReturnType>TRet</ReturnType>
     <Attributes>
-      <Attribute>
+      <Attribute FrameworkAlternate="one">
         <AttributeName>Mono.DocTest.Doc("return", Field=false)</AttributeName>
       </Attribute>
     </Attributes>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/GenericBase`1.xml
@@ -47,7 +47,7 @@
       <TypeParameters>
         <TypeParameter Name="S">
           <Attributes>
-            <Attribute>
+            <Attribute FrameworkAlternate="one">
               <AttributeName>Mono.DocTest.Doc("S")</AttributeName>
             </Attribute>
           </Attributes>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/MyList`1.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/MyList`1.xml
@@ -8,7 +8,7 @@
   <TypeParameters>
     <TypeParameter Name="T">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>Mono.DocTest.Doc("Type Parameter!")</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/DocAttribute.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/DocAttribute.xml
@@ -10,7 +10,7 @@
   </Base>
   <Interfaces />
   <Attributes>
-    <Attribute>
+    <Attribute FrameworkAlternate="one">
       <AttributeName>System.AttributeUsage(System.AttributeTargets.All)</AttributeName>
     </Attribute>
   </Attributes>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+Direction.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget+Direction.xml
@@ -9,7 +9,7 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Attributes>
-    <Attribute>
+    <Attribute FrameworkAlternate="one">
       <AttributeName>System.Flags</AttributeName>
     </Attribute>
   </Attributes>

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest/Widget.xml
@@ -97,13 +97,13 @@
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>Mono.DocTest.Doc("Del event")</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>add: Mono.DocTest.Doc("Del add accessor")</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>remove: Mono.DocTest.Doc("Del remove accessor")</AttributeName>
         </Attribute>
       </Attributes>
@@ -344,7 +344,7 @@
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>System.Obsolete("why not")</AttributeName>
         </Attribute>
       </Attributes>
@@ -422,7 +422,7 @@
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>Mono.DocTest.Doc("Height property")</AttributeName>
         </Attribute>
       </Attributes>
@@ -445,10 +445,10 @@
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>Mono.DocTest.Doc("Item property")</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>set: Mono.DocTest.Doc("Item property set accessor")</AttributeName>
         </Attribute>
       </Attributes>
@@ -517,14 +517,14 @@
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>Mono.DocTest.Doc("normal DocAttribute", Field=true)</AttributeName>
         </Attribute>
       </Attributes>
       <ReturnValue>
         <ReturnType>System.Void</ReturnType>
         <Attributes>
-          <Attribute>
+          <Attribute FrameworkAlternate="one">
             <AttributeName>Mono.DocTest.Doc("return:DocAttribute", Property=typeof(Mono.DocTest.Widget))</AttributeName>
           </Attribute>
         </Attributes>
@@ -532,21 +532,21 @@
       <Parameters>
         <Parameter Name="c" Type="System.Char">
           <Attributes>
-            <Attribute>
+            <Attribute FrameworkAlternate="one">
               <AttributeName>Mono.DocTest.Doc("c", FlagsEnum=System.ConsoleModifiers.Alt | System.ConsoleModifiers.Control)</AttributeName>
             </Attribute>
           </Attributes>
         </Parameter>
         <Parameter Name="f" Type="System.Single&amp;" RefType="out">
           <Attributes>
-            <Attribute>
+            <Attribute FrameworkAlternate="one">
               <AttributeName>Mono.DocTest.Doc("f", NonFlagsEnum=Mono.DocTest.Color.Red)</AttributeName>
             </Attribute>
           </Attributes>
         </Parameter>
         <Parameter Name="v" Type="Mono.DocTest.DocValueType&amp;" RefType="ref">
           <Attributes>
-            <Attribute>
+            <Attribute FrameworkAlternate="one">
               <AttributeName>Mono.DocTest.Doc("v")</AttributeName>
             </Attribute>
           </Attributes>
@@ -670,7 +670,7 @@
         <Parameter Name="i" Type="System.Int32" />
         <Parameter Name="args" Type="System.Object[]">
           <Attributes>
-            <Attribute>
+            <Attribute FrameworkAlternate="one">
               <AttributeName>System.ParamArray</AttributeName>
             </Attribute>
           </Attributes>
@@ -910,13 +910,13 @@
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
       </AssemblyInfo>
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>Mono.DocTest.Doc("Width property")</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>get: Mono.DocTest.Doc("Width get accessor")</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>set: Mono.DocTest.Doc("Width set accessor")</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/Test/en.expected-fx-import/index.xml
+++ b/mdoc/Test/en.expected-fx-import/index.xml
@@ -2,30 +2,30 @@
   <Assemblies>
     <Assembly Name="DocTest" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="one">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/Test/en.expected-vbnet/index.xml
+++ b/mdoc/Test/en.expected-vbnet/index.xml
@@ -2,20 +2,20 @@
   <Assemblies>
     <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/Test/test-nuget-information/en.expected-frameworks-with-nuget-information/index.xml
+++ b/mdoc/Test/test-nuget-information/en.expected-frameworks-with-nuget-information/index.xml
@@ -2,20 +2,20 @@
   <Assemblies>
     <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="One">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>
     </Assembly>
     <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
         </Attribute>
-        <Attribute>
+        <Attribute FrameworkAlternate="Two">
           <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
         </Attribute>
       </Attributes>

--- a/mdoc/mdoc.Test/FrameworkAlternateTests.cs
+++ b/mdoc/mdoc.Test/FrameworkAlternateTests.cs
@@ -1,6 +1,7 @@
 ﻿using Mono.Documentation.Updater.Frameworks;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace mdoc.Test
@@ -16,12 +17,89 @@ namespace mdoc.Test
             Assert.AreEqual ("One", newValue);
         }
 
+        [Test ()]
+        public void AddToExistingList ()
+        {
+            string newValue = FXUtils.AddFXToList ("One", "Two");
+
+            Assert.AreEqual ("One;Two", newValue);
+        }
+
+        [Test ()]
+        public void AddDupeToExistingList ()
+        {
+            string newValue = FXUtils.AddFXToList ("One", "One");
+
+            Assert.AreEqual ("One", newValue);
+        }
+
 
         [Test ()]
         public void RemoveFromList()
         {
             string newValue = FXUtils.RemoveFXFromList ("One", "One");
             Assert.AreEqual ("", newValue);
+        }
+
+
+        [Test ()]
+        public void RemoveFromMultiList ()
+        {
+            string existingValue = "Pre;One;Post";
+            string fxToRemove = "One";
+            string postValue = "Pre;Post";
+
+            string newValue = FXUtils.RemoveFXFromList (existingValue, fxToRemove);
+            Assert.AreEqual (postValue, newValue);
+
+            // make sure the cache returns the same value
+            newValue = FXUtils.RemoveFXFromList (existingValue, fxToRemove);
+            Assert.AreEqual (postValue, newValue);
+        }
+
+        [Test ()]
+        public void AddToMultiList ()
+        {
+            string existingValue = "Pre;Post";
+            string fxToAdd = "One";
+            string postValue = "Pre;Post;One";
+
+            string newValue = FXUtils.AddFXToList (existingValue, fxToAdd);
+            Assert.AreEqual (postValue, newValue);
+
+            // make sure the cache returns the same value
+            newValue = FXUtils.AddFXToList (existingValue, fxToAdd);
+            Assert.AreEqual (postValue, newValue);
+        }
+
+        [Test]
+        public void LastFramework()
+        {
+            List<FrameworkEntry> entries = new List<FrameworkEntry>();
+            entries.Add (new FrameworkEntry (entries));
+            entries.Add (new FrameworkEntry (entries));
+            entries.Add (new FrameworkEntry (entries));
+            entries.Add (new FrameworkEntry (entries));
+
+            Assert.IsFalse (entries[0].IsLastFramework);
+            Assert.IsFalse (entries[1].IsLastFramework);
+            Assert.IsFalse (entries[2].IsLastFramework);
+            Assert.IsTrue (entries[3].IsLastFramework);
+        }
+
+        [Test]
+        public void FirstFramework ()
+        {
+            List<FrameworkEntry> entries = new List<FrameworkEntry> ();
+            entries.Add (new FrameworkEntry (entries));
+            entries.Add (new FrameworkEntry (entries));
+            entries.Add (new FrameworkEntry (entries));
+            entries.Add (new FrameworkEntry (entries));
+
+            Assert.IsTrue (entries[0].IsFirstFramework);
+            Assert.IsFalse (entries[1].IsFirstFramework);
+            Assert.IsFalse (entries[2].IsFirstFramework);
+            Assert.IsFalse (entries[3].IsFirstFramework);
         }
     }
 }

--- a/mdoc/mdoc.Test/XmlUpdateTests.cs
+++ b/mdoc/mdoc.Test/XmlUpdateTests.cs
@@ -8,29 +8,45 @@ using System.Collections.Generic;
 using Mono.Documentation.Updater.Frameworks;
 using Mono.Documentation.Updater;
 
-namespace mdoc.Test2
+namespace mdoc.Test
 {
+    public class OneAttribute : Attribute { }
+    public class TwoAttribute : Attribute { }
+
+    [One]
     public class MyClass
     {
-        public void Meth (int a, string b, int c) { }
+        [One]
+        public void Meth (int a, string d, int c) { }
+
     }
     public class MyClass2
     {
+        public void Meth (int a, string b, int c) { }
+    }
+
+}
+
+namespace mdoc.Test2
+{
+    using mdoc.Test;
+
+    [One, Two]
+    public class MyClass
+    {
+        [One, Two]
+        public void Meth (int a, string b, int c) { }
+    }
+
+    [Two]
+    public class MyClass2
+    {
+        [Two]
         public void Meth (int d, string e, int f) { }
     }
 }
 namespace mdoc.Test
 {
-    public class MyClass
-    {
-        public void Meth(int a, string d, int c) {}
-
-    }
-    public class MyClass2
-    {
-        public void Meth (int a, string b, int c) { }
-    }
-
     /// <summary>
     /// Tests functions that update the EcmaXMl under various conditions from
     /// corresponding classes.
@@ -412,6 +428,309 @@ namespace mdoc.Test
             Assert.IsTrue (matches.Any (m => m.Member == context.method && m.Node != null), "didn't match the member");
         }
 
+        [Test]
+        public void Attributes_TypeOrMethod() 
+        {
+            var context = InitContext<MyClass> (string.Format (typeFrameXml, multiFrameworkXml), 2, forceAlignment: false);
+            var fx = context.fx.Frameworks[1];
+            FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+            string[] attributeList = new[] { "One" };
+
+            MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            var attrNode = context.doc.FirstChild.SelectSingleNode ("Attributes");
+            var attributes = attrNode.SelectNodes ("Attribute").Cast<XmlElement>().ToArray();
+
+            Assert.IsTrue (attributes.Count () == 1);
+            Assert.AreEqual ("One", attributes[0].FirstChild.InnerText);
+            Assert.AreEqual ("Three", attributes[0].GetAttribute (Consts.FrameworkAlternate));
+        }
+
+        [Test]
+        public void Attributes_TypeOrMethod_AllFX ()
+        {
+            var context = InitContext<MyClass> (string.Format (typeFrameXml, multiFrameworkXml), 2, forceAlignment: false);
+
+            foreach (var fx in context.fx.Frameworks)
+            {
+                //var fx = context.fx.Frameworks[1];
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One" };
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            var attrNode = context.doc.FirstChild.SelectSingleNode ("Attributes");
+            var attributes = attrNode.SelectNodes ("Attribute").Cast<XmlElement> ().ToArray ();
+
+            Assert.IsTrue (attributes.Count () == 1);
+            Assert.AreEqual ("One", attributes[0].FirstChild.InnerText);
+            Assert.IsFalse (attributes[0].HasAttribute (Consts.FrameworkAlternate));
+        }
+
+        [Test]
+        public void Attributes_TypeOrMethod_AllFX_OneMissing ()
+        {
+            var context = InitContext<MyClass> (string.Format (typeFrameXml, multiFrameworkXml), 2, forceAlignment: false);
+
+            foreach (var fx in context.fx.Frameworks)
+            {
+                //var fx = context.fx.Frameworks[1];
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One" };
+
+                if (fx.IsFirstFramework)
+                    attributeList = new string[0];
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            var attrNode = context.doc.FirstChild.SelectSingleNode ("Attributes");
+            var attributes = attrNode.SelectNodes ("Attribute").Cast<XmlElement> ().ToArray ();
+
+            Assert.IsTrue (attributes.Count () == 1);
+            Assert.AreEqual ("One", attributes[0].FirstChild.InnerText);
+            Assert.IsTrue (attributes[0].HasAttribute (Consts.FrameworkAlternate));
+            Assert.AreEqual ("Three;Two", attributes[0].GetAttribute (Consts.FrameworkAlternate));
+        }
+
+        [Test]
+        public void Attributes_TypeOrMethod_AllFX_OneMissing_Last ()
+        {
+            var context = InitContext<MyClass> (string.Format (typeFrameXml, multiFrameworkXml), 2, forceAlignment: false);
+
+            foreach (var fx in context.fx.Frameworks)
+            {
+                //var fx = context.fx.Frameworks[1];
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One" };
+
+                if (fx.IsLastFramework)
+                    attributeList = new string[0];
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            var attrNode = context.doc.FirstChild.SelectSingleNode ("Attributes");
+            var attributes = attrNode.SelectNodes ("Attribute").Cast<XmlElement> ().ToArray ();
+
+            Assert.IsTrue (attributes.Count () == 1);
+            Assert.AreEqual ("One", attributes[0].FirstChild.InnerText);
+            Assert.IsTrue (attributes[0].HasAttribute (Consts.FrameworkAlternate));
+            Assert.AreEqual ("One;Three", attributes[0].GetAttribute (Consts.FrameworkAlternate));
+        }
+
+        [Test]
+        public void Attributes_TypeOrMethod_AllFX_RunExisting_Middle ()
+        {
+            var context = InitContext<MyClass> (string.Format (typeFrameXml, multiFrameworkXml), 2, forceAlignment: false);
+
+            // first, go through and add "One" and "Two" to all of them
+            foreach (var fx in context.fx.Frameworks)
+            {
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One", "Two" };
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            // Now, to test the first deployment on an existing set
+            // in this case, the truth of the matter is that `Two` only exists in the middle
+            foreach (var fx in context.fx.Frameworks)
+            {
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One" };
+
+                if (!fx.IsFirstFramework && !fx.IsLastFramework) {
+                    attributeList = new[] { "One", "Two" };
+                }
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            var attrNode = context.doc.FirstChild.SelectSingleNode ("Attributes");
+            var attributes = attrNode.SelectNodes ("Attribute").Cast<XmlElement> ().ToArray ();
+
+            Assert.IsTrue (attributes.Count () == 2);
+            Assert.AreEqual ("One", attributes[0].FirstChild.InnerText);
+            Assert.IsFalse (attributes[0].HasAttribute (Consts.FrameworkAlternate));
+            Assert.AreEqual ("Two", attributes[1].FirstChild.InnerText);
+            Assert.IsTrue (attributes[1].HasAttribute (Consts.FrameworkAlternate));
+            Assert.AreEqual ("Three", attributes[1].GetAttribute (Consts.FrameworkAlternate));
+        }
+
+        [Test]
+        public void Attributes_TypeOrMethod_AllFX_RunExisting_First ()
+        {
+            var context = InitContext<MyClass> (string.Format (typeFrameXml, multiFrameworkXml), 2, forceAlignment: false);
+
+            // first, go through and add "One" and "Two" to all of them
+            foreach (var fx in context.fx.Frameworks)
+            {
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One", "Two" };
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            // Now, to test the first deployment on an existing set
+            // in this case, the truth of the matter is that `Two` only exists in the middle
+            foreach (var fx in context.fx.Frameworks)
+            {
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One" };
+
+                if (fx.IsFirstFramework)
+                {
+                    attributeList = new[] { "One", "Two" };
+                }
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            var attrNode = context.doc.FirstChild.SelectSingleNode ("Attributes");
+            var attributes = attrNode.SelectNodes ("Attribute").Cast<XmlElement> ().ToArray ();
+
+            Assert.IsTrue (attributes.Count () == 2);
+            Assert.AreEqual ("One", attributes[0].FirstChild.InnerText);
+            Assert.IsFalse (attributes[0].HasAttribute (Consts.FrameworkAlternate));
+            Assert.AreEqual ("Two", attributes[1].FirstChild.InnerText);
+            Assert.IsTrue (attributes[1].HasAttribute (Consts.FrameworkAlternate));
+            Assert.AreEqual ("One", attributes[1].GetAttribute (Consts.FrameworkAlternate));
+        }
+
+        [Test]
+        public void Attributes_TypeOrMethod_AllFX_RunExisting_Last ()
+        {
+            var context = InitContext<MyClass> (string.Format (typeFrameXml, multiFrameworkXml), 2, forceAlignment: false);
+
+            // first, go through and add "One" and "Two" to all of them
+            foreach (var fx in context.fx.Frameworks)
+            {
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One", "Two" };
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            // Now, to test the first deployment on an existing set
+            // in this case, the truth of the matter is that `Two` only exists in the middle
+            foreach (var fx in context.fx.Frameworks)
+            {
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "Two" };
+
+                if (fx.IsLastFramework)
+                {
+                    attributeList = new[] { "One", "Two" };
+                }
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            var attrNode = context.doc.FirstChild.SelectSingleNode ("Attributes");
+            var attributes = attrNode.SelectNodes ("Attribute").Cast<XmlElement> ().ToArray ();
+
+            Assert.IsTrue (attributes.Count () == 2);
+            Assert.AreEqual ("One", attributes[0].FirstChild.InnerText);
+            Assert.IsTrue (attributes[0].HasAttribute (Consts.FrameworkAlternate));
+            Assert.AreEqual ("Two", attributes[0].GetAttribute (Consts.FrameworkAlternate));
+            Assert.AreEqual ("Two", attributes[1].FirstChild.InnerText);
+            Assert.IsFalse (attributes[1].HasAttribute (Consts.FrameworkAlternate));
+
+        }
+
+        [Test]
+        public void Attributes_TypeOrMethod_AllFX_OneMissing_Middle ()
+        {
+            var context = InitContext<MyClass> (string.Format (typeFrameXml, multiFrameworkXml), 2, forceAlignment: false);
+
+            foreach (var fx in context.fx.Frameworks)
+            {
+                //var fx = context.fx.Frameworks[1];
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One" };
+
+                if (!fx.IsLastFramework && !fx.IsFirstFramework)
+                    attributeList = new string[0];
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            var attrNode = context.doc.FirstChild.SelectSingleNode ("Attributes");
+            var attributes = attrNode.SelectNodes ("Attribute").Cast<XmlElement> ().ToArray ();
+
+            Assert.IsTrue (attributes.Count () == 1);
+            Assert.AreEqual ("One", attributes[0].FirstChild.InnerText);
+            Assert.IsTrue (attributes[0].HasAttribute (Consts.FrameworkAlternate));
+            Assert.AreEqual ("One;Two", attributes[0].GetAttribute (Consts.FrameworkAlternate));
+        }
+
+
+        [Test]
+        public void Attributes_Assembly ()
+        {
+            var context = InitContext<MyClass> (string.Format (typeFrameXml, multiFrameworkXml), 2, forceAlignment: false);
+
+            foreach (var fx in context.fx.Frameworks)
+            {
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One" };
+
+                if (!fx.IsLastFramework && !fx.IsFirstFramework)
+                {
+                    attributeList = new string[0];
+                }
+
+
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            }
+
+            var attrNode = context.doc.FirstChild.SelectSingleNode ("Attributes");
+            var attributes = attrNode.SelectNodes ("Attribute").Cast<XmlElement> ().ToArray ();
+
+            Assert.IsTrue (attributes.Count () == 1);
+            Assert.AreEqual ("One", attributes[0].FirstChild.InnerText);
+            Assert.IsTrue (attributes[0].HasAttribute (Consts.FrameworkAlternate));
+            Assert.AreEqual ("One;Two", attributes[0].GetAttribute (Consts.FrameworkAlternate));
+        }
+
+        [Test]
+        public void Attributes_Assembly_OtherAssembly ()
+        {
+            var context = InitContext<MyClass> (string.Format (typeFrameXml, multiFrameworkXml), 2, forceAlignment: false);
+
+            var fx = context.fx.Frameworks[1];
+
+
+                FrameworkTypeEntry typeEntry = fx.Types.First ();
+
+                string[] attributeList = new[] { "One" };
+                
+                // this is the 'second' fx, and we've changed the expected assembly name, 
+                // so the attribute, while it doesn't exist yet, shouldn't have an FX made since it doesn't exist in any other FX
+                MDocUpdater.MakeAttributes (context.doc.FirstChild as XmlElement, attributeList, fx);
+            
+
+            var attrNode = context.doc.FirstChild.SelectSingleNode ("Attributes");
+            var attributes = attrNode.SelectNodes ("Attribute").Cast<XmlElement> ().ToArray ();
+
+            Assert.IsTrue (attributes.Count () == 1);
+            Assert.AreEqual ("One", attributes[0].FirstChild.InnerText);
+            Assert.IsTrue (attributes[0].HasAttribute (Consts.FrameworkAlternate));
+        }
+
         string Normalize(string xml) {
             XmlDocument doc = new XmlDocument ();
 
@@ -618,7 +937,7 @@ namespace mdoc.Test
 
             // updater
             var updater = new MDocUpdater ();
-            var fx = new FrameworkIndex ("");
+            var fx = new FrameworkIndex ("", 3);
             fx.Frameworks.Add (new FrameworkEntry (fx.Frameworks) { Id = "One", Name = "One", Replace="mdoc.Test2", With="mdoc.Test" });
             fx.Frameworks.Add (new FrameworkEntry (fx.Frameworks) { Id = "Three", Name = "Three", Replace = "mdoc.Test2", With = "mdoc.Test"  });
             fx.Frameworks.Add (new FrameworkEntry (fx.Frameworks) { Id = "Two", Name = "Two", Replace = "mdoc.Test2", With = "mdoc.Test"  });
@@ -630,6 +949,10 @@ namespace mdoc.Test
                 {
                     var t = f.ProcessType (type);
                     t.ProcessMember (method);
+
+                    var aset = new AssemblySet (new[] { "one.dll" });
+                    f.AddAssemblySet (aset);
+
                 }
                 else {
                     var t = f.ProcessType (type2);

--- a/mdoc/mdoc.csproj
+++ b/mdoc/mdoc.csproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>mdoc</RootNamespace>
     <AssemblyName>mdoc</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.0.1</version>
+    <version>5.7.1</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
While the fix for #76 was originally slated for mdoc 5.7, it was pulled out in order to further stabilize. This PR represents that work.