### PR TITLE
Compare assembly extensions without case

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
@@ -647,7 +647,7 @@ namespace Mono.Documentation.Updater.Frameworks
 
                 // filter out directories that don't have any assemblies
                 darray = darray
-                    .Where(d => Directory.Exists(d) && Directory.EnumerateFiles(d, "*.*").Any(f => extensions.Any(e => f.EndsWith(e))))
+                    .Where(d => Directory.Exists(d) && Directory.EnumerateFiles(d, "*.*").Any(f => extensions.Any(e => f.EndsWith(e, StringComparison.OrdinalIgnoreCase))))
                     .ToArray();
 
                 allDirectories.Add(dkey, darray);


### PR DESCRIPTION
The `Windows.winmd` in UnionMetadata is actually `Windows.WinMD and does not match.