### PR TITLE
mdoc v5.7.4.6

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.4.5";
+		public static string MonoVersion = "5.7.4.6";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -29,5 +29,6 @@ namespace Mono.Documentation
 		public const string CompilationMappingAttribute = "Microsoft.FSharp.Core.CompilationMappingAttribute";
         public const string FrameworksIndex = "FrameworksIndex";
 		public const string FrameworkAlternate = "FrameworkAlternate";
+        public const string Index = "Index";
     }
 }

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -584,14 +584,17 @@ check-monodocer-frameworkalternate: Test/FrameworkTestData-frameworkalternate
 	-rm -Rf Test/en.actual
 
 	# Run Test
+	echo "First run"
 	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/FrameworkTestData-frameworkalternate
 	$(DIFF) Test/en.expected-frameworkalternate Test/en.actual
 	# run test again to make sure subsequent runs maintain data
+	echo "Second run"
 	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/FrameworkTestData-frameworkalternate
 	$(DIFF) Test/en.expected-frameworkalternate Test/en.actual
 
 	# Test Future FX Alignment ... 
-	# compile new version of `two` that looks like `one`
+	echo "compile new version of 'two' that looks like 'one'"
+	
 	rm Test/DocTest-frameworkalternate-two.dll
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -debug -target:library -out:Test/DocTest-frameworkalternate-two.dll Test/DocTest-frameworkalternate.cs /define:FXONE
 	yes | cp Test/DocTest-frameworkalternate-two.dll Test/FrameworkTestData-frameworkalternate/Two/DocTest-frameworkalternate-two.dll

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1491,7 +1491,7 @@ namespace Mono.Documentation
 
             Dictionary<string, List<MemberReference>> implementedMembers = DocUtils.GetImplementedMembersFingerprintLookup(type);
 
-            foreach (DocsNodeInfo info in docEnum.GetDocumentationMembers (basefile, type, typeEntry))
+            foreach (DocsNodeInfo info in docEnum.GetDocumentationMembers(basefile, type, typeEntry))
             {
                 if (info.Node.ParentNode == null)
                     continue;
@@ -1624,7 +1624,7 @@ namespace Mono.Documentation
 
                 if (oldmember.HasAttribute("ToDelete"))
                 {
-                    // this is the restult of an error state, let's remove this
+                    // this is the result of an error state, let's remove this
                     oldmember.RemoveAttribute ("ToDelete");
                 }
             }
@@ -2376,6 +2376,11 @@ namespace Mono.Documentation
                                 }
                             }
 
+                        }
+                        else
+                        {
+                            var newelement = makeNewNode();
+                            newelement.SetAttribute(Consts.FrameworkAlternate, currentFX);
                         }
                         return;
                     }
@@ -3670,8 +3675,6 @@ namespace Mono.Documentation
                         addParameter (p.Definition, lastElement, p.Type, i, false, typeEntry.Framework.Name, false);
                     }
                 }
-
-
             }
 
             // this section syncs up the indices
@@ -3682,7 +3685,7 @@ namespace Mono.Documentation
                 if (xitem != null && xitem.Element.HasAttribute ("Index"))
                 {
                     xitem.Element.SetAttribute ("Index", p.Index.ToString ());
-                }
+                } 
             }
 
             //-purge `typeEntry.Framework` from any<parameter> that 
@@ -3718,6 +3721,17 @@ namespace Mono.Documentation
                     {
                         a.Element.SetAttribute (Consts.FrameworkAlternate, newValue);
                     }
+                }
+            }
+
+            var allFrameworks = typeEntry.Framework.AllFrameworksString;
+            foreach (var parameter in paramNodes
+                .Cast<XmlElement>())
+            {
+                // if FXAlternate is entire list, just remove it
+                if (parameter.HasAttribute(Consts.FrameworkAlternate) && parameter.GetAttribute(Consts.FrameworkAlternate) == allFrameworks)
+                {
+                    parameter.RemoveAttribute(Consts.FrameworkAlternate);
                 }
             }
         }

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -3546,6 +3546,11 @@ namespace Mono.Documentation
         {
             XmlElement e = WriteElement (root, "Parameters");
 
+            if (typeEntry.Framework.IsFirstFramework)
+            {
+                e.RemoveAll();
+            }
+
             #region helper functions
             /// addParameter does the work of adding the actual parameter to the XML
             Action<ParameterDefinition, XmlElement, string, int, bool, string, bool> addParameter = (ParameterDefinition param, XmlElement nextTo, string paramType, int index, bool addIndex, string fx, bool addfx) =>
@@ -3566,9 +3571,9 @@ namespace Mono.Documentation
                     else
                         pe.SetAttribute ("RefType", "ref");
                 }
-                if (addIndex)
+                //if (addIndex)
                     pe.SetAttribute ("Index", index.ToString ());
-                if (addfx)
+                //if (addfx)
                     pe.SetAttribute (Consts.FrameworkAlternate, fx);
 
 				MakeAttributes (pe, GetCustomAttributes (param.CustomAttributes, ""), typeEntry.Framework);
@@ -3630,7 +3635,7 @@ namespace Mono.Documentation
                 if (xitem != null)
                 {
                     var xelement = xitem.Element;
-                    if (xelement.HasAttribute (Consts.FrameworkAlternate) && !xelement.GetAttribute (Consts.FrameworkAlternate).Contains (typeEntry.Framework.Name))
+                    //if (xelement.HasAttribute (Consts.FrameworkAlternate) && !xelement.GetAttribute (Consts.FrameworkAlternate).Contains (typeEntry.Framework.Name))
                         xelement.SetAttribute (Consts.FrameworkAlternate, FXUtils.AddFXToList (xelement.GetAttribute (Consts.FrameworkAlternate), typeEntry.Framework.Name));
                     
                     // update the type name. This supports the migration to a

--- a/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
@@ -13,12 +13,15 @@ namespace Mono.Documentation.Updater.Frameworks
 	public class FrameworkIndex
 	{
 		List<FrameworkEntry> frameworks = new List<FrameworkEntry> ();
+        IList<FrameworkEntry> cachedFrameworks;
+
 		string path;
 
-		public FrameworkIndex (string pathToFrameworks, int fxCount) 
+		public FrameworkIndex (string pathToFrameworks, int fxCount, IList<FrameworkEntry> cachedfx) 
 		{
 			path = pathToFrameworks;
             FrameworksCount = fxCount;
+            cachedFrameworks = cachedfx ?? frameworks;
 		}
 
         public int FrameworksCount {
@@ -45,7 +48,7 @@ namespace Mono.Documentation.Updater.Frameworks
             var entry = frameworks.FirstOrDefault (f => f.Name.Equals (shortPath));
             if (entry == null)
             {
-                entry = new FrameworkEntry (frameworks, FrameworksCount) { Name = shortPath, Importers = importers, Id = Id, Version = Version };
+                entry = new FrameworkEntry (frameworks, FrameworksCount, cachedFrameworks) { Name = shortPath, Importers = importers, Id = Id, Version = Version };
                 frameworks.Add (entry);
             }
 

--- a/mdoc/Test/en.expected-frameworkalternate-aligned/Monodoc.Test/MyClass.xml
+++ b/mdoc/Test/en.expected-frameworkalternate-aligned/Monodoc.Test/MyClass.xml
@@ -57,9 +57,9 @@
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
       <Parameters>
-        <Parameter Name="a" Type="System.Int32" Index="0" />
-        <Parameter Name="b" Type="System.String" Index="1" FrameworkAlternate="One;Three;Two" />
-        <Parameter Name="c" Type="System.Int32" Index="2" />
+        <Parameter Name="a" Type="System.Int32" />
+        <Parameter Name="b" Type="System.String" />
+        <Parameter Name="c" Type="System.Int32" />
       </Parameters>
       <Docs>
         <param name="a">To be added.</param>

--- a/mdoc/mdoc.Test/Enumeration/EnumeratorTests.cs
+++ b/mdoc/mdoc.Test/Enumeration/EnumeratorTests.cs
@@ -48,6 +48,9 @@ namespace mdoc.Test
         [Test]
         public void GetMember_EII2 () => TestPropertyMember ("mdoc.Test.EnumeratorTests.IFace2.AProperty", XML_PROPERTY_IFACE2);
 
+        [Test]
+        public void GetMethod() => TestMethodMember("BeginRead", XML_METHOD_TESTMETHOD);
+
         #region Test infrastructure
 
         private void TestProperty (string propertyName)
@@ -74,6 +77,19 @@ namespace mdoc.Test
             Assert.AreEqual (propertyName, member.Name);
         }
 
+        private void TestMethodMember(string methodName, string theXml)
+        {
+            TypeDefinition theclass = GetTypeDef<ConcreteClass>();
+
+            XmlDocument document = new XmlDocument();
+            document.LoadXml(theXml);
+
+            var member = DocumentationEnumerator.GetMember(theclass, new DocumentationMember(document.FirstChild, FrameworkTypeEntry.Empty));
+
+            Assert.NotNull(member, "didn't find the node");
+            Assert.AreEqual(methodName, member.Name);
+        }
+
         #endregion
 
         #region Test Types
@@ -93,6 +109,7 @@ namespace mdoc.Test
             public string AProperty { get; set; }
             string IFace1.AProperty { get; set; }
             string IFace2.AProperty { get; set; }
+            public IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback asyncCallback, object asyncState) => null;
         }
 
         #endregion
@@ -128,6 +145,21 @@ namespace mdoc.Test
       <ReturnValue>
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
+    </Member>";
+
+        private string XML_METHOD_TESTMETHOD = @"<Member MemberName=""BeginRead"">
+      <MemberType>Method</MemberType>
+      <ReturnValue>
+        <ReturnType>System.IAsyncResult</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name = ""buffer"" Type=""System.Byte[]"" Index=""0"" FrameworkAlternate=""netcore-1.0;netcore-1.1;netcore-2.0"" />
+        <Parameter Name = ""array"" Type=""System.Byte[]"" Index=""0"" FrameworkAlternate=""netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netstandard-2.0"" />
+        <Parameter Name = ""offset"" Type=""System.Int32"" Index=""1"" FrameworkAlternate=""netcore-2.0;netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netstandard-2.0"" />
+        <Parameter Name = ""count"" Type=""System.Int32"" Index=""2"" FrameworkAlternate=""netcore-2.0;netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netstandard-2.0"" />
+        <Parameter Name = ""asyncCallback"" Type=""System.AsyncCallback"" Index=""3"" FrameworkAlternate=""netcore-2.0;netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netstandard-2.0"" />
+        <Parameter Name = ""asyncState"" Type=""System.Object"" Index=""4"" FrameworkAlternate=""netcore-2.0;netframework-4.5;netframework-4.5.1;netframework-4.5.2;netframework-4.6;netframework-4.6.1;netframework-4.6.2;netframework-4.7;netstandard-2.0"" />
+      </Parameters>
     </Member>";
 
         #endregion

--- a/mdoc/mdoc.Test/FrameworkAlternateTests.cs
+++ b/mdoc/mdoc.Test/FrameworkAlternateTests.cs
@@ -76,10 +76,10 @@ namespace mdoc.Test
         public void LastFramework()
         {
             List<FrameworkEntry> entries = new List<FrameworkEntry>();
-            entries.Add (new FrameworkEntry (entries));
-            entries.Add (new FrameworkEntry (entries));
-            entries.Add (new FrameworkEntry (entries));
-            entries.Add (new FrameworkEntry (entries));
+            entries.Add (new FrameworkEntry (entries, entries));
+            entries.Add (new FrameworkEntry (entries, entries));
+            entries.Add (new FrameworkEntry (entries, entries));
+            entries.Add (new FrameworkEntry (entries, entries));
 
             Assert.IsFalse (entries[0].IsLastFramework);
             Assert.IsFalse (entries[1].IsLastFramework);
@@ -91,10 +91,10 @@ namespace mdoc.Test
         public void FirstFramework ()
         {
             List<FrameworkEntry> entries = new List<FrameworkEntry> ();
-            entries.Add (new FrameworkEntry (entries));
-            entries.Add (new FrameworkEntry (entries));
-            entries.Add (new FrameworkEntry (entries));
-            entries.Add (new FrameworkEntry (entries));
+            entries.Add (new FrameworkEntry (entries, entries));
+            entries.Add (new FrameworkEntry (entries, entries));
+            entries.Add (new FrameworkEntry (entries, entries));
+            entries.Add (new FrameworkEntry (entries, entries));
 
             Assert.IsTrue (entries[0].IsFirstFramework);
             Assert.IsFalse (entries[1].IsFirstFramework);

--- a/mdoc/mdoc.Test/XmlConsts.cs
+++ b/mdoc/mdoc.Test/XmlConsts.cs
@@ -10,9 +10,25 @@
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
       <Parameters>
-          <Parameter Name = ""a"" Type=""System.Int32"" />
-          <Parameter Name = ""b"" Type=""System.String"" />
-          <Parameter Name = ""c"" Type=""System.Int32"" />
+          <Parameter Name = ""a"" Type=""System.Int32"" Index=""0"" FrameworkAlternate=""One"" />
+          <Parameter Name = ""b"" Type=""System.String"" Index=""1"" FrameworkAlternate=""One"" />
+          <Parameter Name = ""c"" Type=""System.Int32"" Index=""2"" FrameworkAlternate=""One"" />
+      </Parameters>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>";
+
+        public const string NormalSingleXml = @"<Member MemberName=""Meth"">
+      <MemberType>Method</MemberType>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+          <Parameter Name = ""a"" Type=""System.Int32"" Index=""0"" FrameworkAlternate=""One"" />
+          <Parameter Name = ""d"" Type=""System.String"" Index=""1"" FrameworkAlternate=""One"" />
+          <Parameter Name = ""c"" Type=""System.Int32"" Index=""2"" FrameworkAlternate=""One"" />
       </Parameters>
       <Docs>
         <summary>To be added.</summary>
@@ -80,14 +96,47 @@
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
       <Parameters>
-        <Parameter Name = ""d"" Type=""System.Int32"" Index=""0"" FrameworkAlternate=""One;Three;Two"" />
-        <Parameter Name = ""e"" Type=""System.String"" Index=""1"" FrameworkAlternate=""One;Three;Two"" />
-        <Parameter Name = ""f"" Type=""System.Int32"" Index=""2"" FrameworkAlternate=""One;Three;Two"" />
+        <Parameter Name = ""d"" Type=""System.Int32"" />
+        <Parameter Name = ""e"" Type=""System.String"" />
+        <Parameter Name = ""f"" Type=""System.Int32"" />
       </Parameters>
       <Docs>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
+    </Member>";
+
+        public const string XML_METHOD_TESTMETHOD_BEFORE = @"<Member MemberName=""BeginRead"">
+      <MemberType>Method</MemberType>
+      <ReturnValue>
+        <ReturnType>System.IAsyncResult</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name = ""buffer"" Type=""System.Byte[]"" Index=""0"" FrameworkAlternate=""One"" />
+        <Parameter Name = ""array"" Type=""System.Byte[]"" Index=""0"" FrameworkAlternate=""Two"" />
+        <Parameter Name = ""offset"" Type=""System.Int32"" Index=""1"" FrameworkAlternate=""One;Two"" />
+        <Parameter Name = ""count"" Type=""System.Int32"" Index=""2"" FrameworkAlternate=""One;Two"" />
+        <Parameter Name = ""asyncCallback"" Type=""System.AsyncCallback"" Index=""3"" FrameworkAlternate=""One;Two"" />
+        <Parameter Name = ""asyncState"" Type=""System.Object"" Index=""4"" FrameworkAlternate=""One;Two"" />
+      </Parameters>
+    </Member>";
+
+        //byte[] buffer, int offset, int count, AsyncCallback cback, object state
+        public const string XML_METHOD_TESTMETHOD_AFTER = @"<Member MemberName=""BeginRead"">
+      <MemberType>Method</MemberType>
+      <ReturnValue>
+        <ReturnType>System.IAsyncResult</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name = ""buffer"" Type=""System.Byte[]"" Index=""0"" FrameworkAlternate=""One;Three"" />
+        <Parameter Name = ""array"" Type=""System.Byte[]"" Index=""0"" FrameworkAlternate=""Two"" />
+        <Parameter Name = ""offset"" Type=""System.Int32"" Index=""1"" />
+        <Parameter Name = ""count"" Type=""System.Int32"" Index=""2"" />
+        <Parameter Name = ""asyncCallback"" Type=""System.AsyncCallback"" Index=""3"" FrameworkAlternate=""One;Two"" />
+        <Parameter Name = ""cback"" Type=""System.AsyncCallback"" Index=""3"" FrameworkAlternate=""Three"" />
+        <Parameter Name = ""asyncState"" Type=""System.Object"" Index=""4"" FrameworkAlternate=""One;Two"" />
+        <Parameter Name = ""state"" Type=""System.Object"" Index=""4"" FrameworkAlternate=""Three"" />
+      </Parameters>
     </Member>";
 
         #endregion

--- a/mdoc/mdoc.Test/XmlUpdateTests.cs
+++ b/mdoc/mdoc.Test/XmlUpdateTests.cs
@@ -159,11 +159,11 @@ namespace mdoc.Test
         [Test()]
         public void Parameters_Updating_BeginRead()
         {
-            FrameworkIndex fx = new FrameworkIndex("", 3);
+            FrameworkIndex fx = new FrameworkIndex("", 3, null);
 
-            fx.Frameworks.Add(new FrameworkEntry(fx.Frameworks) { Id = "One", Name = "One", Replace = "mdoc.Test2", With = "mdoc.Test" });
-            fx.Frameworks.Add(new FrameworkEntry(fx.Frameworks) { Id = "Two", Name = "Two", Replace = "mdoc.Test2", With = "mdoc.Test" });
-            fx.Frameworks.Add(new FrameworkEntry(fx.Frameworks) { Id = "Three", Name = "Three", Replace = "mdoc.Test2", With = "mdoc.Test" });
+            fx.Frameworks.Add(new FrameworkEntry(fx.Frameworks, fx.Frameworks) { Id = "One", Name = "One", Replace = "mdoc.Test2", With = "mdoc.Test" });
+            fx.Frameworks.Add(new FrameworkEntry(fx.Frameworks, fx.Frameworks) { Id = "Two", Name = "Two", Replace = "mdoc.Test2", With = "mdoc.Test" });
+            fx.Frameworks.Add(new FrameworkEntry(fx.Frameworks, fx.Frameworks) { Id = "Three", Name = "Three", Replace = "mdoc.Test2", With = "mdoc.Test" });
             
             var context = InitComplexContext<MyComplicatedClass>(XmlConsts.XML_METHOD_TESTMETHOD_BEFORE, "mdoc.Test", "BeginRead", fx);
             var theType = context.method.DeclaringType.Resolve();
@@ -848,10 +848,10 @@ namespace mdoc.Test
 
             // updater
             var updater = new MDocUpdater ();
-            var fx = new FrameworkIndex ("", 3);
-            fx.Frameworks.Add (new FrameworkEntry (fx.Frameworks) { Id = "One", Name = "One", Replace="mdoc.Test2", With="mdoc.Test" });
-            fx.Frameworks.Add (new FrameworkEntry (fx.Frameworks) { Id = "Three", Name = "Three", Replace = "mdoc.Test2", With = "mdoc.Test"  });
-            fx.Frameworks.Add (new FrameworkEntry (fx.Frameworks) { Id = "Two", Name = "Two", Replace = "mdoc.Test2", With = "mdoc.Test"  });
+            var fx = new FrameworkIndex ("", 3, null);
+            fx.Frameworks.Add (new FrameworkEntry (fx.Frameworks, fx.Frameworks) { Id = "One", Name = "One", Replace="mdoc.Test2", With="mdoc.Test" });
+            fx.Frameworks.Add (new FrameworkEntry (fx.Frameworks, fx.Frameworks) { Id = "Three", Name = "Three", Replace = "mdoc.Test2", With = "mdoc.Test"  });
+            fx.Frameworks.Add (new FrameworkEntry (fx.Frameworks, fx.Frameworks) { Id = "Two", Name = "Two", Replace = "mdoc.Test2", With = "mdoc.Test"  });
 
             var i = 0;
             foreach (var f in fx.Frameworks)

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.4.5</version>
+    <version>5.7.4.6</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
- #291 - Fixes an issue with property indexing in frameworks mode
- #249 - added C# signature support for `ref readonly` and `ref return`
- Now supports resolving assemblies with non-lowercase extensions