### PR TITLE
mdoc 5.7.2.3

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.2.2";
+		public static string MonoVersion = "5.7.2.3";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1465,7 +1465,7 @@ namespace Mono.Documentation
 
             foreach (DocsNodeInfo info in docEnum.GetDocumentationMembers (basefile, type, typeEntry))
             {
-                if (info.Node.ParentNode == null || info.Node.GetAttribute ("ToDelete") == "true")
+                if (info.Node.ParentNode == null)
                     continue;
                 
                 XmlElement oldmember = info.Node;
@@ -1592,6 +1592,12 @@ namespace Mono.Documentation
                 foreach (var stylesig in styles)
                 {
                     seenmembers.Add (stylesig, oldmember);
+                }
+
+                if (oldmember.HasAttribute("ToDelete"))
+                {
+                    // this is the restult of an error state, let's remove this
+                    oldmember.RemoveAttribute ("ToDelete");
                 }
             }
             foreach (XmlElement oldmember in todelete.Where(mem => mem.ParentNode != null))
@@ -2203,6 +2209,10 @@ namespace Mono.Documentation
             XmlElement me = (XmlElement)info.Node;
             MemberReference mi = info.Member;
             typeEntry.ProcessMember (mi);
+
+
+            var memberName = GetMemberName (mi);
+            me.SetAttribute ("MemberName", memberName);
 
             WriteElementText (me, "MemberType", GetMemberType (mi));
             AddImplementedMembers(mi, implementedMembers, me);

--- a/mdoc/Mono.Documentation/Updater/DocumentationEnumerator.cs
+++ b/mdoc/Mono.Documentation/Updater/DocumentationEnumerator.cs
@@ -40,7 +40,7 @@ namespace Mono.Documentation.Updater
                     oldmember.RemoveAttribute ("__monodocer-seen__");
                     continue;
                 }
-                if (oldmember.ParentNode == null || oldmember.GetAttribute("ToDelete") == "true")
+                if (oldmember.ParentNode == null)
                     continue;
                 
                 MemberReference m = GetMember (type, new DocumentationMember (oldmember, typeEntry));

--- a/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
@@ -31,8 +31,6 @@ namespace Mono.Documentation.Updater.Frameworks
                 exportedFiles = new List<string> ();
 
             var a = this.ResolveCore (name, r, exportedFiles);
-            //Console.WriteLine($"resolver, resolving {forType.FullName} in {name}");
-
 
             if (forType != null && a.MainModule.HasExportedTypes) {
                 var etype = a.MainModule.ExportedTypes.SingleOrDefault (t => t.FullName == forType.FullName) as ExportedType;

--- a/mdoc/Test/en.expected.importecmadoc/System/Array.xml
+++ b/mdoc/Test/en.expected.importecmadoc/System/Array.xml
@@ -135,7 +135,7 @@ and the second dimension indexed by 1, 2, and 3. </para>
           <see cref="M:System.Array.AsReadOnly``1(``0[])" /></exception>
       </Docs>
     </Member>
-    <Member MemberName="ConvertAll&lt;T,U&gt;">
+    <Member MemberName="ConvertAll&lt;TInput,TOutput&gt;">
       <MemberSignature Language="C#" Value="public static TOutput[] ConvertAll&lt;TInput,TOutput&gt; (TInput[] array, Converter&lt;TInput,TOutput&gt; converter);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig !!TOutput[] ConvertAll&lt;TInput, TOutput&gt;(!!TInput[] array, class System.Converter`2&lt;!!TInput, !!TOutput&gt; converter) cil managed" />
       <MemberType>Method</MemberType>

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.2.2</version>
+    <version>5.7.2.3</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
Adjusts the member dupe removal algorithm slightly so that it can recover better, and has less of a chance of getting into an error state.