### PR TITLE
mdoc 5.7.4.4

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.4.3";
+		public static string MonoVersion = "5.7.4.4";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -312,7 +312,7 @@ namespace Mono.Documentation
                 var sets = fxd.Select (d => new AssemblySet (
                     d.Name,
                     getFiles (d.Path, "*.dll|*.exe|*.winmd"),
-                    this.globalSearchPaths.Union (d.SearchPaths),
+                    d.SearchPaths.Union(this.globalSearchPaths),
                     d.Imports,
                     d.Version,
                     d.Id

--- a/mdoc/Mono.Documentation/Updater/Frameworks/AssemblySet.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/AssemblySet.cs
@@ -12,9 +12,9 @@ namespace Mono.Documentation.Updater.Frameworks
     /// </summary>
     public class AssemblySet : IDisposable
     {
-        static readonly BaseAssemblyResolver resolver = new Frameworks.MDocResolver ();
-        static IAssemblyResolver cachedResolver;
-        static IMetadataResolver metadataResolver;
+        BaseAssemblyResolver resolver = new Frameworks.MDocResolver ();
+        IAssemblyResolver cachedResolver;
+        IMetadataResolver metadataResolver;
 
         HashSet<string> assemblyPaths = new HashSet<string> ();
         Dictionary<string, bool> assemblyPathsMap = new Dictionary<string, bool> ();
@@ -71,7 +71,7 @@ namespace Mono.Documentation.Updater.Frameworks
                 .Where (p => p.Contains (Path.DirectorySeparatorChar))
                 .Select (p => Path.GetDirectoryName (p));
 
-            foreach (var searchPath in resolverSearchPaths.Union (assemblyDirectories))
+            foreach (var searchPath in assemblyDirectories.Union(resolverSearchPaths))
                 assemblySearchPaths.Add (searchPath);
 
             char oppositeSeparator = Path.DirectorySeparatorChar == '/' ? '\\' : '/';

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.4.3</version>
+    <version>5.7.4.4</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
- #357 - fixes an issue with the assembly resolver cache that was causing cross-framework type/member contamination.
- Also includes a fix to reduce the possibility of duplicating a docid in the frameworks index file.