### PR TITLE
skip add forwarding when ExportedType is not resolved from the assemblies being documented

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
@@ -75,8 +75,6 @@ namespace Mono.Documentation.Updater.Frameworks
                     string file = a.MainModule.FileName;
                     AssemblyNameReference exportedTo = (AssemblyNameReference)etype.Scope;
                     Console.WriteLine($"resolving {forType.FullName} in {name.FullName}. Found {file}, but it's exported to {exportedTo.FullName}");
-                    if (forType != null)
-                        TypeExported?.Invoke(this, new TypeForwardEventArgs(name, exportedTo, forType?.FullName));
 
                     exportedFiles.Add(file);
                     return Resolve(exportedTo, r, forType, exportedFiles, cache);


### PR DESCRIPTION
#VSTS Bug 182488

mdoc used to fetch the exported types while:

1. Loading the assemblies to document
2. Enumerate each target assembly to update types
3. Resolve the assembly referenced by the type, such as when call GetDeclaration 

Since NO.3,  the exported types are not from the assemblies/versions to be documented, so they should not be added to ECMA2Xml