### PR TITLE
mdoc 5.7.4.8

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.4.7";
+		public static string MonoVersion = "5.7.4.8";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.4.7</version>
+    <version>5.7.4.8</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
- `param` nodes will no longer 'lose' documentation.
- `Parameter` nodes will now have more consistent `Index` and `FrameworkAlternate` attributes when necessary.
- #413 - framework names are now sorted by alpha in the `fx-bootstrap` subcommand.
- #367 - attached property support now includes read or write only attached properties.