### PR TITLE
Disabling 'UseZip64' from Mono Builds

### DIFF
--- a/monodoc/Monodoc/storage/ZipStorage.cs
+++ b/monodoc/Monodoc/storage/ZipStorage.cs
@@ -103,7 +103,9 @@ namespace Monodoc.Storage
 			if (zipOutput != null)
 				return;
 			zipOutput = new ZipOutputStream (File.Create (zipFileName));
+#if !MONO
             zipOutput.UseZip64 = UseZip64.Off;
+#endif
 		}
 
 		void EnsureInput ()


### PR DESCRIPTION
They are using an older version of sharp zip lib, which already defaults to off (and doesn't have this property anyways)