### PR TITLE
mdoc 5.7.3.4

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.3.3";
+		public static string MonoVersion = "5.7.3.4";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
@@ -613,7 +613,7 @@ namespace Mono.Documentation.Updater.Frameworks
 
                 foreach (var sub in Directory.EnumerateDirectories(dir, "*", SearchOption.AllDirectories))
                 {
-                    yield return dir;
+                    yield return sub;
                 }
             }
         }

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.3.3</version>
+    <version>5.7.3.4</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
fixed a small bug in subdirectory resolution ... it wasn't recursing through added directories, which reduces mdoc's ability to properly resolve assemblies.