### PR TITLE
Incorrect FXA attributes on Parameter

### DIFF
--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -3767,6 +3767,9 @@ namespace Mono.Documentation
 
         public void MakeParameters (XmlElement root, MemberReference member, IList<ParameterDefinition> parameters, FrameworkTypeEntry typeEntry, ref bool fxAlternateTriggered, bool shouldDuplicateWithNew = false)
         {
+            if (typeEntry.TimesProcessed > 1)
+                return;
+
             XmlElement e = WriteElement (root, "Parameters");
 
             if (typeEntry.Framework.IsFirstFrameworkForType(typeEntry))


### PR DESCRIPTION
This fixes an issue caused by a type forwarded type being processed more than one type, resulting in incorrect FrameworkAlternate attributes on Parameter nodes.