### PR TITLE
MemberFormatter.cs: Fix compilation against Mono mscorlib.dll

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Formatters/MemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/MemberFormatter.cs
@@ -71,7 +71,7 @@ namespace Mono.Documentation.Updater
             // expressed in C#. If finer control is needed in the future, you can
             // use IModifierType, PointerType, ByReferenceType, etc.
 
-            int modIndex = Math.Max (typeName.LastIndexOf ("modopt(", StringComparison.Ordinal), typeName.LastIndexOf ("modreq(", StringComparison.Ordinal));
+            int modIndex = System.Math.Max (typeName.LastIndexOf ("modopt(", StringComparison.Ordinal), typeName.LastIndexOf ("modreq(", StringComparison.Ordinal));
             if (modIndex > 0)
             {
                 var tname = typeName.Substring (0, modIndex - 1);
@@ -83,7 +83,7 @@ namespace Mono.Documentation.Updater
                 typeName = tname;
             }
 
-            modIndex = Math.Max (typeName.LastIndexOf ("modopt(", StringComparison.Ordinal), typeName.LastIndexOf ("modreq(", StringComparison.Ordinal));
+            modIndex = System.Math.Max (typeName.LastIndexOf ("modopt(", StringComparison.Ordinal), typeName.LastIndexOf ("modreq(", StringComparison.Ordinal));
             if (modIndex >= 0)
                 return RemoveMod (typeName);
             else


### PR DESCRIPTION
It contains an internal Mono.Math namespace which confuses the compiler and causes:

```
MemberFormatter.cs(74,28): error CS0234: The type or namespace name 'Max' does not exist in the namespace 'Mono.Math' (are you missing an assembly reference?)
```