### PR TITLE
Fix MemberSignatures for ref returns and ref readonly returns

### DIFF
--- a/apidoctools.sln
+++ b/apidoctools.sln
@@ -15,8 +15,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mdoc.Test", "mdoc\mdoc.Test
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "mdoc.Test.FSharp", "mdoc\mdoc.Test\mdoc.Test.FSharp\mdoc.Test.FSharp.fsproj", "{979F9F80-12FE-4236-9E93-6D554AB13701}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mdoc.Test.Cplusplus", "mdoc.Test.Cplusplus\mdoc.Test.Cplusplus.vcxproj", "{9398D4E3-1779-44FD-AF8C-BB46562DCD88}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,18 +123,6 @@ Global
 		{979F9F80-12FE-4236-9E93-6D554AB13701}.Release|x64.Build.0 = Release|Any CPU
 		{979F9F80-12FE-4236-9E93-6D554AB13701}.Release|x86.ActiveCfg = Release|Any CPU
 		{979F9F80-12FE-4236-9E93-6D554AB13701}.Release|x86.Build.0 = Release|Any CPU
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|Any CPU.ActiveCfg = Debug|Win32
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|ARM.ActiveCfg = Debug|Win32
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|x64.ActiveCfg = Debug|x64
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|x64.Build.0 = Debug|x64
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|x86.ActiveCfg = Debug|Win32
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|x86.Build.0 = Debug|Win32
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|Any CPU.ActiveCfg = Release|Win32
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|ARM.ActiveCfg = Release|Win32
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|x64.ActiveCfg = Release|x64
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|x64.Build.0 = Release|x64
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|x86.ActiveCfg = Release|Win32
-		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/apidoctools.sln
+++ b/apidoctools.sln
@@ -13,12 +13,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ICSharpCode.SharpZipLib", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mdoc.Test", "mdoc\mdoc.Test\mdoc.Test.csproj", "{5ADDEFB6-930C-46BC-8B2B-FDE5C7E3B5AD}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "mdoc.Test.FSharp", "mdoc\mdoc.Test\mdoc.Test.FSharp\mdoc.Test.FSharp.fsproj", "{979F9F80-12FE-4236-9E93-6D554AB13701}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "mdoc.Test.FSharp", "mdoc\mdoc.Test\mdoc.Test.FSharp\mdoc.Test.FSharp.fsproj", "{979F9F80-12FE-4236-9E93-6D554AB13701}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mdoc.Test.Cplusplus", "mdoc.Test.Cplusplus\mdoc.Test.Cplusplus.vcxproj", "{9398D4E3-1779-44FD-AF8C-BB46562DCD88}"
 EndProject
 Global
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM = Debug|ARM
@@ -126,12 +125,27 @@ Global
 		{979F9F80-12FE-4236-9E93-6D554AB13701}.Release|x64.Build.0 = Release|Any CPU
 		{979F9F80-12FE-4236-9E93-6D554AB13701}.Release|x86.ActiveCfg = Release|Any CPU
 		{979F9F80-12FE-4236-9E93-6D554AB13701}.Release|x86.Build.0 = Release|Any CPU
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|ARM.ActiveCfg = Debug|Win32
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|x64.ActiveCfg = Debug|x64
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|x64.Build.0 = Debug|x64
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|x86.ActiveCfg = Debug|Win32
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Debug|x86.Build.0 = Debug|Win32
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|Any CPU.ActiveCfg = Release|Win32
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|ARM.ActiveCfg = Release|Win32
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|x64.ActiveCfg = Release|x64
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|x64.Build.0 = Release|x64
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|x86.ActiveCfg = Release|Win32
+		{9398D4E3-1779-44FD-AF8C-BB46562DCD88}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6D6A6927-89D3-42DF-A416-294A841822A9}
+	EndGlobalSection
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = mdoc.csproj

--- a/apidoctools.sln
+++ b/apidoctools.sln
@@ -130,9 +130,6 @@ Global
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6D6A6927-89D3-42DF-A416-294A841822A9}
 	EndGlobalSection
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = mdoc.csproj
 	EndGlobalSection

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -48,7 +48,7 @@ MULTI-UNIFIED = Test/DocTest-DropNS-unified.dll Test/DocTest-DropNS-unified-mult
 
 DIFF = diff -rup
 DIFF_QUIET = diff --brief
-ifeq ($(OS), Windows_NT)
+ifeq ($(PLATFORM), win32)
 DIFF = diff -rupZ
 DIFF_QUIET = diff --brief -Z
 endif

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -48,7 +48,7 @@ MULTI-UNIFIED = Test/DocTest-DropNS-unified.dll Test/DocTest-DropNS-unified-mult
 
 DIFF = diff -rup
 DIFF_QUIET = diff --brief
-ifeq ($(PLATFORM), win32)
+ifeq ($(OS), Windows_NT)
 DIFF = diff -rupZ
 DIFF_QUIET = diff --brief -Z
 endif

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -3830,14 +3830,17 @@ namespace Mono.Documentation
         {
             XmlElement e = WriteElement (root, "ReturnValue");
             var valueToUse = GetDocTypeFullName (type);
-            if (type.IsByReference)
-                e.SetAttribute("RefType", "Ref");
-
-            if (type.IsRequiredModifier && IsReadonlyAttribute(attributes))
+            if (type.IsRequiredModifier)
             {
-                e.SetAttribute("RefType", "Readonly");
-                if (valueToUse[valueToUse.Length - 1] == '&')
-                    valueToUse = valueToUse.Remove(valueToUse.Length - 1);
+                if (((RequiredModifierType)type).ElementType.IsByReference)
+                    e.SetAttribute("RefType", "Ref");
+
+                if (IsReadonlyAttribute(attributes))
+                {
+                    e.SetAttribute("RefType", "Readonly");
+                    if (valueToUse[valueToUse.Length - 1] == '&')
+                        valueToUse = valueToUse.Remove(valueToUse.Length - 1);
+                }
             }
 
             AddXmlNode (e.SelectNodes ("ReturnType").Cast<XmlElement> ().ToArray (),

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -3830,17 +3830,15 @@ namespace Mono.Documentation
         {
             XmlElement e = WriteElement (root, "ReturnValue");
             var valueToUse = GetDocTypeFullName (type);
-            if (type.IsRequiredModifier)
-            {
-                if (((RequiredModifierType)type).ElementType.IsByReference)
-                    e.SetAttribute("RefType", "Ref");
+            if ((type.IsRequiredModifier && ((RequiredModifierType)type).ElementType.IsByReference)
+                    || type.IsByReference)
+                e.SetAttribute("RefType", "Ref");
 
-                if (IsReadonlyAttribute(attributes))
-                {
-                    e.SetAttribute("RefType", "Readonly");
-                    if (valueToUse[valueToUse.Length - 1] == '&')
-                        valueToUse = valueToUse.Remove(valueToUse.Length - 1);
-                }
+            if (type.IsRequiredModifier && IsReadonlyAttribute(attributes))
+            {
+                e.SetAttribute("RefType", "Readonly");
+                if (valueToUse[valueToUse.Length - 1] == '&')
+                    valueToUse = valueToUse.Remove(valueToUse.Length - 1);
             }
 
             AddXmlNode (e.SelectNodes ("ReturnType").Cast<XmlElement> ().ToArray (),

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -411,6 +411,19 @@ namespace Mono.Documentation.Updater
             if (method.IsFinal) modifiers += " sealed";
             if (modifiers == " virtual sealed") modifiers = "";
 
+            if (method.ReturnType.IsRequiredModifier)
+            {
+                if (((RequiredModifierType)method.ReturnType).ElementType.IsByReference)
+                {
+                    modifiers += " ref";
+                }
+
+                if (method.MethodReturnType.CustomAttributes.Any(attr => attr.AttributeType.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute"))
+                {
+                    modifiers += " readonly";
+                }
+            }
+
             switch (method.Name)
             {
                 case "op_Implicit":

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -411,17 +411,17 @@ namespace Mono.Documentation.Updater
             if (method.IsFinal) modifiers += " sealed";
             if (modifiers == " virtual sealed") modifiers = "";
 
-            if (method.ReturnType.IsRequiredModifier)
+            if ((method.ReturnType.IsRequiredModifier
+                  && ((RequiredModifierType)method.ReturnType).ElementType.IsByReference)
+                || method.ReturnType.IsByReference)
             {
-                if (((RequiredModifierType)method.ReturnType).ElementType.IsByReference)
-                {
-                    modifiers += " ref";
-                }
+                modifiers += " ref";
+            }
 
-                if (method.MethodReturnType.CustomAttributes.Any(attr => attr.AttributeType.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute"))
-                {
-                    modifiers += " readonly";
-                }
+            if (method.ReturnType.IsRequiredModifier
+                && method.MethodReturnType.CustomAttributes.Any(attr => attr.AttributeType.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute"))
+            {
+                modifiers += " readonly";
             }
 
             switch (method.Name)

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -207,6 +207,15 @@ namespace mdoc.Test
                 "~SomeGenericClass ();",
                 "Finalize");
 
+        [Test]
+        public void CSharpReadonlyRef()
+        {
+            var member = GetMethod(typeof(ReadonlyRefClass), m => m.Name == "ReadonlyRef");
+            var formatter = new CSharpFullMemberFormatter();
+            var sig = formatter.GetDeclaration(member);
+            Assert.AreEqual("public ref readonly int ReadonlyRef ();", sig);
+        }
+
         #region Helper Methods
         string RealTypeName(string name){
             switch (name) {

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -208,12 +208,21 @@ namespace mdoc.Test
                 "Finalize");
 
         [Test]
-        public void CSharpReadonlyRef()
+        public void CSharpReadonlyRefReturn()
         {
             var member = GetMethod(typeof(ReadonlyRefClass), m => m.Name == "ReadonlyRef");
             var formatter = new CSharpFullMemberFormatter();
             var sig = formatter.GetDeclaration(member);
             Assert.AreEqual("public ref readonly int ReadonlyRef ();", sig);
+        }
+
+        [Test]
+        public void CSharpRefReturn()
+        {
+            var member = GetMethod(typeof(ReadonlyRefClass), m => m.Name == "Ref");
+            var formatter = new CSharpFullMemberFormatter();
+            var sig = formatter.GetDeclaration(member);
+            Assert.AreEqual("public ref int Ref ();", sig);
         }
 
         #region Helper Methods

--- a/mdoc/mdoc.Test/SampleClasses/ReadonlyRefClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/ReadonlyRefClass.cs
@@ -1,0 +1,10 @@
+﻿namespace mdoc.Test.SampleClasses
+{
+    public class ReadonlyRefClass
+    {
+        int i;
+
+        public ref int Ref() => ref i;
+        public ref readonly int ReadonlyRef() => ref i;
+    }
+}

--- a/mdoc/mdoc.Test/mdoc.Test.csproj
+++ b/mdoc/mdoc.Test/mdoc.Test.csproj
@@ -21,12 +21,14 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RunPostBuildEvent>Always</RunPostBuildEvent>
@@ -88,6 +90,7 @@
     <Compile Include="JsUsageFormatterTests.cs" />
     <Compile Include="MDocFileSourceTests.cs" />
     <Compile Include="MDocUpdaterTests.cs" />
+    <Compile Include="SampleClasses\ReadonlyRefClass.cs" />
     <Compile Include="SampleClasses\ReadOnlySpan.cs" />
     <Compile Include="SampleClasses\SomeDelegate.cs" />
     <Compile Include="SampleClasses\SomeInterface.cs" />


### PR DESCRIPTION
This PR is to fix issue #249 . 

It seems that `type.IsByReference` is always false for return values, so I also updated the logic in MDocUpdater.cs.

Not sure whether we need integration test for this change, for now I only added one UT. @joelmartinez please let me know if I need to move the test case to somewhere else.