### PR TITLE
mdoc 5.7.4.2 release

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.4.1";
+		public static string MonoVersion = "5.7.4.2";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -2630,7 +2630,7 @@ namespace Mono.Documentation
             TypeDefinition typeDefinition = mi as TypeDefinition;
             if (typeDefinition != null && typeDefinition.IsSerializable)
             {
-                attrs = attrs.Concat (new[] { "Serializable" });
+                attrs = attrs.Concat (new[] { "System.Serializable" });
             }
 
             PropertyDefinition pd = mi as PropertyDefinition;

--- a/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
@@ -57,6 +57,16 @@ namespace Mono.Documentation.Updater.Frameworks
 
         public static string GetFrameworkNameFromPath (string rootpath, string assemblyPath)
         {
+            char otherSepChar = '/';
+            if (Path.DirectorySeparatorChar == '/')
+                otherSepChar = '\\';
+
+            if (rootpath.Contains(otherSepChar))
+                rootpath = rootpath.Replace(otherSepChar, Path.DirectorySeparatorChar);
+
+            if (assemblyPath.Contains(otherSepChar))
+                assemblyPath = assemblyPath.Replace(otherSepChar, Path.DirectorySeparatorChar);
+
             var frameworksDirectory = rootpath.EndsWith ("frameworks.xml", StringComparison.OrdinalIgnoreCase)
                                                         ? Path.GetDirectoryName (rootpath) : rootpath;
             string relativePath = assemblyPath.Replace (frameworksDirectory, string.Empty);

--- a/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkTypeEntry.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkTypeEntry.cs
@@ -70,8 +70,11 @@ namespace Mono.Documentation.Updater.Frameworks
             try
             {
                 var sig = formatter.GetDeclaration(member);
-                if (sig != null && !sigMap.ContainsKey(sig))
-                    sigMap.Add(sig, string.Empty);
+                if (sig != null && !sigMap.ContainsKey (sig))
+                {
+                    sigMap.Add (sig, string.Empty);
+                    key = sig;
+                }
             }
             catch { }
 

--- a/mdoc/Test/en.expected-fsharp/AbstractClasses+Circle.xml
+++ b/mdoc/Test/en.expected-fsharp/AbstractClasses+Circle.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/AbstractClasses+Shape2D.xml
+++ b/mdoc/Test/en.expected-fsharp/AbstractClasses+Shape2D.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/AbstractClasses+Square.xml
+++ b/mdoc/Test/en.expected-fsharp/AbstractClasses+Square.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Animals+Animal.xml
+++ b/mdoc/Test/en.expected-fsharp/Animals+Animal.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Animals+Dog.xml
+++ b/mdoc/Test/en.expected-fsharp/Animals+Dog.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Attributes+CompanyAttribute.xml
+++ b/mdoc/Test/en.expected-fsharp/Attributes+CompanyAttribute.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Attributes+OwnerAttribute.xml
+++ b/mdoc/Test/en.expected-fsharp/Attributes+OwnerAttribute.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Attributes+SomeType1.xml
+++ b/mdoc/Test/en.expected-fsharp/Attributes+SomeType1.xml
@@ -21,7 +21,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Attributes+TypeWithFlagAttribute.xml
+++ b/mdoc/Test/en.expected-fsharp/Attributes+TypeWithFlagAttribute.xml
@@ -18,7 +18,7 @@
       <AttributeName>System.AttributeUsage(System.AttributeTargets.Module | System.AttributeTargets.Event | System.AttributeTargets.Delegate, AllowMultiple=false)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/ClassMembers+PointWithCounter.xml
+++ b/mdoc/Test/en.expected-fsharp/ClassMembers+PointWithCounter.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Collections+MDocInterface`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Collections+MDocInterface`1.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Collections+MDocTestMap`2.xml
+++ b/mdoc/Test/en.expected-fsharp/Collections+MDocTestMap`2.xml
@@ -23,7 +23,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class10`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class10`1.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class11`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class11`1.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class12`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class12`1.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class13`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class13`1.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class14`2.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class14`2.xml
@@ -19,7 +19,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class15.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class15.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class16.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class16.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class17.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class17.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class18.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class18.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class1`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class1`1.xml
@@ -22,7 +22,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class2_1`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class2_1`1.xml
@@ -23,7 +23,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class2_2`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class2_2`1.xml
@@ -23,7 +23,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class2`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class2`1.xml
@@ -22,7 +22,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class3`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class3`1.xml
@@ -22,7 +22,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class4`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class4`1.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class5`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class5`1.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class6`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class6`1.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class7`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class7`1.xml
@@ -22,7 +22,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class8`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class8`1.xml
@@ -22,7 +22,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constraints+Class9`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constraints+Class9`1.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+Account.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+Account.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+Account2.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+Account2.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+BaseClass.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+BaseClass.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+DerivedClass.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+DerivedClass.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClass.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClass.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClass1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClass1.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClass2.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClass2.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClass3.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClass3.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClass3_1.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClass3_1.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClass3_2.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClass3_2.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClass3_3.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClass3_3.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClass3_4.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClass3_4.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClassBase2.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClassBase2.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClassDerived2.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClassDerived2.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyClassObjectParameters.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyClassObjectParameters.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyStruct.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyStruct.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyStruct2.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyStruct2.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyStruct33.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyStruct33.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyStruct44.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyStruct44.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyStruct55.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyStruct55.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyStruct66.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyStruct66.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyStruct77.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyStruct77.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyStruct88.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyStruct88.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+MyType.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+MyType.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+Person.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+Person.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+Pet.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+Pet.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Constructors+PetData.xml
+++ b/mdoc/Test/en.expected-fsharp/Constructors+PetData.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.RecordType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Customers+ICustomer.xml
+++ b/mdoc/Test/en.expected-fsharp/Customers+ICustomer.xml
@@ -12,7 +12,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate1.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate1.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate10.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate10.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate11.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate11.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate12.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate12.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters />

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate13.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate13.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate2.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate2.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate3.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate3.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate4.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate4.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate5.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate5.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate6.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate6.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate7.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate7.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate8.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate8.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Delegate9.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Delegate9.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Parameters>

--- a/mdoc/Test/en.expected-fsharp/Delegates+Test1.xml
+++ b/mdoc/Test/en.expected-fsharp/Delegates+Test1.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+ColorEnum.xml
+++ b/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+ColorEnum.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+Shape+Circle.xml
+++ b/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+Shape+Circle.xml
@@ -18,7 +18,7 @@
       <AttributeName>System.Diagnostics.DebuggerTypeProxy(typeof(DiscriminatedUnions/Shape/Circle@DebugTypeProxy))</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+Shape+Prism.xml
+++ b/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+Shape+Prism.xml
@@ -18,7 +18,7 @@
       <AttributeName>System.Diagnostics.DebuggerTypeProxy(typeof(DiscriminatedUnions/Shape/Prism@DebugTypeProxy))</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+Shape+Rectangle.xml
+++ b/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+Shape+Rectangle.xml
@@ -18,7 +18,7 @@
       <AttributeName>System.Diagnostics.DebuggerTypeProxy(typeof(DiscriminatedUnions/Shape/Rectangle@DebugTypeProxy))</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+Shape.xml
+++ b/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+Shape.xml
@@ -34,7 +34,7 @@
       <AttributeName>System.Diagnostics.DebuggerDisplay("{__DebugDisplay(),nq}")</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+SizeUnion.xml
+++ b/mdoc/Test/en.expected-fsharp/DiscriminatedUnions+SizeUnion.xml
@@ -34,7 +34,7 @@
       <AttributeName>System.Diagnostics.DebuggerDisplay("{__DebugDisplay(),nq}")</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/DoBindings+MyBindingType.xml
+++ b/mdoc/Test/en.expected-fsharp/DoBindings+MyBindingType.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Enumerations+Color.xml
+++ b/mdoc/Test/en.expected-fsharp/Enumerations+Color.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Extensions+MyModule1+MyClass.xml
+++ b/mdoc/Test/en.expected-fsharp/Extensions+MyModule1+MyClass.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Functions+TestFunction.xml
+++ b/mdoc/Test/en.expected-fsharp/Functions+TestFunction.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Generics+Map2`2.xml
+++ b/mdoc/Test/en.expected-fsharp/Generics+Map2`2.xml
@@ -34,7 +34,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/IndexedProperties+NumberStrings.xml
+++ b/mdoc/Test/en.expected-fsharp/IndexedProperties+NumberStrings.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Inheritance+BaseClass.xml
+++ b/mdoc/Test/en.expected-fsharp/Inheritance+BaseClass.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Inheritance+DerivedClass.xml
+++ b/mdoc/Test/en.expected-fsharp/Inheritance+DerivedClass.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Inheritance+MyClassBase1.xml
+++ b/mdoc/Test/en.expected-fsharp/Inheritance+MyClassBase1.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Inheritance+MyClassBase2.xml
+++ b/mdoc/Test/en.expected-fsharp/Inheritance+MyClassBase2.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Inheritance+MyClassDerived1.xml
+++ b/mdoc/Test/en.expected-fsharp/Inheritance+MyClassDerived1.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Inheritance+MyClassDerived2.xml
+++ b/mdoc/Test/en.expected-fsharp/Inheritance+MyClassDerived2.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/InlineFunctions+WrapInt32.xml
+++ b/mdoc/Test/en.expected-fsharp/InlineFunctions+WrapInt32.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Interfaces+IPrintable.xml
+++ b/mdoc/Test/en.expected-fsharp/Interfaces+IPrintable.xml
@@ -12,7 +12,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Interfaces+Interface0.xml
+++ b/mdoc/Test/en.expected-fsharp/Interfaces+Interface0.xml
@@ -12,7 +12,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Interfaces+Interface1.xml
+++ b/mdoc/Test/en.expected-fsharp/Interfaces+Interface1.xml
@@ -12,7 +12,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Interfaces+Interface2.xml
+++ b/mdoc/Test/en.expected-fsharp/Interfaces+Interface2.xml
@@ -12,7 +12,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Interfaces+Interface3.xml
+++ b/mdoc/Test/en.expected-fsharp/Interfaces+Interface3.xml
@@ -19,7 +19,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Interfaces+MyClass.xml
+++ b/mdoc/Test/en.expected-fsharp/Interfaces+MyClass.xml
@@ -25,7 +25,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Interfaces+SomeClass1.xml
+++ b/mdoc/Test/en.expected-fsharp/Interfaces+SomeClass1.xml
@@ -19,7 +19,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Interfaces+SomeClass2.xml
+++ b/mdoc/Test/en.expected-fsharp/Interfaces+SomeClass2.xml
@@ -19,7 +19,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Methods+Circle.xml
+++ b/mdoc/Test/en.expected-fsharp/Methods+Circle.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Methods+Ellipse.xml
+++ b/mdoc/Test/en.expected-fsharp/Methods+Ellipse.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Methods+RectangleXY.xml
+++ b/mdoc/Test/en.expected-fsharp/Methods+RectangleXY.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Methods+SomeType.xml
+++ b/mdoc/Test/en.expected-fsharp/Methods+SomeType.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/OperatorsOverloading+Vector.xml
+++ b/mdoc/Test/en.expected-fsharp/OperatorsOverloading+Vector.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+Color.xml
+++ b/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+Color.xml
@@ -14,7 +14,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+MyRecord.xml
+++ b/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+MyRecord.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.RecordType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+PersonName+FirstLast.xml
+++ b/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+PersonName+FirstLast.xml
@@ -18,7 +18,7 @@
       <AttributeName>System.Diagnostics.DebuggerTypeProxy(typeof(PatternMatching.PatternMatchingExamples/PersonName/FirstLast@DebugTypeProxy))</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+PersonName+FirstOnly.xml
+++ b/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+PersonName+FirstOnly.xml
@@ -18,7 +18,7 @@
       <AttributeName>System.Diagnostics.DebuggerTypeProxy(typeof(PatternMatching.PatternMatchingExamples/PersonName/FirstOnly@DebugTypeProxy))</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+PersonName+LastOnly.xml
+++ b/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+PersonName+LastOnly.xml
@@ -18,7 +18,7 @@
       <AttributeName>System.Diagnostics.DebuggerTypeProxy(typeof(PatternMatching.PatternMatchingExamples/PersonName/LastOnly@DebugTypeProxy))</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+PersonName.xml
+++ b/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+PersonName.xml
@@ -34,7 +34,7 @@
       <AttributeName>System.Diagnostics.DebuggerDisplay("{__DebugDisplay(),nq}")</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+Shape+Circle.xml
+++ b/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+Shape+Circle.xml
@@ -18,7 +18,7 @@
       <AttributeName>System.Diagnostics.DebuggerTypeProxy(typeof(PatternMatching.PatternMatchingExamples/Shape/Circle@DebugTypeProxy))</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+Shape+Rectangle.xml
+++ b/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+Shape+Rectangle.xml
@@ -18,7 +18,7 @@
       <AttributeName>System.Diagnostics.DebuggerTypeProxy(typeof(PatternMatching.PatternMatchingExamples/Shape/Rectangle@DebugTypeProxy))</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+Shape.xml
+++ b/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples+Shape.xml
@@ -34,7 +34,7 @@
       <AttributeName>System.Diagnostics.DebuggerDisplay("{__DebugDisplay(),nq}")</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Properties+MyAutoPropertyClass.xml
+++ b/mdoc/Test/en.expected-fsharp/Properties+MyAutoPropertyClass.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Properties+MyPropertiesType.xml
+++ b/mdoc/Test/en.expected-fsharp/Properties+MyPropertiesType.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Properties+MyPropertyClass2.xml
+++ b/mdoc/Test/en.expected-fsharp/Properties+MyPropertyClass2.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Records+Car.xml
+++ b/mdoc/Test/en.expected-fsharp/Records+Car.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.RecordType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Records+MyRecord.xml
+++ b/mdoc/Test/en.expected-fsharp/Records+MyRecord.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.RecordType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/SomeNamespace/SomeModule+IVector.xml
+++ b/mdoc/Test/en.expected-fsharp/SomeNamespace/SomeModule+IVector.xml
@@ -12,7 +12,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/SomeNamespace/SomeModule+Vector'''.xml
+++ b/mdoc/Test/en.expected-fsharp/SomeNamespace/SomeModule+Vector'''.xml
@@ -19,7 +19,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/SomeNamespace/SomeModule+Vector.xml
+++ b/mdoc/Test/en.expected-fsharp/SomeNamespace/SomeModule+Vector.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/SomeNamespace/SomeModule+Vector2.xml
+++ b/mdoc/Test/en.expected-fsharp/SomeNamespace/SomeModule+Vector2.xml
@@ -19,7 +19,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Structures+Point2D.xml
+++ b/mdoc/Test/en.expected-fsharp/Structures+Point2D.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Structures+Point3D.xml
+++ b/mdoc/Test/en.expected-fsharp/Structures+Point3D.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Structures+StructureType.xml
+++ b/mdoc/Test/en.expected-fsharp/Structures+StructureType.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Structures+StructureType2.xml
+++ b/mdoc/Test/en.expected-fsharp/Structures+StructureType2.xml
@@ -34,7 +34,7 @@
       <AttributeName>Microsoft.FSharp.Core.Struct</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/TypeExtensions+ExtraCSharpStyleExtensionMethodsInFSharp.xml
+++ b/mdoc/Test/en.expected-fsharp/TypeExtensions+ExtraCSharpStyleExtensionMethodsInFSharp.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/TypeExtensions+TypeExtensions1+MyClass.xml
+++ b/mdoc/Test/en.expected-fsharp/TypeExtensions+TypeExtensions1+MyClass.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+L.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+L.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.Measure</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+bar.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+bar.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.Measure</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+cm.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+cm.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.Measure</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+ft.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+ft.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.Measure</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+g.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+g.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.Measure</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+inch.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+inch.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.Measure</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+kg.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+kg.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.Measure</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+lb.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+lb.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.Measure</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+m.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+m.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.Measure</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+s.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+s.xml
@@ -18,7 +18,7 @@
       <AttributeName>Microsoft.FSharp.Core.Measure</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+vector3D.xml
+++ b/mdoc/Test/en.expected-fsharp/UnitsOfMeasure+vector3D.xml
@@ -31,7 +31,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.RecordType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/Widgets/MyWidget1.xml
+++ b/mdoc/Test/en.expected-fsharp/Widgets/MyWidget1.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/mdoc.Test.FSharp/Class1.xml
+++ b/mdoc/Test/en.expected-fsharp/mdoc.Test.FSharp/Class1.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/Test/en.expected-fsharp/mdoc.Test.FSharp/ClassPipes.xml
+++ b/mdoc/Test/en.expected-fsharp/mdoc.Test.FSharp/ClassPipes.xml
@@ -15,7 +15,7 @@
       <AttributeName>Microsoft.FSharp.Core.CompilationMapping(Microsoft.FSharp.Core.SourceConstructFlags.ObjectType)</AttributeName>
     </Attribute>
     <Attribute>
-      <AttributeName>Serializable</AttributeName>
+      <AttributeName>System.Serializable</AttributeName>
     </Attribute>
   </Attributes>
   <Docs>

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.4.1</version>
+    <version>5.7.4.2</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
- #365 - fully qualifying `Serializable`
- #368 - reduced memory usage on large worksets.
- Fixed unit test suite on windows