### PR TITLE
Added a new function to make sure a file is deleted on slower HDDs

### DIFF
--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1291,7 +1291,7 @@ namespace Mono.Documentation
                         Action actuallyDelete = () =>
                         {
                             string newname = typefile.FullName + ".remove";
-                            try { System.IO.File.Delete (newname); } catch (Exception) { Warning ("Unable to delete existing file: {0}", newname); }
+                            try { MdocFile.DeleteFile (newname); } catch (Exception) { Warning ("Unable to delete existing file: {0}", newname); }
                             try { typefile.MoveTo (newname); } catch (Exception) { Warning ("Unable to rename to: {0}", newname); }
                             Console.WriteLine ("Class no longer present; file renamed: " + Path.Combine (nsdir.Name, typefile.Name));
 

--- a/mdoc/Mono.Documentation/MdocFile.cs
+++ b/mdoc/Mono.Documentation/MdocFile.cs
@@ -52,13 +52,33 @@ namespace Mono.Documentation {
 				}
 
 				if (move) {
-					File.Delete (file);
+					DeleteFile (file);
 					File.Move (temp, file);
 				}
 			}
 			finally {
 				if (!move && File.Exists (temp))
 					File.Delete (temp);
+			}
+		}
+
+		public static void DeleteFile (string fileToDelete, int retries = 10)
+		{
+			var startRetries = retries;
+
+			var fi = new FileInfo(fileToDelete);
+			if (fi.Exists) {
+				fi.Delete ();
+				fi.Refresh ();
+
+				while (fi.Exists && retries-- > 0) {
+					System.Threading.Thread.Sleep (100);
+					fi.Refresh ();
+				}
+
+				fi.Refresh ();
+				if (fi.Exists)
+					throw new IOException ($"Unable to delete file '{fileToDelete}' after {startRetries} attempts.");
 			}
 		}
 

--- a/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
@@ -94,8 +94,7 @@ namespace Mono.Documentation.Updater.Frameworks
 				// now save the document
 				string filePath = Path.Combine (outputPath, fx.Name + ".xml");
 
-				if (File.Exists (filePath))
-					File.Delete (filePath);
+				MdocFile.DeleteFile (filePath);
 
 				var settings = new XmlWriterSettings { Indent = true };
 				using (var writer = XmlWriter.Create (filePath, settings)) {


### PR DESCRIPTION
Sometimes when a device is working hard, the file has a few milliseconds delay between the delete call and the delete operation being completed.