### PR TITLE
Incorrect signatures for span indexers

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -598,6 +598,9 @@ namespace Mono.Documentation.Updater
                 modifiers = "";
             buf.Append (modifiers).Append (' ');
 
+            if (property.PropertyType.IsByReference)
+                buf.Append("ref ");
+
             buf.Append (GetTypeName (property.PropertyType, new DynamicParserContext (property))).Append (' ');
 
             IEnumerable<MemberReference> defs = property.DeclaringType.GetDefaultMembers ();

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -208,6 +208,17 @@ namespace mdoc.Test
             var sig = formatter.GetDeclaration (member);
             Assert.AreEqual ("public void DoSomethingWithParams (params int[] values);", sig);
         }
+
+        [Test]
+        public void RefProperty()
+        {
+            var member = GetType(typeof(SpanSpecial<>))
+                .Properties.FirstOrDefault(t => t.FullName == "T& mdoc.Test.SpanSpecial`1::Item(System.Int32)");
+            var formatterCsharp = new CSharpFullMemberFormatter();
+            string sig = formatterCsharp.GetDeclaration(member);
+            Assert.AreEqual("public ref T this[int index] { get; }", sig);
+        }
+
         [Test]
         public void IL_RefAndOut ()
         {

--- a/mdoc/mdoc.Test/SpanSpecial.cs
+++ b/mdoc/mdoc.Test/SpanSpecial.cs
@@ -1,0 +1,90 @@
+﻿using System;
+
+namespace mdoc.Test
+{
+    public struct SpanSpecial<T>
+    {
+        public struct Enumerator
+        {
+            private readonly SpanSpecial<T> _span;
+
+            private int _index;
+
+            public T Current
+            {
+                get
+                {
+                    return this._span[this._index];
+                }
+            }
+
+            internal Enumerator(SpanSpecial<T> span)
+            {
+                this._span = span;
+                this._index = -1;
+            }
+
+            public bool MoveNext()
+            {
+                int num = this._index + 1;
+                if (num < this._span.Length)
+                {
+                    this._index = num;
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        private readonly int _length;
+
+        public int Length
+        {
+            get
+            {
+                return this._length;
+            }
+        }
+
+        public bool IsEmpty
+        {
+            get
+            {
+                return this._length == 0;
+            }
+        }
+
+        public static SpanSpecial<T> Empty
+        {
+            get
+            {
+                return default(SpanSpecial<T>);
+            }
+        }
+
+        public ref T this[int index]
+        {
+            get
+            {
+                if (index >= this._length)
+                {
+                    throw new Exception("error");
+                }
+
+                return  ref this[index];
+      
+            }
+        }
+
+        public SpanSpecial<T>.Enumerator GetEnumerator()
+        {
+            return new SpanSpecial<T>.Enumerator(this);
+        }
+
+        public SpanSpecial( int length)
+        {
+            this._length = length;
+        }
+
+    }
+}

--- a/mdoc/mdoc.Test/mdoc.Test.csproj
+++ b/mdoc/mdoc.Test/mdoc.Test.csproj
@@ -95,6 +95,7 @@
     <Compile Include="SampleClasses\NullablesAndTuples.cs" />
     <Compile Include="SampleClasses\StaticClass.cs" />
     <Compile Include="SampleClasses\TestClassThree.cs" />
+    <Compile Include="SpanSpecial.cs" />
     <Compile Include="TypeMapTests.cs" />
     <Compile Include="SampleClasses\ReadonlyRefClass.cs" />
     <Compile Include="SampleClasses\ReadOnlySpan.cs" />


### PR DESCRIPTION
The unit test  uses the class written by myself, At the same time, it has also been tested with struct span < T > in  system.memory.dll,It also passed.

bug:
https://ceapex.visualstudio.com/Engineering/_workitems/edit/167409
https://ceapex.visualstudio.com/Engineering/_workitems/edit/167407