### PR TITLE
add type forwarding for multiple levels nested type

### DIFF
--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -3217,10 +3217,19 @@ namespace Mono.Documentation
 
             forwardings.AddRange(getForwardings(type));
 
-            // If current type is nested inner class, add forwardings from outer class as well
-            if (type.IsNested && !type.HasNestedTypes)
+            // If current type is nested inner class, add forwardings from outer classes as well
+            // Using AddRange here becuase IsForwarder=true is used as filter when import exportedType from metadata
+            // And for inner class IsForwarder will be false
+            if (type.IsNested)
             {
-                forwardings.AddRange(getForwardings(type.DeclaringType.Resolve()));
+                var outerType = type.DeclaringType;
+
+                // Handle multiple layers nested
+                while (null != outerType)
+                {
+                    forwardings.AddRange(getForwardings(outerType.Resolve()));
+                    outerType = outerType.DeclaringType;
+                }
             }
 
             XmlElement exsitingChain = (XmlElement)root.SelectSingleNode(elementName);

--- a/mdoc/Test/DocTest-nestedType-typeForwards.cs
+++ b/mdoc/Test/DocTest-nestedType-typeForwards.cs
@@ -9,7 +9,9 @@ namespace TheNamespace
     public class TheClass
     {
         protected class InnerClass
-        {}
+        {
+            protected class Enumerator {}
+        }
     }
     #endif
 }

--- a/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/One.xml
@@ -11,5 +11,8 @@
     <Type Name="TheNamespace.TheClass/InnerClass" Id="T:TheNamespace.TheClass.InnerClass">
       <Member Id="M:TheNamespace.TheClass.InnerClass.#ctor" />
     </Type>
+    <Type Name="TheNamespace.TheClass/InnerClass/Enumerator" Id="T:TheNamespace.TheClass.InnerClass.Enumerator">
+      <Member Id="M:TheNamespace.TheClass.InnerClass.Enumerator.#ctor" />
+    </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/Three.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/Three.xml
@@ -11,5 +11,8 @@
     <Type Name="TheNamespace.TheClass/InnerClass" Id="T:TheNamespace.TheClass.InnerClass">
       <Member Id="M:TheNamespace.TheClass.InnerClass.#ctor" />
     </Type>
+    <Type Name="TheNamespace.TheClass/InnerClass/Enumerator" Id="T:TheNamespace.TheClass.InnerClass.Enumerator">
+      <Member Id="M:TheNamespace.TheClass.InnerClass.Enumerator.#ctor" />
+    </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/FrameworksIndex/Two.xml
@@ -11,5 +11,8 @@
     <Type Name="TheNamespace.TheClass/InnerClass" Id="T:TheNamespace.TheClass.InnerClass">
       <Member Id="M:TheNamespace.TheClass.InnerClass.#ctor" />
     </Type>
+    <Type Name="TheNamespace.TheClass/InnerClass/Enumerator" Id="T:TheNamespace.TheClass.InnerClass.Enumerator">
+      <Member Id="M:TheNamespace.TheClass.InnerClass.Enumerator.#ctor" />
+    </Type>
   </Namespace>
 </Framework>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/TheNamespace/TheClass+InnerClass+Enumerator.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/TheNamespace/TheClass+InnerClass+Enumerator.xml
@@ -1,0 +1,52 @@
+<Type Name="TheClass+InnerClass+Enumerator" FullName="TheNamespace.TheClass+InnerClass+Enumerator">
+  <TypeSignature Language="C#" Value="protected class TheClass.InnerClass.Enumerator" />
+  <TypeSignature Language="ILAsm" Value=".class nested protected auto ansi beforefieldinit TheClass/InnerClass/Enumerator extends System.Object" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-First</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-Second</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <AssemblyInfo>
+    <AssemblyName>DocTest-nestedType-typeForwards-Third</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <TypeForwardingChain>
+    <TypeForwarding From="DocTest-nestedType-typeForwards-Second-First" FromVersion="0.0.0.0" To="DocTest-nestedType-typeForwards-Second" ToVersion="0.0.0.0" />
+    <TypeForwarding From="DocTest-nestedType-typeForwards-Third-First" FromVersion="0.0.0.0" To="DocTest-nestedType-typeForwards-Third" ToVersion="0.0.0.0" FrameworkAlternate="Three;Two" />
+  </TypeForwardingChain>
+  <Base>
+    <BaseTypeName>System.Object</BaseTypeName>
+  </Base>
+  <Interfaces />
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=".ctor">
+      <MemberSignature Language="C#" Value="public Enumerator ();" />
+      <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor() cil managed" />
+      <MemberType>Constructor</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-First</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-Second</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <AssemblyInfo>
+        <AssemblyName>DocTest-nestedType-typeForwards-Third</AssemblyName>
+        <AssemblyVersion>0.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Parameters />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>

--- a/mdoc/Test/en.expected-nestedType.typeForwards/index.xml
+++ b/mdoc/Test/en.expected-nestedType.typeForwards/index.xml
@@ -37,6 +37,7 @@
     <Namespace Name="TheNamespace">
       <Type Name="TheClass" Kind="Class" />
       <Type Name="TheClass+InnerClass" Kind="Class" />
+      <Type Name="TheClass+InnerClass+Enumerator" Kind="Class" />
     </Namespace>
   </Types>
   <Title>Untitled</Title>


### PR DESCRIPTION
https://ceapex.visualstudio.com/Engineering/_workitems/edit/185167

1. For inner type condition, `IsNested = true` is enough.
2. There could be more then 2 levels of nested, for example Dictionary`2+KeyCollection+Enumerator. So we need to handle check and apply forwarding information for each layer.