### PR TITLE
mdoc 5.7.3.2

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.3.1";
+		public static string MonoVersion = "5.7.3.2";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -97,12 +97,12 @@ namespace Mono.Documentation
 
         public static bool HasDroppedNamespace (ModuleDefinition forModule)
         {
-            return HasDroppedNamespace (forModule.Assembly.Name);
+            return HasDroppedNamespace (forModule?.Assembly?.Name);
         }
 
         public static bool HasDroppedNamespace (AssemblyNameReference assemblyRef)
         {
-            return !string.IsNullOrWhiteSpace (droppedNamespace) && droppedAssemblies.Any (da => Path.GetFileNameWithoutExtension(da) == assemblyRef.Name);
+            return assemblyRef != null && !string.IsNullOrWhiteSpace (droppedNamespace) && droppedAssemblies.Any (da => Path.GetFileNameWithoutExtension(da) == assemblyRef.Name);
         }
 
         public static bool HasDroppedAnyNamespace ()

--- a/mdoc/Mono.Documentation/Updater/DynamicParserContext.cs
+++ b/mdoc/Mono.Documentation/Updater/DynamicParserContext.cs
@@ -16,7 +16,7 @@ namespace Mono.Documentation.Updater
         {
             CustomAttribute da;
             if (provider.HasCustomAttributes &&
-                    (da = (provider.CustomAttributes.Cast<CustomAttribute> ()
+                    (da = (provider.CustomAttributes.SafeCast<CustomAttribute> ()
                         .SingleOrDefault (ca => ca.GetDeclaringType () == "System.Runtime.CompilerServices.DynamicAttribute"))) != null)
             {
                 CustomAttributeArgument[] values = da.ConstructorArguments.Count == 0

--- a/mdoc/Mono.Documentation/Updater/Formatters/FSharpFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/FSharpFormatter.cs
@@ -366,8 +366,7 @@ namespace Mono.Documentation.Updater
                     {
                         AppendConstraints(buf,
                             genArgs.GetRange(0, notYetDisplayedArguments)
-                                .Where(i => i is GenericParameter)
-                                .Cast<GenericParameter>()
+                                .SafeCast<GenericParameter>()
                                 .ToList());
                     }
                     if (!isTuple && !isFSharpFunction)

--- a/mdoc/Mono.Documentation/Util/CecilExtensions.cs
+++ b/mdoc/Mono.Documentation/Util/CecilExtensions.cs
@@ -75,7 +75,11 @@ namespace Mono.Documentation.Util
 
         public static IEnumerable<TypeDefinition> GetTypes (this AssemblyDefinition assembly)
         {
-            var types = assembly.Modules.SelectMany (md => md.GetAllTypes ()).Union(assembly.MainModule.ExportedTypes.Select(et => et.Resolve()));
+            var exportedTypes = assembly.MainModule.ExportedTypes
+                                        .Select (et => et.Resolve ())
+                                        .Where(e => e != null);
+
+            var types = assembly.Modules.SelectMany (md => md.GetAllTypes ()).Union(exportedTypes);
             return types;
         }
 

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.3.1</version>
+    <version>5.7.3.2</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
The last release included a crash under certain circumstances related to export type tracking. This patch improves the safety of the code in that section. 

Additionally, it includes some performance improvements that should reduce caching time.