### PR TITLE
remove <TypeParameter> not declared by delegate itself

### DIFF
--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -2299,7 +2299,10 @@ namespace Mono.Documentation
 
             if (DocUtils.IsDelegate (type))
             {
-                MakeTypeParameters (typeEntry, root, type.GenericParameters, type, MDocUpdater.HasDroppedNamespace (type));
+                // Checked with dotnet team, we should be align with MSDN
+                // If a generic parameter is from delaring type rather than delegate itself, we should not add "TypeParameter" node in ecmaxml
+
+                MakeTypeParameters(typeEntry, root, DocUtils.GetGenericParameters(type), type, MDocUpdater.HasDroppedNamespace (type));
                 var member = type.GetMethod ("Invoke");
 
                 bool fxAlternateTriggered = false;
@@ -4210,6 +4213,7 @@ namespace Mono.Documentation
                     root.RemoveChild (f);
                 return;
             }
+
             XmlElement e = WriteElement (root, "TypeParameters");
 
             var nodes = e.SelectNodes ("TypeParameter").Cast<XmlElement> ().ToArray ();

--- a/mdoc/Mono.Documentation/Updater/DocUtils.cs
+++ b/mdoc/Mono.Documentation/Updater/DocUtils.cs
@@ -805,5 +805,27 @@ namespace Mono.Documentation.Updater
 
             return false;
         }
+
+        // For some types, the generic parameters resolved by mono declared by their declaring type
+        // This method will return the generic parameters declared by type itself
+        public static List<GenericParameter> GetGenericParameters(TypeDefinition type)
+        {
+            if (type == null)
+                throw new ArgumentNullException("type");
+
+            var genericParameters = new List<GenericParameter>(type.GenericParameters);
+            List<TypeReference> declTypes = GetDeclaringTypes(type);
+            int maxGenArgs = GetGenericArgumentCount(type);
+            
+            for (int i = 0; i < declTypes.Count - 1; ++i)
+            {
+                int remove = System.Math.Min(maxGenArgs,
+                        GetGenericArgumentCount(declTypes[i]));
+                maxGenArgs -= remove;
+                while (remove-- > 0)
+                    genericParameters.RemoveAt(0);
+            }
+            return genericParameters;
+        }
     }
 }

--- a/mdoc/Mono.Documentation/Updater/DocsNodeInfo.cs
+++ b/mdoc/Mono.Documentation/Updater/DocsNodeInfo.cs
@@ -32,17 +32,8 @@ namespace Mono.Documentation.Updater
             if (type == null)
                 throw new ArgumentNullException ("type");
             Type = type;
-            GenericParameters = new List<GenericParameter> (type.GenericParameters);
-            List<TypeReference> declTypes = DocUtils.GetDeclaringTypes (type);
-            int maxGenArgs = DocUtils.GetGenericArgumentCount (type);
-            for (int i = 0; i < declTypes.Count - 1; ++i)
-            {
-                int remove = System.Math.Min (maxGenArgs,
-                        DocUtils.GetGenericArgumentCount (declTypes[i]));
-                maxGenArgs -= remove;
-                while (remove-- > 0)
-                    GenericParameters.RemoveAt (0);
-            }
+            GenericParameters = DocUtils.GetGenericParameters(type);
+
             if (DocUtils.IsDelegate (type))
             {
                 Parameters = type.GetMethod ("Invoke").Parameters;

--- a/mdoc/Test/DocTest-v1.cs
+++ b/mdoc/Test/DocTest-v1.cs
@@ -636,6 +636,9 @@ namespace Mono.DocTest.Generic {
 
 		/// <remarks><c>M:Mono.DocTest.MyList`1.GetEnumerator</c>.</remarks>
 		public IEnumerator<int[]> GetEnumerator () {return null;}
+		
+		/// <remarks><c>T:Mono.DocTest.MyList`1.RefDelegate</c>.</remarks>
+		public delegate bool RefDelegate ();
 	}
 
 	/// <typeparam name="T">T generic param</typeparam>

--- a/mdoc/Test/en.expected-cppcx2/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
+++ b/mdoc/Test/en.expected-cppcx2/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
@@ -1,0 +1,21 @@
+<Type Name="MyList&lt;T&gt;+RefDelegate" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+RefDelegate">
+  <TypeSignature Language="C#" Value="public delegate bool MyList&lt;T&gt;.RefDelegate();" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed MyList`1/RefDelegate&lt;T&gt; extends System.MulticastDelegate" />
+  <TypeSignature Language="C++ CX" Value="public: delegate bool MyList&lt;T&gt;::RefDelegate();" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters />
+  <ReturnValue>
+    <ReturnType>System.Boolean</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-cppcx2/index.xml
+++ b/mdoc/Test/en.expected-cppcx2/index.xml
@@ -44,6 +44,7 @@
       <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
       <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
       <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`1+RefDelegate" DisplayName="MyList&lt;T&gt;+RefDelegate" Kind="Delegate" />
       <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
     </Namespace>
     <Namespace Name="System">

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
@@ -1,0 +1,20 @@
+<Type Name="MyList&lt;T&gt;+RefDelegate" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+RefDelegate">
+  <TypeSignature Language="C#" Value="public delegate bool MyList&lt;T&gt;.RefDelegate();" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed MyList`1/RefDelegate&lt;T&gt; extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters />
+  <ReturnValue>
+    <ReturnType>System.Boolean</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-cppwinrt2/index.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/index.xml
@@ -44,6 +44,7 @@
       <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
       <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
       <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`1+RefDelegate" DisplayName="MyList&lt;T&gt;+RefDelegate" Kind="Delegate" />
       <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
     </Namespace>
     <Namespace Name="System">

--- a/mdoc/Test/en.expected-fx-import/FrameworksIndex/one.xml
+++ b/mdoc/Test/en.expected-fx-import/FrameworksIndex/one.xml
@@ -150,6 +150,7 @@
       <Member Id="M:Mono.DocTest.Generic.MyList`1.Helper`2.#ctor" />
       <Member Id="M:Mono.DocTest.Generic.MyList`1.Helper`2.UseT(`0,`1,`2)" />
     </Type>
+    <Type Name="Mono.DocTest.Generic.MyList`1/RefDelegate" Id="T:Mono.DocTest.Generic.MyList`1.RefDelegate" />
     <Type Name="Mono.DocTest.Generic.MyList`2" Id="T:Mono.DocTest.Generic.MyList`2">
       <Member Id="M:Mono.DocTest.Generic.MyList`2.#ctor" />
       <Member Id="M:Mono.DocTest.Generic.MyList`2.CopyTo(`0[],System.Int32)" />

--- a/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
+++ b/mdoc/Test/en.expected-fx-import/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
@@ -1,0 +1,21 @@
+<Type Name="MyList&lt;T&gt;+RefDelegate" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+RefDelegate">
+  <TypeSignature Language="C#" Value="public delegate bool MyList&lt;T&gt;.RefDelegate();" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed MyList`1/RefDelegate&lt;T&gt; extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters />
+  <ReturnValue>
+    <ReturnType>System.Boolean</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>
+      <c>T:Mono.DocTest.MyList`1.RefDelegate</c>.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-fx-import/index.xml
+++ b/mdoc/Test/en.expected-fx-import/index.xml
@@ -64,6 +64,7 @@
       <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
       <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
       <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`1+RefDelegate" DisplayName="MyList&lt;T&gt;+RefDelegate" Kind="Delegate" />
       <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
     </Namespace>
     <Namespace Name="MyFramework.MyNamespace">

--- a/mdoc/Test/en.expected-javascript/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
+++ b/mdoc/Test/en.expected-javascript/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
@@ -1,0 +1,20 @@
+<Type Name="MyList&lt;T&gt;+RefDelegate" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+RefDelegate">
+  <TypeSignature Language="C#" Value="public delegate bool MyList&lt;T&gt;.RefDelegate();" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed MyList`1/RefDelegate&lt;T&gt; extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters />
+  <ReturnValue>
+    <ReturnType>System.Boolean</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-javascript/index.xml
+++ b/mdoc/Test/en.expected-javascript/index.xml
@@ -44,6 +44,7 @@
       <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
       <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
       <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`1+RefDelegate" DisplayName="MyList&lt;T&gt;+RefDelegate" Kind="Delegate" />
       <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
     </Namespace>
     <Namespace Name="System">

--- a/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
+++ b/mdoc/Test/en.expected-vbnet2/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
@@ -1,0 +1,21 @@
+<Type Name="MyList&lt;T&gt;+RefDelegate" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+RefDelegate">
+  <TypeSignature Language="C#" Value="public delegate bool MyList&lt;T&gt;.RefDelegate();" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed MyList`1/RefDelegate&lt;T&gt; extends System.MulticastDelegate" />
+  <TypeSignature Language="VB.NET" Value="Public Delegate Function MyList(Of T).RefDelegate() As Boolean " />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters />
+  <ReturnValue>
+    <ReturnType>System.Boolean</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected-vbnet2/index.xml
+++ b/mdoc/Test/en.expected-vbnet2/index.xml
@@ -44,6 +44,7 @@
       <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
       <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
       <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`1+RefDelegate" DisplayName="MyList&lt;T&gt;+RefDelegate" Kind="Delegate" />
       <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
     </Namespace>
     <Namespace Name="System">

--- a/mdoc/Test/en.expected.delete/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
+++ b/mdoc/Test/en.expected.delete/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
@@ -1,0 +1,19 @@
+<Type Name="MyList&lt;T&gt;+RefDelegate" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+RefDelegate">
+  <TypeSignature Language="C#" Value="public delegate bool MyList&lt;T&gt;.RefDelegate();" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed MyList`1/RefDelegate&lt;T&gt; extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters />
+  <ReturnValue>
+    <ReturnType>System.Boolean</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected.delete/index.xml
+++ b/mdoc/Test/en.expected.delete/index.xml
@@ -44,6 +44,7 @@
       <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
       <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
       <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`1+RefDelegate" DisplayName="MyList&lt;T&gt;+RefDelegate" Kind="Delegate" />
       <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
     </Namespace>
     <Namespace Name="System">

--- a/mdoc/Test/en.expected.importslashdoc/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
+++ b/mdoc/Test/en.expected.importslashdoc/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
@@ -1,0 +1,21 @@
+<Type Name="MyList&lt;T&gt;+RefDelegate" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+RefDelegate">
+  <TypeSignature Language="C#" Value="public delegate bool MyList&lt;T&gt;.RefDelegate();" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed MyList`1/RefDelegate&lt;T&gt; extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters />
+  <ReturnValue>
+    <ReturnType>System.Boolean</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>
+      <c>T:Mono.DocTest.MyList`1.RefDelegate</c>.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected.importslashdoc/index.xml
+++ b/mdoc/Test/en.expected.importslashdoc/index.xml
@@ -44,6 +44,7 @@
       <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
       <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
       <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`1+RefDelegate" DisplayName="MyList&lt;T&gt;+RefDelegate" Kind="Delegate" />
       <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
     </Namespace>
     <Namespace Name="System">

--- a/mdoc/Test/en.expected.since/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
+++ b/mdoc/Test/en.expected.since/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
@@ -1,0 +1,21 @@
+<Type Name="MyList&lt;T&gt;+RefDelegate" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+RefDelegate">
+  <TypeSignature Language="C#" Value="public delegate bool MyList&lt;T&gt;.RefDelegate();" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed MyList`1/RefDelegate&lt;T&gt; extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters />
+  <ReturnValue>
+    <ReturnType>System.Boolean</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected.since/index.xml
+++ b/mdoc/Test/en.expected.since/index.xml
@@ -45,6 +45,7 @@
       <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
       <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
       <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`1+RefDelegate" DisplayName="MyList&lt;T&gt;+RefDelegate" Kind="Delegate" />
       <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
     </Namespace>
     <Namespace Name="System">

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
@@ -1,0 +1,25 @@
+<Type Name="MyList&lt;T&gt;+RefDelegate" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+RefDelegate">
+  <TypeSignature Language="C#" Value="public delegate bool MyList&lt;T&gt;.RefDelegate();" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed MyList`1/RefDelegate&lt;T&gt; extends System.MulticastDelegate" />
+  <TypeSignature Language="DocId" Value="T:Mono.DocTest.Generic.MyList`1.RefDelegate" />
+  <TypeSignature Language="VB.NET" Value="Public Delegate Function MyList(Of T).RefDelegate() As Boolean " />
+  <TypeSignature Language="F#" Value="type MyList&lt;'T&gt;.RefDelegate = delegate of unit -&gt; bool" />
+  <TypeSignature Language="C++ CLI" Value="public: delegate bool MyList&lt;T&gt;::RefDelegate();" />
+  <TypeSignature Language="C++ CX" Value="public: delegate bool MyList&lt;T&gt;::RefDelegate();" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters />
+  <ReturnValue>
+    <ReturnType>System.Boolean</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>To be added.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/en.expected/index.xml
+++ b/mdoc/Test/en.expected/index.xml
@@ -44,6 +44,7 @@
       <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
       <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
       <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`1+RefDelegate" DisplayName="MyList&lt;T&gt;+RefDelegate" Kind="Delegate" />
       <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
     </Namespace>
     <Namespace Name="System">

--- a/mdoc/Test/expected_statistics.txt
+++ b/mdoc/Test/expected_statistics.txt
@@ -1,8 +1,8 @@
 Framework: one
 --------
-Types Added: 31
+Types Added: 32
 Types Removed: 0
-Types Total: 31
+Types Total: 32
 
 Namespaces Added: 4
 Namespaces Removed: 0

--- a/mdoc/Test/html.expected-with-array-extension/Mono.DocTest.Generic/MyList`1+RefDelegate.html
+++ b/mdoc/Test/html.expected-with-array-extension/Mono.DocTest.Generic/MyList`1+RefDelegate.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>DocTest: Mono.DocTest.Generic</title>
+    <title>Mono.DocTest.Generic.MyList&lt;T&gt;.RefDelegate</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <style>
       a { text-decoration: none }
@@ -187,114 +187,49 @@
   </head>
   <body>
     <div class="CollectionTitle">
-      <a href="../index.html">DocTest</a>
+      <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
+    <div class="SideBar">
+      <p>
+        <a href="#T:Mono.DocTest.Generic.MyList`1.RefDelegate">Overview</a>
+      </p>
+      <p>
+        <a href="#T:Mono.DocTest.Generic.MyList`1.RefDelegate:Signature">Signature</a>
+      </p>
+      <p>
+        <a href="#T:Mono.DocTest.Generic.MyList`1.RefDelegate:Docs">Remarks</a>
+      </p>
+      <p>
+        <a href="#Members">Members</a>
+      </p>
+      <p>
+        <a href="#T:Mono.DocTest.Generic.MyList`1.RefDelegate:Members">Member Details</a>
+      </p>
     </div>
-    <h1 class="PageTitle">Mono.DocTest.Generic Namespace</h1>
-    <p class="Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate">MyList&lt;T&gt;.RefDelegate  Delegate</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Summary">
+      <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
+      <h2>Syntax</h2>
+      <div class="Signature" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Signature">public delegate <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a> <b>MyList&lt;T&gt;.RefDelegate</b> ()</div>
     </div>
-    <div class="Remarks">
-      <h2 class="Section"> Namespace</h2>
-      <p>
+    <div class="Remarks" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Docs">
+      <h4 class="Subsection">Returns</h4>
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Docs:Returns">
         <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-      </p>
-      <table class="TypesListing" style="margin-top: 1em">
-        <tr>
-          <th>Type</th>
-          <th>Description</th>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./Extensions.html">Extensions</a>
-          </td>
-          <td>extension methods!</td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./Func`2.html">Func&lt;TArg,TRet&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./GenericBase`1.html">GenericBase&lt;U&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./GenericBase`1+FooEventArgs.html">GenericBase&lt;U&gt;.FooEventArgs</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./GenericBase`1+NestedCollection.html">GenericBase&lt;U&gt;.NestedCollection</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./GenericBase`1+NestedCollection+Enumerator.html">GenericBase&lt;U&gt;.NestedCollection.Enumerator</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./IFoo`1.html">IFoo&lt;T&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./MyList`1.html">MyList&lt;T&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./MyList`1+Helper`2.html">MyList&lt;T&gt;.Helper&lt;U,V&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./MyList`1+RefDelegate.html">MyList&lt;T&gt;.RefDelegate</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./MyList`2.html">MyList&lt;A,B&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-      </table>
+      </blockquote>
+      <h2 class="Section">Remarks</h2>
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Docs:Remarks">
+        <span class="NotEntered">Documentation for this section has not yet been entered.</span>
+      </div>
+      <h2 class="Section">Requirements</h2>
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Docs:Version Information">
+        <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
     </div>
-    <div class="Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Members">
     </div>
     <hr size="1" />
-    <div class="Copyright">To be added.</div>
+    <div class="Copyright">
+    </div>
   </body>
 </html>

--- a/mdoc/Test/html.expected-with-array-extension/Mono.DocTest.Generic/index.html
+++ b/mdoc/Test/html.expected-with-array-extension/Mono.DocTest.Generic/index.html
@@ -278,6 +278,14 @@
         </tr>
         <tr valign="top">
           <td>
+            <a href="./MyList`1+RefDelegate.html">MyList&lt;T&gt;.RefDelegate</a>
+          </td>
+          <td>
+            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
+          </td>
+        </tr>
+        <tr valign="top">
+          <td>
             <a href="./MyList`2.html">MyList&lt;A,B&gt;</a>
           </td>
           <td>

--- a/mdoc/Test/html.expected-with-array-extension/index.html
+++ b/mdoc/Test/html.expected-with-array-extension/index.html
@@ -432,6 +432,14 @@
         </tr>
         <tr valign="top">
           <td>
+            <a href="Mono.DocTest.Generic/MyList`1+RefDelegate.html">MyList&lt;T&gt;.RefDelegate</a>
+          </td>
+          <td>
+            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
+          </td>
+        </tr>
+        <tr valign="top">
+          <td>
             <a href="Mono.DocTest.Generic/MyList`2.html">MyList&lt;A,B&gt;</a>
           </td>
           <td>

--- a/mdoc/Test/html.expected/Mono.DocTest.Generic/MyList`1+RefDelegate.html
+++ b/mdoc/Test/html.expected/Mono.DocTest.Generic/MyList`1+RefDelegate.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>DocTest: Mono.DocTest.Generic</title>
+    <title>Mono.DocTest.Generic.MyList&lt;T&gt;.RefDelegate</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <style>
       a { text-decoration: none }
@@ -187,114 +187,48 @@
   </head>
   <body>
     <div class="CollectionTitle">
-      <a href="../index.html">DocTest</a>
+      <a href="../index.html">DocTest</a> : <a href="index.html">Mono.DocTest.Generic Namespace</a></div>
+    <div class="SideBar">
+      <p>
+        <a href="#T:Mono.DocTest.Generic.MyList`1.RefDelegate">Overview</a>
+      </p>
+      <p>
+        <a href="#T:Mono.DocTest.Generic.MyList`1.RefDelegate:Signature">Signature</a>
+      </p>
+      <p>
+        <a href="#T:Mono.DocTest.Generic.MyList`1.RefDelegate:Docs">Remarks</a>
+      </p>
+      <p>
+        <a href="#Members">Members</a>
+      </p>
+      <p>
+        <a href="#T:Mono.DocTest.Generic.MyList`1.RefDelegate:Members">Member Details</a>
+      </p>
     </div>
-    <h1 class="PageTitle">Mono.DocTest.Generic Namespace</h1>
-    <p class="Summary">
+    <h1 class="PageTitle" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate">MyList&lt;T&gt;.RefDelegate  Delegate</h1>
+    <p class="Summary" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Summary">
+      <span class="NotEntered">Documentation for this section has not yet been entered.</span>
     </p>
     <div>
+      <h2>Syntax</h2>
+      <div class="Signature" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Signature">public delegate <a href="http://www.go-mono.com/docs/monodoc.ashx?link=T:System.Boolean">bool</a> <b>MyList&lt;T&gt;.RefDelegate</b> ()</div>
     </div>
-    <div class="Remarks">
-      <h2 class="Section"> Namespace</h2>
-      <p>
+    <div class="Remarks" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Docs">
+      <h4 class="Subsection">Returns</h4>
+      <blockquote class="SubsectionBox" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Docs:Returns">
         <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-      </p>
-      <table class="TypesListing" style="margin-top: 1em">
-        <tr>
-          <th>Type</th>
-          <th>Description</th>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./Extensions.html">Extensions</a>
-          </td>
-          <td>extension methods!</td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./Func`2.html">Func&lt;TArg,TRet&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./GenericBase`1.html">GenericBase&lt;U&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./GenericBase`1+FooEventArgs.html">GenericBase&lt;U&gt;.FooEventArgs</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./GenericBase`1+NestedCollection.html">GenericBase&lt;U&gt;.NestedCollection</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./GenericBase`1+NestedCollection+Enumerator.html">GenericBase&lt;U&gt;.NestedCollection.Enumerator</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./IFoo`1.html">IFoo&lt;T&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./MyList`1.html">MyList&lt;T&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./MyList`1+Helper`2.html">MyList&lt;T&gt;.Helper&lt;U,V&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./MyList`1+RefDelegate.html">MyList&lt;T&gt;.RefDelegate</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-        <tr valign="top">
-          <td>
-            <a href="./MyList`2.html">MyList&lt;A,B&gt;</a>
-          </td>
-          <td>
-            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
-          </td>
-        </tr>
-      </table>
+      </blockquote>
+      <h2 class="Section">Remarks</h2>
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Docs:Remarks">
+        <tt>T:Mono.DocTest.MyList`1.RefDelegate</tt>.</div>
+      <h2 class="Section">Requirements</h2>
+      <div class="SectionBox" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Docs:Version Information">
+        <b>Namespace: </b>Mono.DocTest.Generic<br /><b>Assembly: </b>DocTest (in DocTest.dll)<br /><b>Assembly Versions: </b>0.0.0.0</div>
     </div>
-    <div class="Members">
+    <div class="Members" id="T:Mono.DocTest.Generic.MyList`1.RefDelegate:Members">
     </div>
     <hr size="1" />
-    <div class="Copyright">To be added.</div>
+    <div class="Copyright">
+    </div>
   </body>
 </html>

--- a/mdoc/Test/html.expected/index.html
+++ b/mdoc/Test/html.expected/index.html
@@ -422,6 +422,14 @@
         </tr>
         <tr valign="top">
           <td>
+            <a href="Mono.DocTest.Generic/MyList`1+RefDelegate.html">MyList&lt;T&gt;.RefDelegate</a>
+          </td>
+          <td>
+            <span class="NotEntered">Documentation for this section has not yet been entered.</span>
+          </td>
+        </tr>
+        <tr valign="top">
+          <td>
             <a href="Mono.DocTest.Generic/MyList`2.html">MyList&lt;A,B&gt;</a>
           </td>
           <td>

--- a/mdoc/Test/msxdoc-expected.importslashdoc.xml
+++ b/mdoc/Test/msxdoc-expected.importslashdoc.xml
@@ -818,6 +818,12 @@ class Example {
             <remarks>
                 <c>M:Mono.DocTest.MyList`1.Helper`2.UseT(`0,`1,`2)</c>.</remarks>
         </member>
+        <member name="T:Mono.DocTest.Generic.MyList`1.RefDelegate">
+            <summary>To be added.</summary>
+            <returns>To be added.</returns>
+            <remarks>
+                <c>T:Mono.DocTest.MyList`1.RefDelegate</c>.</remarks>
+        </member>
         <member name="T:Mono.DocTest.Generic.MyList`2">
             <typeparam name="A">Ako generic param</typeparam>
             <typeparam name="B">Bko generic param</typeparam>

--- a/mdoc/Test/test-multiple-mdoc/en.expected.test.multiple.mdoc/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
+++ b/mdoc/Test/test-multiple-mdoc/en.expected.test.multiple.mdoc/Mono.DocTest.Generic/MyList`1+RefDelegate.xml
@@ -1,0 +1,21 @@
+<Type Name="MyList&lt;T&gt;+RefDelegate" FullName="Mono.DocTest.Generic.MyList&lt;T&gt;+RefDelegate">
+  <TypeSignature Language="C#" Value="public delegate bool MyList&lt;T&gt;.RefDelegate();" />
+  <TypeSignature Language="ILAsm" Value=".class nested public auto ansi sealed MyList`1/RefDelegate&lt;T&gt; extends System.MulticastDelegate" />
+  <AssemblyInfo>
+    <AssemblyName>DocTest</AssemblyName>
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
+  </AssemblyInfo>
+  <Base>
+    <BaseTypeName>System.Delegate</BaseTypeName>
+  </Base>
+  <Parameters />
+  <ReturnValue>
+    <ReturnType>System.Boolean</ReturnType>
+  </ReturnValue>
+  <Docs>
+    <summary>To be added.</summary>
+    <returns>To be added.</returns>
+    <remarks>
+      <c>T:Mono.DocTest.MyList`1.RefDelegate</c>.</remarks>
+  </Docs>
+</Type>

--- a/mdoc/Test/test-multiple-mdoc/en.expected.test.multiple.mdoc/index.xml
+++ b/mdoc/Test/test-multiple-mdoc/en.expected.test.multiple.mdoc/index.xml
@@ -44,6 +44,7 @@
       <Type Name="IFoo`1" DisplayName="IFoo&lt;T&gt;" Kind="Interface" />
       <Type Name="MyList`1" DisplayName="MyList&lt;T&gt;" Kind="Class" />
       <Type Name="MyList`1+Helper`2" DisplayName="MyList&lt;T&gt;+Helper&lt;U,V&gt;" Kind="Class" />
+      <Type Name="MyList`1+RefDelegate" DisplayName="MyList&lt;T&gt;+RefDelegate" Kind="Delegate" />
       <Type Name="MyList`2" DisplayName="MyList&lt;A,B&gt;" Kind="Class" />
     </Namespace>
     <Namespace Name="System">


### PR DESCRIPTION
https://ceapex.visualstudio.com/Engineering/_workitems/edit/178475

For some delegates, they have node added but they do not have the generic parameter in their definitions. After investigation, the generic parameter comes from their declaring type.

Discussed with dotnet team, for this situation, node should not be added to ecmayaml