### PR TITLE
handle type forwarding for nested inner class

### DIFF
--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -157,6 +157,25 @@ Test/DocTest-typeForwards-Third.dll:
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-typeForwards.cs /define:FIRST
 	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:Test/DocTest-typeForwards-Third-First.dll /reference:$@ Test/DocTest-typeForwards.cs /define:THIRD
 
+# build test dll to test forwardings nested type
+Test/DocTest-nestedType-typeForwards-First.dll:
+	rm -f $@
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-nestedType-typeForwards.cs /define:FIRST
+
+.PHONY: Test/DocTest-nestedType-typeForwards-Second.dll
+Test/DocTest-nestedType-typeForwards-Second.dll:
+	rm -f $@
+	rm -f Test/DocTest-nestedType-typeForwards-Second-First.dll
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-nestedType-typeForwards.cs /define:FIRST
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:Test/DocTest-nestedType-typeForwards-Second-First.dll /reference:$@ Test/DocTest-nestedType-typeForwards.cs /define:SECOND
+
+.PHONY: Test/DocTest-nestedType-typeForwards-Third.dll
+Test/DocTest-nestedType-typeForwards-Third.dll:
+	rm -f $@
+	rm -f Test/DocTest-nestedType-typeForwards-Third-First.dll
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:$@ Test/DocTest-nestedType-typeForwards.cs /define:FIRST
+	$(CSCOMPILE) $(TEST_CSCFLAGS) -unsafe -debug -optimize -target:library -out:Test/DocTest-nestedType-typeForwards-Third-First.dll /reference:$@ Test/DocTest-nestedType-typeForwards.cs /define:THIRD
+
 .PHONY: Test/FrameworkTestData
 Test/FrameworkTestData: Test/DocTest-addNonGeneric.dll Test/DocTest-DropNS-classic.dll Test/DocTest-DropNS-classic-secondary.dll
 	rm -rf Test/FrameworkTestData
@@ -215,6 +234,37 @@ check-monodocer-typeForwards : Test/DocTest-typeForwards-First.dll Test/DocTest-
 	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/FrameworkTestData-fx-typeForwards
 	$(DIFF) Test/en.expected.typeForwards Test/en.actual
 
+.PHONY: check-monodocer-nestedType-typeForwards
+check-monodocer-nestedType-typeForwards : Test/DocTest-nestedType-typeForwards-First.dll Test/DocTest-nestedType-typeForwards-Second.dll Test/DocTest-nestedType-typeForwards-Third.dll
+	-rm -Rf Test/en.actual
+
+	# set up the fx test data
+	-rm -Rf Test/FrameworkTestData-fx-nestedType-typeForwards
+	mkdir Test/FrameworkTestData-fx-nestedType-typeForwards
+	mkdir Test/FrameworkTestData-fx-nestedType-typeForwards/One
+	mkdir Test/FrameworkTestData-fx-nestedType-typeForwards/Two
+	mkdir Test/FrameworkTestData-fx-nestedType-typeForwards/Three
+	mkdir Test/FrameworkTestData-fx-nestedType-typeForwards/dependencies
+	mkdir Test/FrameworkTestData-fx-nestedType-typeForwards/dependencies/One
+	mkdir Test/FrameworkTestData-fx-nestedType-typeForwards/dependencies/Two
+	mkdir Test/FrameworkTestData-fx-nestedType-typeForwards/dependencies/Three
+	cp Test/DocTest-nestedType-typeForwards-First.dll Test/FrameworkTestData-fx-nestedType-typeForwards/One
+	cp Test/DocTest-nestedType-typeForwards-Second-First.dll Test/FrameworkTestData-fx-nestedType-typeForwards/One
+	cp Test/DocTest-nestedType-typeForwards-Second.dll Test/FrameworkTestData-fx-nestedType-typeForwards/dependencies/One
+	cp Test/DocTest-nestedType-typeForwards-Second-First.dll Test/FrameworkTestData-fx-nestedType-typeForwards/Two
+	cp Test/DocTest-nestedType-typeForwards-Third-First.dll Test/FrameworkTestData-fx-nestedType-typeForwards/Two
+	cp Test/DocTest-nestedType-typeForwards-Second.dll Test/FrameworkTestData-fx-nestedType-typeForwards/dependencies/Two
+	cp Test/DocTest-nestedType-typeForwards-Third.dll Test/FrameworkTestData-fx-nestedType-typeForwards/dependencies/Two
+	cp Test/DocTest-nestedType-typeForwards-Second-First.dll Test/FrameworkTestData-fx-nestedType-typeForwards/Three
+	cp Test/DocTest-nestedType-typeForwards-Third-First.dll Test/FrameworkTestData-fx-nestedType-typeForwards/Three
+	cp Test/DocTest-nestedType-typeForwards-Second.dll Test/FrameworkTestData-fx-nestedType-typeForwards/dependencies/Three
+	cp Test/DocTest-nestedType-typeForwards-Third.dll Test/FrameworkTestData-fx-nestedType-typeForwards/dependencies/Three
+	$(MONO) $(PROGRAM) fx-bootstrap Test/FrameworkTestData-fx-nestedType-typeForwards
+
+	# now run mdoc update
+	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/FrameworkTestData-fx-nestedType-typeForwards
+	$(DIFF) Test/en.expected-nestedType.typeForwards Test/en.actual
+	
 check-monodocer-frameworks: Test/FrameworkTestData
 	-rm -Rf Test/en.actual
 	$(MONO) $(PROGRAM) update -o Test/en.actual -frameworks Test/FrameworkTestData
@@ -778,6 +828,7 @@ run-test-update : check-doc-tools-update
 
 check-doc-tools:  \
 	check-monodocer-typeForwards \
+	check-monodocer-nestedType-typeForwards \
 	check-monodocer-Eii-importslashdoc \
 	check-monodocer-Eii-importecmadoc-oldNames \
 	check-monodocer-Eii \

--- a/mdoc/Test/DocTest-nestedType-typeForwards.cs
+++ b/mdoc/Test/DocTest-nestedType-typeForwards.cs
@@ -1,0 +1,15 @@
+#if SECOND || THIRD
+using System.Runtime.CompilerServices;
+[assembly:TypeForwardedToAttribute(typeof(TheNamespace.TheClass))] 
+#endif
+
+namespace TheNamespace
+{
+    #if FIRST
+    public class TheClass
+    {
+        protected class InnerClass
+        {}
+    }
+    #endif
+}

--- a/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/One.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework Name="One">
+  <Assemblies>
+    <Assembly Name="DocTest-nestedType-typeForwards-First" Version="0.0.0.0" />
+    <Assembly Name="DocTest-nestedType-typeForwards-Second-First" Version="0.0.0.0" />
+  </Assemblies>
+  <Namespace Name="TheNamespace">
+    <Type Name="TheNamespace.TheClass" Id="T:TheNamespace.TheClass">
+      <Member Id="M:TheNamespace.TheClass.#ctor" />
+    </Type>
+    <Type Name="TheNamespace.TheClass/InnerClass" Id="T:TheNamespace.TheClass.InnerClass">
+      <Member Id="M:TheNamespace.TheClass.InnerClass.#ctor" />
+    </Type>
+  </Namespace>
+</Framework>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/Three.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/Three.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework Name="Three">
+  <Assemblies>
+    <Assembly Name="DocTest-nestedType-typeForwards-Second-First" Version="0.0.0.0" />
+    <Assembly Name="DocTest-nestedType-typeForwards-Third-First" Version="0.0.0.0" />
+  </Assemblies>
+  <Namespace Name="TheNamespace">
+    <Type Name="TheNamespace.TheClass" Id="T:TheNamespace.TheClass">
+      <Member Id="M:TheNamespace.TheClass.#ctor" />
+    </Type>
+    <Type Name="TheNamespace.TheClass/InnerClass" Id="T:TheNamespace.TheClass.InnerClass">
+      <Member Id="M:TheNamespace.TheClass.InnerClass.#ctor" />
+    </Type>
+  </Namespace>
+</Framework>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/Two.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Framework Name="Two">
+  <Assemblies>
+    <Assembly Name="DocTest-nestedType-typeForwards-Second-First" Version="0.0.0.0" />
+    <Assembly Name="DocTest-nestedType-typeForwards-Third-First" Version="0.0.0.0" />
+  </Assemblies>
+  <Namespace Name="TheNamespace">
+    <Type Name="TheNamespace.TheClass" Id="T:TheNamespace.TheClass">
+      <Member Id="M:TheNamespace.TheClass.#ctor" />
+    </Type>
+    <Type Name="TheNamespace.TheClass/InnerClass" Id="T:TheNamespace.TheClass.InnerClass">
+      <Member Id="M:TheNamespace.TheClass.InnerClass.#ctor" />
+    </Type>
+  </Namespace>
+</Framework>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/TheNamespace/TheClass+InnerClass.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/TheNamespace/TheClass+InnerClass.xml
@@ -1,0 +1,52 @@
+<Type Name="TheClass+InnerClass" FullName="TheNamespace.TheClass+InnerClass">
+  <TypeSignature Language="C#" Value="protected class TheClass.InnerClass" />
+  <TypeSignature Language="ILAsm" Value=".class nested protected auto ansi beforefieldinit TheClass/InnerClass extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-First</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-Second</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-Third</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeForwardingChain>
+    <TypeForwarding From="DocTest-nestedType-typeForwards-Second-First" FromVersion="0.0.0.0" To="DocTest-nestedType-typeForwards-Second" ToVersion="0.0.0.0" />
+    <TypeForwarding From="DocTest-nestedType-typeForwards-Third-First" FromVersion="0.0.0.0" To="DocTest-nestedType-typeForwards-Third" ToVersion="0.0.0.0" FrameworkAlternate="Three;Two" />
+  </TypeForwardingChain>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public InnerClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-First</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-Second</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-Third</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/TheNamespace/TheClass.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/TheNamespace/TheClass.xml
@@ -1,0 +1,64 @@
+<Type Name="TheClass" FullName="TheNamespace.TheClass">
+  <TypeSignature Language="C#" Value="public class TheClass" />
+  <TypeSignature Language="ILAsm" Value=".class public auto ansi beforefieldinit TheClass extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-First</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-Second</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-Second-First</AssemblyName>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-Third</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-Third-First</AssemblyName>
+  </AssemblyInfo>
+  <TypeForwardingChain>
+    <TypeForwarding From="DocTest-nestedType-typeForwards-Second-First" FromVersion="0.0.0.0" To="DocTest-nestedType-typeForwards-Second" ToVersion="0.0.0.0" />
+    <TypeForwarding From="DocTest-nestedType-typeForwards-Third-First" FromVersion="0.0.0.0" To="DocTest-nestedType-typeForwards-Third" ToVersion="0.0.0.0" FrameworkAlternate="Three;Two" />
+  </TypeForwardingChain>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public TheClass ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-First</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-Second</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-Second-First</AssemblyName>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-Third</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-Third-First</AssemblyName>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/index.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/index.xml
@@ -1,0 +1,43 @@
+<Overview>
+  <Assemblies>
+    <Assembly Name="DocTest-nestedType-typeForwards-First" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+    <Assembly Name="DocTest-nestedType-typeForwards-Second-First" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+    <Assembly Name="DocTest-nestedType-typeForwards-Third-First" Version="0.0.0.0">
+      <Attributes>
+        <Attribute>
+          <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
+        </Attribute>
+        <Attribute>
+          <AttributeName>System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows=true)</AttributeName>
+        </Attribute>
+      </Attributes>
+    </Assembly>
+  </Assemblies>
+  <Remarks>To be added.</Remarks>
+  <Copyright>To be added.</Copyright>
+  <Types>
+    <Namespace Name="TheNamespace">
+      <Type Name="TheClass" Kind="Class" />
+      <Type Name="TheClass+InnerClass" Kind="Class" />
+    </Namespace>
+  </Types>
+  <Title>Untitled</Title>
+</Overview>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/ns-.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/ns-.xml
@@ -1,0 +1,6 @@
+<Namespace Name="">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/ns-TheNamespace.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/ns-TheNamespace.xml
@@ -1,0 +1,6 @@
+<Namespace Name="TheNamespace">
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Namespace>


### PR DESCRIPTION
VSTS bug 185167

In mono resolver, even if inner type has exported type, its IsForwarder will be set to false.

When caching assembly meta data, we will only load those which IsForwarder = true.

So the nested types, we will also check the outer type's forwarding information and add to  inner type.

