### PR TITLE
mdoc 5.7.4.5

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.4.4";
+		public static string MonoVersion = "5.7.4.5";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -245,7 +245,7 @@ check-monodocer-cppcli: Test/FrameworkTestData
 
 check-monodocer-cppwinrtUwp: 
 	-rm -Rf Test/en.actual
-	$(MONO) $(PROGRAM) update -lib ..\external\Windows --lang c++/winrt -o Test/en.actual Test/UwpTestWinRtComponentCpp.winmd
+	$(MONO) $(PROGRAM) update -lib ../external/Windows --lang c++/winrt -o Test/en.actual Test/UwpTestWinRtComponentCpp.winmd
 	$(DIFF) Test/ex.expected-cppwinrtuwp Test/en.actual
 	
 check-monodocer-cppcx: Test/FrameworkTestData

--- a/mdoc/Mono.Documentation/MDocException.cs
+++ b/mdoc/Mono.Documentation/MDocException.cs
@@ -6,20 +6,41 @@ namespace Mono.Documentation
     [Serializable]
     internal class MDocException : Exception
     {
-        public MDocException ()
+        public MDocException()
         {
         }
 
-        public MDocException (string message) : base (message)
+        public MDocException(string message) : base(message)
         {
         }
 
-        public MDocException (string message, Exception innerException) : base (message, innerException)
+        public MDocException(string message, Exception innerException) : base(message, innerException)
         {
         }
 
-        protected MDocException (SerializationInfo info, StreamingContext context) : base (info, context)
+        protected MDocException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
+        }
+    }
+
+    [Serializable]
+    internal class MDocAssemblyException : Exception
+    {
+        public string AssemblyName { get; set; }
+
+        public MDocAssemblyException(string assemblyName, string message) : base(message)
+        {
+            this.AssemblyName = assemblyName;
+        }
+
+        public MDocAssemblyException(string assemblyName, string message, Exception innerException) : base(message, innerException)
+        {
+            this.AssemblyName = assemblyName;
+        }
+
+        protected MDocAssemblyException(string assemblyName, SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            this.AssemblyName = assemblyName;
         }
     }
 }

--- a/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
@@ -633,7 +633,7 @@ namespace Mono.Documentation.Updater.Frameworks
 
         internal IEnumerable<string> GetAssemblyPaths(AssemblyNameReference name, IEnumerable<string> directories, IEnumerable<string> filesToIgnore, bool subdirectories)
         {
-            var extensions = name.IsWindowsRuntime ? new[] { ".winmd", ".dll" } : new[] { ".exe", ".dll" };
+            var extensions = name.IsWindowsRuntime ? new[] { ".winmd", ".dll", ".exe" } : new[] { ".exe", ".dll", ".winmd" };
 
             string[] darray = directories.Distinct().ToArray();
             string dkey = string.Join("|", darray);

--- a/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
@@ -42,6 +42,16 @@ namespace Mono.Documentation.Updater.Frameworks
             }
         }
 
+        public MDocResolver() : base()
+        {
+            try
+            {
+                this.RemoveSearchDirectory(".");
+                this.RemoveSearchDirectory("bin");
+            }
+            catch { }
+        }
+
         public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
         {
             return Resolve(name, parameters, null, null);
@@ -361,10 +371,11 @@ namespace Mono.Documentation.Updater.Frameworks
         {
             return Resolve(name, parameters, emptyStringArray);
         }
-
+        
         internal AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters, IEnumerable<string> filesToIgnore)
         {
             var directories = this.GetSearchDirectories();
+            
             var assembly = SearchDirectory(name, directories, parameters, filesToIgnore);
             if (assembly != null)
                 return assembly;

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.4.4</version>
+    <version>5.7.4.5</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
- Improves logging - Log will now be more explicit about what assembly it's currently processing, and include the assembly name and path if an exception is thrown (for example, if it can't resolve a type)
- Resolver is now removing [default cecil search paths](https://github.com/jbevain/cecil/blob/master/Mono.Cecil/BaseAssemblyResolver.cs#L104) - due to re-prioritizing the search paths in the last release, if the program's working directory is set to something else (as would be the case on a CI server), the `.` would result in unexpected assembly resolutions.