### PR TITLE
Mdoc 5.7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ obj
 mdoc/Test/actual_statistics.txt
 mdoc/Test/test-overwrite-attribute/SomeClass.xml
 mdoc/Test/test-overwrite-attribute/SomeClass.dll
+mdoc/Test/test-generic-ignored-namespace/ReadOnlySpan.dll
 mdoc/Test/test-nuget-information/input_data/
 /Debug/UwpTestWinRtComponentCpp
 Debug

--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.1";
+		public static string MonoVersion = "5.7.2";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Test/html.expected-with-array-extension/Mono.DocTest.Generic/MyList`2.html
+++ b/mdoc/Test/html.expected-with-array-extension/Mono.DocTest.Generic/MyList`2.html
@@ -330,7 +330,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/GenericBase`1.html#M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0)">BaseMethod&lt;S&gt;</a>
-                  </b>(<i title="To be added.">S</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary`2">Dictionary&lt;A, B&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span> (<i>Inherited from <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;U&gt;</a>.</i>)</blockquote></td>
+                  </b>(<i title="To be added.">S</i>)<nobr> : <i title="">System.Collections.Generic.Dictionary&lt;A,B&gt;</i></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span> (<i>Inherited from <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;U&gt;</a>.</i>)</blockquote></td>
               </tr>
               <tr valign="top">
                 <td>

--- a/mdoc/Test/html.expected/Mono.DocTest.Generic/MyList`2.html
+++ b/mdoc/Test/html.expected/Mono.DocTest.Generic/MyList`2.html
@@ -325,7 +325,7 @@
                 <td colspan="2">
                   <b>
                     <a href="../Mono.DocTest.Generic/GenericBase`1.html#M:Mono.DocTest.Generic.GenericBase`1.BaseMethod``1(``0)">BaseMethod&lt;S&gt;</a>
-                  </b>(<i title="Insert more text here.">S</i>)<nobr> : <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Collections.Generic.Dictionary`2">Dictionary&lt;A, B&gt;</a></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span> (<i>Inherited from <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;U&gt;</a>.</i>)</blockquote></td>
+                  </b>(<i title="Insert more text here.">S</i>)<nobr> : <i title="">System.Collections.Generic.Dictionary&lt;A,B&gt;</i></nobr><blockquote><span class="NotEntered">Documentation for this section has not yet been entered.</span> (<i>Inherited from <a href="../Mono.DocTest.Generic/GenericBase`1.html">GenericBase&lt;U&gt;</a>.</i>)</blockquote></td>
               </tr>
               <tr valign="top">
                 <td>

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.1</version>
+    <version>5.7.2</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
- #230 - return type signature fixes: no longer prints the namespace for some generic type names, and adds `RefType` attribute to the `ReturnType` element
- #194 - `mdoc assemble` now supports an `-fx` argument, which is the name of the framework (when in frameworks mode) to assemble. This will exclude any types and members that are not in that framework from the resulting .tree and .zip