### PR TITLE
Ensuring a distinct set of members

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkTypeEntry.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkTypeEntry.cs
@@ -58,7 +58,7 @@ namespace Mono.Documentation.Updater.Frameworks
 
 		public IEnumerable<string> Members {
 			get {
-				return this.sigMap.Values.OrderBy(v => v);
+				return this.sigMap.Values.OrderBy(v => v).Distinct();
 			}
 		}
 


### PR DESCRIPTION
per https://github.com/dotnet/dotnet-api-docs/pull/1173#discussion_r236001734 , there exists a scenario where a duplicate member docid is being included in the frameworks index file. This `.Distinct()` ensures that this is no longer possible