### PR TITLE
Sort for assembly files and update expected XML files

### DIFF
--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -361,6 +361,10 @@ namespace Mono.Documentation
                 Func<string, string, IEnumerable<string>> getFiles = (string path, string filters) =>
                 {
                     var assemblyFiles = filters.Split('|').SelectMany(v => Directory.GetFiles(path, v));
+
+                    // Directory.GetFiles method returned file names is not sort, 
+                    // this makes the order of the assembly elements of our generated XML files is inconsistent in different environments,
+                    // so we need to sort it.
                     return new SortedSet<string>(assemblyFiles);
                 };
 

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -360,9 +360,8 @@ namespace Mono.Documentation
 
                 Func<string, string, IEnumerable<string>> getFiles = (string path, string filters) =>
                 {
-                    return filters
-                        .Split ('|')
-                        .SelectMany (v => Directory.GetFiles (path, v));
+                    var assemblyFiles = filters.Split('|').SelectMany(v => Directory.GetFiles(path, v));
+                    return new SortedSet<string>(assemblyFiles);
                 };
 
                 var sets = fxd.Select (d => new AssemblySet (

--- a/mdoc/Test/en.expected-cppcli/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-cppcli/FrameworksIndex/One.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="One">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyNamespace">
     <Type Name="MyFramework.MyNamespace.MyClass" Id="T:MyFramework.MyNamespace.MyClass">

--- a/mdoc/Test/en.expected-cppcli/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-cppcli/FrameworksIndex/Two.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Two">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyOtherNamespace">
     <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">

--- a/mdoc/Test/en.expected-cppcli/index.xml
+++ b/mdoc/Test/en.expected-cppcli/index.xml
@@ -10,7 +10,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
+    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
@@ -20,7 +20,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>

--- a/mdoc/Test/en.expected-cppcx/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-cppcx/FrameworksIndex/One.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="One">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyNamespace">
     <Type Name="MyFramework.MyNamespace.MyClass" Id="T:MyFramework.MyNamespace.MyClass">

--- a/mdoc/Test/en.expected-cppcx/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-cppcx/FrameworksIndex/Two.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Two">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyOtherNamespace">
     <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">

--- a/mdoc/Test/en.expected-cppcx/index.xml
+++ b/mdoc/Test/en.expected-cppcx/index.xml
@@ -10,7 +10,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
+    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
@@ -20,7 +20,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>

--- a/mdoc/Test/en.expected-cppwinrt/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-cppwinrt/FrameworksIndex/One.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="One">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyNamespace">
     <Type Name="MyFramework.MyNamespace.MyClass" Id="T:MyFramework.MyNamespace.MyClass">

--- a/mdoc/Test/en.expected-cppwinrt/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-cppwinrt/FrameworksIndex/Two.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Two">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyOtherNamespace">
     <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">

--- a/mdoc/Test/en.expected-cppwinrt/index.xml
+++ b/mdoc/Test/en.expected-cppwinrt/index.xml
@@ -10,7 +10,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
+    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
@@ -20,7 +20,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>

--- a/mdoc/Test/en.expected-docid/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-docid/FrameworksIndex/One.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="One">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyNamespace">
     <Type Name="MyFramework.MyNamespace.MyClass" Id="T:MyFramework.MyNamespace.MyClass">

--- a/mdoc/Test/en.expected-docid/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-docid/FrameworksIndex/Two.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Two">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyOtherNamespace">
     <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">

--- a/mdoc/Test/en.expected-docid/index.xml
+++ b/mdoc/Test/en.expected-docid/index.xml
@@ -10,7 +10,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
+    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
@@ -20,7 +20,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>

--- a/mdoc/Test/en.expected-frameworks/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-frameworks/FrameworksIndex/One.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="One">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyNamespace">
     <Type Name="MyFramework.MyNamespace.MyClass" Id="T:MyFramework.MyNamespace.MyClass">

--- a/mdoc/Test/en.expected-frameworks/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-frameworks/FrameworksIndex/Two.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Two">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyOtherNamespace">
     <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">

--- a/mdoc/Test/en.expected-frameworks/index.xml
+++ b/mdoc/Test/en.expected-frameworks/index.xml
@@ -10,7 +10,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
+    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
@@ -20,7 +20,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>

--- a/mdoc/Test/en.expected-fsharp/Collections+MDocInterface`1.xml
+++ b/mdoc/Test/en.expected-fsharp/Collections+MDocInterface`1.xml
@@ -1,6 +1,6 @@
 <Type Name="Collections+MDocInterface&lt;key&gt;" FullName="Collections+MDocInterface&lt;key&gt;">
   <TypeSignature Language="C#" Value="public interface Collections.MDocInterface&lt;key&gt;" />
-  <TypeSignature Language="ILAsm" Value=".class nested public interface auto ansi abstract serializable Collections/MDocInterface`1&lt;key&gt;" />
+  <TypeSignature Language="ILAsm" Value=".class nested public interface auto ansi abstract serializable beforefieldinit Collections/MDocInterface`1&lt;key&gt;" />
   <TypeSignature Language="F#" Value="type Collections.MDocInterface&lt;'key&gt; = interface" />
   <AssemblyInfo>
     <AssemblyName>mdoc.Test.FSharp</AssemblyName>

--- a/mdoc/Test/en.expected-fx-import/FrameworksIndex/two.xml
+++ b/mdoc/Test/en.expected-fx-import/FrameworksIndex/two.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="two">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
     <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyNamespace">
     <Type Name="MyFramework.MyNamespace.MyClass" Id="T:MyFramework.MyNamespace.MyClass">

--- a/mdoc/Test/en.expected-fx-import/index.xml
+++ b/mdoc/Test/en.expected-fx-import/index.xml
@@ -10,7 +10,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
@@ -20,7 +20,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0">
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>

--- a/mdoc/Test/en.expected-vbnet/FrameworksIndex/One.xml
+++ b/mdoc/Test/en.expected-vbnet/FrameworksIndex/One.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="One">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyNamespace">
     <Type Name="MyFramework.MyNamespace.MyClass" Id="T:MyFramework.MyNamespace.MyClass">

--- a/mdoc/Test/en.expected-vbnet/FrameworksIndex/Two.xml
+++ b/mdoc/Test/en.expected-vbnet/FrameworksIndex/Two.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Two">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyOtherNamespace">
     <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">

--- a/mdoc/Test/en.expected-vbnet/index.xml
+++ b/mdoc/Test/en.expected-vbnet/index.xml
@@ -10,7 +10,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
+    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
@@ -20,7 +20,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>

--- a/mdoc/Test/test-nuget-information/en.expected-frameworks-with-nuget-information/FrameworksIndex/One.xml
+++ b/mdoc/Test/test-nuget-information/en.expected-frameworks-with-nuget-information/FrameworksIndex/One.xml
@@ -2,8 +2,8 @@
 <Framework Name="One">
   <package Id="thepackage" Version="2.2.2" />
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyNamespace">
     <Type Name="MyFramework.MyNamespace.MyClass" Id="T:MyFramework.MyNamespace.MyClass">

--- a/mdoc/Test/test-nuget-information/en.expected-frameworks-with-nuget-information/FrameworksIndex/Two.xml
+++ b/mdoc/Test/test-nuget-information/en.expected-frameworks-with-nuget-information/FrameworksIndex/Two.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Framework Name="Two">
   <Assemblies>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
     <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0" />
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0" />
   </Assemblies>
   <Namespace Name="MyFramework.MyOtherNamespace">
     <Type Name="MyFramework.MyOtherNamespace.MyOtherClass" Id="T:MyFramework.MyOtherNamespace.MyOtherClass">

--- a/mdoc/Test/test-nuget-information/en.expected-frameworks-with-nuget-information/index.xml
+++ b/mdoc/Test/test-nuget-information/en.expected-frameworks-with-nuget-information/index.xml
@@ -10,7 +10,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
+    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>
@@ -20,7 +20,7 @@
         </Attribute>
       </Attributes>
     </Assembly>
-    <Assembly Name="DocTest-addNonGeneric" Version="0.0.0.0">
+    <Assembly Name="DocTest-DropNS-classic-secondary" Version="0.0.0.0">
       <Attributes>
         <Attribute>
           <AttributeName>System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute+DebuggingModes.IgnoreSymbolStoreSequencePoints)</AttributeName>


### PR DESCRIPTION
The Directory.GetFiles method returned file names is not sort, this makes the order of the assembly elements of our generated XML files is inconsistent in different environments, so we need to sort it and update those expected XML files.