### PR TITLE
mdoc 5.7.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,8 @@ nuget:
 
 check-monodoc:
 	cd monodoc; $(MAKE) check -B
+
+zip:
+	rm -f $(BIN)/mdoc*.zip
+	zip -j $(BIN)/mdoc.zip $(BIN)/*
 	

--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.7.6";
+		public static string MonoVersion = "5.7.7";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.7.6</version>
+    <version>5.7.7</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
- [222981](https://ceapex.visualstudio.com/Engineering/_workitems/edit/222981): F# attributes are now added, in addition to C# attributes (when adding `-lang fsharp` in frameworks mode)
- [239534](https://ceapex.visualstudio.com/Engineering/_workitems/edit/239534): Nullable reference types are now rendered in C# signatures
- [221125](https://ceapex.visualstudio.com/Engineering/_workitems/edit/221125): VB Signatures now use `Nothing` instead of `null`
- [180984](https://ceapex.visualstudio.com/Engineering/_workitems/edit/180984): More accurate member implementation detection
- [196895](https://ceapex.visualstudio.com/Engineering/_workitems/edit/196895): C++/winrt interface syntax update
- [155808](https://ceapex.visualstudio.com/Engineering/_workitems/edit/155808): Return type was getting removed in certain import scenarios
- [163956](https://ceapex.visualstudio.com/Engineering/_workitems/edit/163956): AssemblyVersion was missing in some instances