### PR TITLE
DocumentationEnumerator.cs: Declare iface and ifaceMethod correctly to

### DIFF
--- a/mdoc/Mono.Documentation/Updater/DocumentationEnumerator.cs
+++ b/mdoc/Mono.Documentation/Updater/DocumentationEnumerator.cs
@@ -341,7 +341,7 @@ namespace Mono.Documentation.Updater
                             var method = ((PropertyDefinition) mr).GetMethod ?? ((PropertyDefinition) mr).SetMethod;
                             if (method?.Overrides != null && method.Overrides.Any())
                             {
-                                DocUtils.GetInfoForExplicitlyImplementedMethod(method, out var iface, out var ifaceMethod);
+                                DocUtils.GetInfoForExplicitlyImplementedMethod(method, out TypeReference iface, out MethodReference ifaceMethod);
                                 var newName = DocUtils.GetMemberForProperty(ifaceMethod.Name);
                                 if (newName == memberName && verifyInterface(mr) && docName.Contains (iface.Name))
                                     yield return mr;


### PR DESCRIPTION
fix NRE

Using TypeReference and MethodReference instead of var to declare them.

Fix #462

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>