### PR TITLE
mdoc 5.7.2.1

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.2";
+		public static string MonoVersion = "5.7.2.1";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -3733,9 +3733,11 @@ namespace Mono.Documentation
 
         private bool IsReadonlyAttribute(IList<CustomAttribute> attributes)
         {
+            if (attributes == null) return false;
+
             foreach (var attribute in attributes)
             {
-                if (attribute.AttributeType.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute")
+                if (attribute?.AttributeType?.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute")
                 {
                     return true;
                 }

--- a/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
@@ -553,7 +553,7 @@ namespace Mono.Documentation.Updater.Frameworks
             var extensions = name.IsWindowsRuntime ? new[] { ".winmd", ".dll" } : new[] { ".exe", ".dll" };
 
             if (subdirectories)
-                directories = GetAllDirectories(directories);
+                directories = GetAllDirectories(directories).Distinct();
 
             foreach (var dir in directories)
             {

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.2</version>
+    <version>5.7.2.1</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
- #92 - Explicitly Implemented Members that use a custom name (VB) are now named using the same naming convention as C# EII members. There is an additional `ExplicitInterfaceMemberName` attribute on the `Member` node in these cases that have the custom name.
- #293 - fixes NRE.
- Additional minor perf improvement with assembly resolution.
