### PR TITLE
Added a flag to instruct the export-msxdoc command to be quiet

### DIFF
--- a/mdoc/Mono.Documentation/monodocs2slashdoc.cs
+++ b/mdoc/Mono.Documentation/monodocs2slashdoc.cs
@@ -15,6 +15,7 @@ public class MDocToMSXDocConverter : MDocCommand {
 	public override void Run (IEnumerable<string> args)
 	{
 		string file = null;
+		bool quiet = false;
 		var p = new OptionSet () {
 			{ "o|out=", 
 				"The XML {FILE} to generate.\n" + 
@@ -22,6 +23,9 @@ public class MDocToMSXDocConverter : MDocCommand {
 				"based on the //AssemblyInfo/AssemblyName values within the documentation.\n" +
 				"Use '-' to write to standard output.",
 				v => file = v },
+			{ "q|quiet=", 
+				"Reduce logging to the console.",
+				v => quiet = v != null },
 		};
 		List<string> directories = Parse (p, args, "export-slashdoc", 
 				"[OPTIONS]+ DIRECTORIES",
@@ -29,10 +33,10 @@ public class MDocToMSXDocConverter : MDocCommand {
 					"Microsoft XML Documentation format files.");
 		if (directories == null)
 			return;
-		Run (file, directories);
+		Run (file, directories, quiet);
 	}
 	
-	public static void Run (string file, IEnumerable<string> dirs)
+	public static void Run (string file, IEnumerable<string> dirs, bool quiet)
 	{
 		Dictionary<string, XmlElement> outputfiles = new Dictionary<string, XmlElement> ();
 
@@ -64,14 +68,16 @@ public class MDocToMSXDocConverter : MDocCommand {
 		// Write out each of the assembly documents
 		foreach (string assemblyName in outputfiles.Keys) {
 			XmlElement members = (XmlElement)outputfiles[assemblyName];
-			Console.WriteLine(assemblyName + ".xml");
+			if (!quiet)
+				Console.WriteLine(assemblyName + ".xml");
 			using(StreamWriter sw = new StreamWriter(assemblyName + ".xml")) {
 				WriteXml(members.OwnerDocument.DocumentElement, sw);
 			}
 		}
 	
 		// Write out a namespace summaries file.
-		Console.WriteLine("NamespaceSummaries.xml");
+		if (!quiet)
+				Console.WriteLine("NamespaceSummaries.xml");
 		using(StreamWriter writer = new StreamWriter("NamespaceSummaries.xml")) {
 			WriteXml(nsSummaries.DocumentElement, writer);
 		}


### PR DESCRIPTION
This is going to be a nice thing to have to reduce the console output - especially when this is running as a build task.

Usage:

```
mdoc export-msxdoc --quiet "C:\Projects\SkiaSharp\docs\xml"
```

For a minimal SkiaSharp build, each platform will output this:
```
1>------ Rebuild All started: Project: SkiaSharp.Desktop, Configuration: Debug Any CPU ------
1>SkiaSharp.xml
1>SkiaSharp.Views.Android.xml
1>SkiaSharp.Views.Desktop.xml
1>SkiaSharp.Views.Gtk.xml
1>SkiaSharp.Views.WPF.xml
1>SkiaSharp.Views.Tizen.xml
1>SkiaSharp.Views.UWP.xml
1>SkiaSharp.Views.iOS.xml
1>SkiaSharp.Views.Mac.xml
1>SkiaSharp.Views.tvOS.xml
1>SkiaSharp.Views.watchOS.xml
1>SkiaSharp.Views.Forms.xml
1>HarfBuzzSharp.xml
1>SkiaSharp.HarfBuzz.xml
1>NamespaceSummaries.xml
1>SkiaSharp.Desktop -> C:\Projects\SkiaSharp\binding\SkiaSharp.Desktop\bin\Debug\net45\SkiaSharp.dll
========== Rebuild All: 1 succeeded, 0 failed, 0 skipped ==========
```

But, with the flag:

```
1>------ Rebuild All started: Project: SkiaSharp.Desktop, Configuration: Debug Any CPU ------
1>SkiaSharp.Desktop -> C:\Projects\SkiaSharp\binding\SkiaSharp.Desktop\bin\Debug\net45\SkiaSharp.dll
========== Rebuild All: 1 succeeded, 0 failed, 0 skipped ==========
```