### PR TITLE
bump to 5.7.4

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.3.4";
+		public static string MonoVersion = "5.7.4";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.3.4</version>
+    <version>5.7.4</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
- #334 - all interfaces are now listed
- #103 - all assemblies in a framework are now listed in the framework index file
   ```xml
       <Assemblies>
           <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
           <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
       </Assemblies>
   ```
- #357 - stubbing out new types uses the loaded assembly to resolve the framework, rather than the resolved assembly (which might be different due to type exports)