### PR TITLE
msxdoc importer now clears all existing nodes,

### DIFF
--- a/mdoc/Mono.Documentation/Updater/MsxdocDocumentationImporter.cs
+++ b/mdoc/Mono.Documentation/Updater/MsxdocDocumentationImporter.cs
@@ -56,6 +56,12 @@ namespace Mono.Documentation.Updater
 
             XmlElement e = info.Node;
 
+            if (e.SelectNodes("./*[@overwrite]").Count == 0)
+            {
+                // there are no overwrites in this node, just clear everything except for default nodes and nodes that don't have an incoming equivalent
+                DocUtils.ClearNodesIfNotDefault(e, elem);
+            }
+
             if (elem.SelectSingleNode("summary") != null && DocUtils.NeedsOverwrite(e["summary"]))
                 MDocUpdater.ClearElement(e, "summary");
             if (elem.SelectSingleNode("remarks") != null && DocUtils.NeedsOverwrite(e["remarks"]))
@@ -81,6 +87,15 @@ namespace Mono.Documentation.Updater
                             if (name == null)
                                 break;
                             XmlElement p2 = (XmlElement)e.SelectSingleNode (child.Name + "[@name='" + name.Value + "']");
+                            if (p2 == null)
+                            {
+                                p2 = e.OwnerDocument.CreateElement(child.Name);
+                                var pname = e.OwnerDocument.CreateAttribute("name");
+                                pname.Value = name.Value;
+
+                                p2.Attributes.Append(pname);
+                                e.AppendChild(p2);
+                            }
                             if (DocUtils.NeedsOverwrite(p2))
                             {
                                 p2.RemoveAttribute("overwrite");

--- a/mdoc/mdoc.Test/DocUtilsTests.cs
+++ b/mdoc/mdoc.Test/DocUtilsTests.cs
@@ -1,6 +1,7 @@
 ﻿using mdoc.Test.SampleClasses;
 using Mono.Documentation.Updater;
 using NUnit.Framework;
+using System.Xml;
 
 namespace mdoc.Test
 {
@@ -45,6 +46,26 @@ namespace mdoc.Test
             var isIgnoredPropertyGeneratedMethod = DocUtils.IsIgnored(method);
 
             Assert.IsTrue(isIgnoredPropertyGeneratedMethod);
+        }
+
+        [Test]
+        public void TestNodeCleaner()
+        {
+            string xml = @"<Docs>
+    <summary>To be added.</summary>
+    <param name=""one"">To be added.</param>
+    <param name=""two"">written docs</param>
+<param name=""three"">Written but not provided</param>
+</Docs>"; string xml2 = @"<Docs>
+    <param name=""two"">written docs</param>
+</Docs>";
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+
+            XmlDocument incomingDoc = new XmlDocument();
+            incomingDoc.LoadXml(xml2);
+            DocUtils.ClearNodesIfNotDefault(doc.FirstChild, incomingDoc.FirstChild);
+            Assert.IsTrue(doc.FirstChild.ChildNodes.Count == 3) ;
         }
     }
 }


### PR DESCRIPTION
Except for undocumented nodes, and nodes that don't have an incoming equivalent.
Closes #391.
Closes Internal Item https://ceapex.visualstudio.com/Engineering/_workitems/edit/173471