### PR TITLE
Added missing const& for cpp/winrt syntax

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppWinRtFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppWinRtFullMemberFormatter.cs
@@ -10,7 +10,7 @@ namespace Mono.Documentation.Updater.Formatters.CppFormatters
     public class CppWinRtFullMemberFormatter : CppCxFullMemberFormatter
     {
         protected override bool AppendHatOnReturn => false;
-        protected override string HatModifier => $" const{RefTypeModifier}";
+        protected override string HatModifier => $" const&";
         public override string Language => Consts.CppWinRt;
         protected override string RefTypeModifier => " &";
 

--- a/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppWinRtFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppWinRtFullMemberFormatter.cs
@@ -99,15 +99,7 @@ namespace Mono.Documentation.Updater.Formatters.CppFormatters
             }
 
             buf.Append(GetTypeName(parameter.ParameterType, EmptyAttributeParserContext.Empty()));
-            if (parameter.IsIn)
-            {
-                buf.Append(HatModifier);
-            }
-            else if (parameter.IsOut)
-            {
-                buf.Append(RefTypeModifier);
-            }
-            buf.Append(" ");
+            buf.Append(parameter.IsOut ? RefTypeModifier : HatModifier).Append(" ");
             buf.Append(parameter.Name);
 
             if (parameter.HasDefault && parameter.IsOptional && parameter.HasConstant)

--- a/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppWinRtFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppWinRtFullMemberFormatter.cs
@@ -99,7 +99,15 @@ namespace Mono.Documentation.Updater.Formatters.CppFormatters
             }
 
             buf.Append(GetTypeName(parameter.ParameterType, EmptyAttributeParserContext.Empty()));
-            buf.Append(parameter.IsIn ? HatModifier : RefTypeModifier).Append(" ");
+            if (parameter.IsIn)
+            {
+                buf.Append(HatModifier);
+            }
+            else if (parameter.IsOut)
+            {
+                buf.Append(RefTypeModifier);
+            }
+            buf.Append(" ");
             buf.Append(parameter.Name);
 
             if (parameter.HasDefault && parameter.IsOptional && parameter.HasConstant)

--- a/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppWinRtFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppWinRtFullMemberFormatter.cs
@@ -99,7 +99,11 @@ namespace Mono.Documentation.Updater.Formatters.CppFormatters
             }
 
             buf.Append(GetTypeName(parameter.ParameterType, EmptyAttributeParserContext.Empty()));
-            buf.Append(parameter.IsOut ? RefTypeModifier : HatModifier).Append(" ");
+            if (!parameter.ParameterType.IsByReference && !parameter.ParameterType.IsPointer)
+            {
+                buf.Append(parameter.IsOut ? RefTypeModifier : HatModifier);
+            }
+            buf.Append(" ");
             buf.Append(parameter.Name);
 
             if (parameter.HasDefault && parameter.IsOptional && parameter.HasConstant)

--- a/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppWinRtFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppWinRtFullMemberFormatter.cs
@@ -98,7 +98,8 @@ namespace Mono.Documentation.Updater.Formatters.CppFormatters
                     buf.AppendFormat("... ");
             }
 
-            buf.Append(GetTypeNameWithOptions(parameter.ParameterType, !AppendHatOnReturn)).Append(" ");
+            buf.Append(GetTypeName(parameter.ParameterType, EmptyAttributeParserContext.Empty()));
+            buf.Append(parameter.IsIn ? HatModifier : RefTypeModifier).Append(" ");
             buf.Append(parameter.Name);
 
             if (parameter.HasDefault && parameter.IsOptional && parameter.HasConstant)

--- a/mdoc/Test/ClassEnumeratorECMA.xml
+++ b/mdoc/Test/ClassEnumeratorECMA.xml
@@ -97,7 +97,7 @@
                <MemberSignature Language="JavaScript" Value="function main(cmdArgs)" Usage="CustomNamespace.ClassEnumerator.main(cmdArgs)" />
                <MemberSignature Language="C++ CLI" Value="public:&#xA; static void Main(cli::array &lt;System::String ^&gt; ^ cmdArgs);" />
                <MemberSignature Language="C++ CX" Value="public:&#xA; static void Main(Platform::Array &lt;Platform::String ^&gt; ^ cmdArgs);" />
-               <MemberSignature Language="C++ WINRT" Value=" static void Main(std::Array &lt;winrt::hstring const &amp;&gt; const &amp; cmdArgs);" />
+               <MemberSignature Language="C++ WINRT" Value=" static void Main(std::Array &lt;winrt::hstring const&amp;&gt; const&amp; cmdArgs);" />
                <MemberType>Method</MemberType>
                <AssemblyInfo>
                   <AssemblyVersion>0.0.65535.65535</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt/MyFramework.MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-cppwinrt/MyFramework.MyNamespace/MyClass.xml
@@ -33,7 +33,7 @@
     <Member MemberName="Hello">
       <MemberSignature Language="C#" Value="public float Hello (int value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="float Hello(int value);" />
+      <MemberSignature Language="C++ WINRT" Value="float Hello(int const &amp; value);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyName>DocTest-DropNS-classic</AssemblyName>

--- a/mdoc/Test/en.expected-cppwinrt/MyFramework.MyNamespace/MyClass.xml
+++ b/mdoc/Test/en.expected-cppwinrt/MyFramework.MyNamespace/MyClass.xml
@@ -33,7 +33,7 @@
     <Member MemberName="Hello">
       <MemberSignature Language="C#" Value="public float Hello (int value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="float Hello(int const &amp; value);" />
+      <MemberSignature Language="C++ WINRT" Value="float Hello(int const&amp; value);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyName>DocTest-DropNS-classic</AssemblyName>

--- a/mdoc/Test/en.expected-cppwinrt/MyFramework.MyOtherNamespace/MyOtherClass.xml
+++ b/mdoc/Test/en.expected-cppwinrt/MyFramework.MyOtherNamespace/MyOtherClass.xml
@@ -33,7 +33,7 @@
     <Member MemberName="Hello">
       <MemberSignature Language="C#" Value="public float Hello (double value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(float64 value) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="float Hello(double value);" />
+      <MemberSignature Language="C++ WINRT" Value="float Hello(double const &amp; value);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
@@ -55,7 +55,7 @@
     <Member MemberName="Hello">
       <MemberSignature Language="C#" Value="public float Hello (int value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="float Hello(int value);" />
+      <MemberSignature Language="C++ WINRT" Value="float Hello(int const &amp; value);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>

--- a/mdoc/Test/en.expected-cppwinrt/MyFramework.MyOtherNamespace/MyOtherClass.xml
+++ b/mdoc/Test/en.expected-cppwinrt/MyFramework.MyOtherNamespace/MyOtherClass.xml
@@ -33,7 +33,7 @@
     <Member MemberName="Hello">
       <MemberSignature Language="C#" Value="public float Hello (double value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(float64 value) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="float Hello(double const &amp; value);" />
+      <MemberSignature Language="C++ WINRT" Value="float Hello(double const&amp; value);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>
@@ -55,7 +55,7 @@
     <Member MemberName="Hello">
       <MemberSignature Language="C#" Value="public float Hello (int value);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance float32 Hello(int32 value) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="float Hello(int const &amp; value);" />
+      <MemberSignature Language="C++ WINRT" Value="float Hello(int const&amp; value);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyName>DocTest-DropNS-classic-secondary</AssemblyName>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/GenericBase`1.xml
@@ -36,7 +36,7 @@
     <Member MemberName="BaseMethod&lt;S&gt;">
       <MemberSignature Language="C#" Value="public U BaseMethod&lt;S&gt; (S genericParameter);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance !U BaseMethod&lt;S&gt;(!!S genericParameter) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename S&gt;&#xA; U BaseMethod(S genericParameter);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename S&gt;&#xA; U BaseMethod(S const &amp; genericParameter);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/GenericBase`1.xml
@@ -36,7 +36,7 @@
     <Member MemberName="BaseMethod&lt;S&gt;">
       <MemberSignature Language="C#" Value="public U BaseMethod&lt;S&gt; (S genericParameter);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance !U BaseMethod&lt;S&gt;(!!S genericParameter) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename S&gt;&#xA; U BaseMethod(S const &amp; genericParameter);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename S&gt;&#xA; U BaseMethod(S const&amp; genericParameter);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -85,7 +85,7 @@
     <Member MemberName="ItemChanged">
       <MemberSignature Language="C#" Value="public event Action&lt;Mono.DocTest.Generic.MyList&lt;U&gt;,Mono.DocTest.Generic.MyList&lt;U&gt;.Helper&lt;U,U&gt;&gt; ItemChanged;" />
       <MemberSignature Language="ILAsm" Value=".event class System.Action`2&lt;class Mono.DocTest.Generic.MyList`1&lt;!U&gt;, class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!U, !U, !U&gt;&gt; ItemChanged" />
-      <MemberSignature Language="C++ WINRT" Value="// Register&#xA;event_token ItemChanged(Action&lt;Mono::DocTest::Generic::MyList&lt;U&gt;, Mono::DocTest::Generic::MyList&lt;U&gt;::Helper&lt;U, U&gt; const &amp;&gt; const&amp; handler) const;&#xA;&#xA;// Revoke with event_token&#xA;void ItemChanged(event_token const* cookie) const;&#xA;&#xA;// Revoke with event_revoker&#xA;ItemChanged_revoker ItemChanged(auto_revoke_t, Action&lt;Mono::DocTest::Generic::MyList&lt;U&gt;, Mono::DocTest::Generic::MyList&lt;U&gt;::Helper&lt;U, U&gt; const &amp;&gt; const&amp; handler) const;" />
+      <MemberSignature Language="C++ WINRT" Value="// Register&#xA;event_token ItemChanged(Action&lt;Mono::DocTest::Generic::MyList&lt;U&gt;, Mono::DocTest::Generic::MyList&lt;U&gt;::Helper&lt;U, U&gt; const&amp;&gt; const&amp; handler) const;&#xA;&#xA;// Revoke with event_token&#xA;void ItemChanged(event_token const* cookie) const;&#xA;&#xA;// Revoke with event_revoker&#xA;ItemChanged_revoker ItemChanged(auto_revoke_t, Action&lt;Mono::DocTest::Generic::MyList&lt;U&gt;, Mono::DocTest::Generic::MyList&lt;U&gt;::Helper&lt;U, U&gt; const&amp;&gt; const&amp; handler) const;" />
       <MemberType>Event</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -117,7 +117,7 @@
     <Member MemberName="op_Explicit">
       <MemberSignature Language="C#" Value="public static explicit operator U (Mono.DocTest.Generic.GenericBase&lt;U&gt; list);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname !U op_Explicit(class Mono.DocTest.Generic.GenericBase`1&lt;!U&gt; list) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value=" static explicit operator U(Mono::DocTest::Generic::GenericBase&lt;U&gt; const &amp; list);" />
+      <MemberSignature Language="C++ WINRT" Value=" static explicit operator U(Mono::DocTest::Generic::GenericBase&lt;U&gt; const&amp; list);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/IFoo`1.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/IFoo`1.xml
@@ -19,7 +19,7 @@
     <Member MemberName="Method&lt;U&gt;">
       <MemberSignature Language="C#" Value="public T Method&lt;U&gt; (T t, U u);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance !T Method&lt;U&gt;(!T t, !!U u) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; T Method(T const &amp; t, U const &amp; u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; T Method(T const&amp; t, U const&amp; u);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/IFoo`1.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/IFoo`1.xml
@@ -19,7 +19,7 @@
     <Member MemberName="Method&lt;U&gt;">
       <MemberSignature Language="C#" Value="public T Method&lt;U&gt; (T t, U u);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance !T Method&lt;U&gt;(!T t, !!U u) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; T Method(T t, U u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; T Method(T const &amp; t, U const &amp; u);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`1+Helper`2.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`1+Helper`2.xml
@@ -39,7 +39,7 @@
     <Member MemberName="UseT">
       <MemberSignature Language="C#" Value="public void UseT (T a, U b, V c);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void UseT(!T a, !U b, !V c) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void UseT(T a, U b, V c);" />
+      <MemberSignature Language="C++ WINRT" Value="void UseT(T const &amp; a, U const &amp; b, V const &amp; c);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`1+Helper`2.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`1+Helper`2.xml
@@ -39,7 +39,7 @@
     <Member MemberName="UseT">
       <MemberSignature Language="C#" Value="public void UseT (T a, U b, V c);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void UseT(!T a, !U b, !V c) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void UseT(T const &amp; a, U const &amp; b, V const &amp; c);" />
+      <MemberSignature Language="C++ WINRT" Value="void UseT(T const&amp; a, U const&amp; b, V const&amp; c);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`1.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`1.xml
@@ -96,7 +96,7 @@
     <Member MemberName="Method&lt;U&gt;">
       <MemberSignature Language="C#" Value="public void Method&lt;U&gt; (T t, U u);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Method&lt;U&gt;(!T t, !!U u) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void Method(T t, U u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void Method(T const &amp; t, U const &amp; u);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -168,7 +168,7 @@
     <Member MemberName="Test">
       <MemberSignature Language="C#" Value="public void Test (T t);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Test(!T t) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void Test(T t);" />
+      <MemberSignature Language="C++ WINRT" Value="void Test(T const &amp; t);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`1.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`1.xml
@@ -96,7 +96,7 @@
     <Member MemberName="Method&lt;U&gt;">
       <MemberSignature Language="C#" Value="public void Method&lt;U&gt; (T t, U u);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Method&lt;U&gt;(!T t, !!U u) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void Method(T const &amp; t, U const &amp; u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void Method(T const&amp; t, U const&amp; u);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -168,7 +168,7 @@
     <Member MemberName="Test">
       <MemberSignature Language="C#" Value="public void Test (T t);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Test(!T t) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void Test(T const &amp; t);" />
+      <MemberSignature Language="C++ WINRT" Value="void Test(T const&amp; t);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -188,7 +188,7 @@
     <Member MemberName="UseHelper&lt;U,V&gt;">
       <MemberSignature Language="C#" Value="public void UseHelper&lt;U,V&gt; (Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U,V&gt; helper);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void UseHelper&lt;U, V&gt;(class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!T, !!U, !!V&gt; helper) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U, typename V&gt;&#xA; void UseHelper(Mono::DocTest::Generic::MyList&lt;T&gt;::Helper&lt;U, V&gt; const &amp; helper);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U, typename V&gt;&#xA; void UseHelper(Mono::DocTest::Generic::MyList&lt;T&gt;::Helper&lt;U, V&gt; const&amp; helper);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`2.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`2.xml
@@ -76,7 +76,7 @@
     <Member MemberName="CopyTo">
       <MemberSignature Language="C#" Value="public void CopyTo (A[] array, int arrayIndex);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void CopyTo(!A[] array, int32 arrayIndex) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void CopyTo(std::Array &lt;A&gt; const &amp; array, int const &amp; arrayIndex);" />
+      <MemberSignature Language="C++ WINRT" Value="void CopyTo(std::Array &lt;A&gt; const&amp; array, int const&amp; arrayIndex);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.CopyTo(`0[],System.Int32)</InterfaceMember>
@@ -195,7 +195,7 @@
     <Member MemberName="Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt;">
       <MemberSignature Language="C#" Value="A IFoo&lt;A&gt;.Method&lt;U&gt; (A a, U u);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance !A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt;(!A a, !!U u) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A const &amp; a, U const &amp; u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A const&amp; a, U const&amp; u);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0)</InterfaceMember>
@@ -266,7 +266,7 @@
     <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Add">
       <MemberSignature Language="C#" Value="void ICollection&lt;A&gt;.Add (A item);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void System.Collections.Generic.ICollection&lt;A&gt;.Add(!A item) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void System.Collections.Generic.ICollection&lt;A&gt;.Add(A const &amp; item);" />
+      <MemberSignature Language="C++ WINRT" Value="void System.Collections.Generic.ICollection&lt;A&gt;.Add(A const&amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Add(`0)</InterfaceMember>
@@ -309,7 +309,7 @@
     <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Contains">
       <MemberSignature Language="C#" Value="bool ICollection&lt;A&gt;.Contains (A item);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(!A item) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A const &amp; item);" />
+      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A const&amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Contains(`0)</InterfaceMember>
@@ -353,7 +353,7 @@
     <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Remove">
       <MemberSignature Language="C#" Value="bool ICollection&lt;A&gt;.Remove (A item);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(!A item) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A const &amp; item);" />
+      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A const&amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Remove(`0)</InterfaceMember>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`2.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest.Generic/MyList`2.xml
@@ -76,7 +76,7 @@
     <Member MemberName="CopyTo">
       <MemberSignature Language="C#" Value="public void CopyTo (A[] array, int arrayIndex);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void CopyTo(!A[] array, int32 arrayIndex) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void CopyTo(std::Array &lt;A&gt; const &amp; array, int arrayIndex);" />
+      <MemberSignature Language="C++ WINRT" Value="void CopyTo(std::Array &lt;A&gt; const &amp; array, int const &amp; arrayIndex);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.CopyTo(`0[],System.Int32)</InterfaceMember>
@@ -195,7 +195,7 @@
     <Member MemberName="Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt;">
       <MemberSignature Language="C#" Value="A IFoo&lt;A&gt;.Method&lt;U&gt; (A a, U u);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance !A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method&lt;U&gt;(!A a, !!U u) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A a, U u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A const &amp; a, U const &amp; u);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0)</InterfaceMember>
@@ -266,7 +266,7 @@
     <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Add">
       <MemberSignature Language="C#" Value="void ICollection&lt;A&gt;.Add (A item);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance void System.Collections.Generic.ICollection&lt;A&gt;.Add(!A item) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void System.Collections.Generic.ICollection&lt;A&gt;.Add(A item);" />
+      <MemberSignature Language="C++ WINRT" Value="void System.Collections.Generic.ICollection&lt;A&gt;.Add(A const &amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Add(`0)</InterfaceMember>
@@ -309,7 +309,7 @@
     <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Contains">
       <MemberSignature Language="C#" Value="bool ICollection&lt;A&gt;.Contains (A item);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(!A item) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A item);" />
+      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A const &amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Contains(`0)</InterfaceMember>
@@ -353,7 +353,7 @@
     <Member MemberName="System.Collections.Generic.ICollection&lt;A&gt;.Remove">
       <MemberSignature Language="C#" Value="bool ICollection&lt;A&gt;.Remove (A item);" />
       <MemberSignature Language="ILAsm" Value=".method hidebysig newslot virtual instance bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(!A item) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A item);" />
+      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A const &amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Remove(`0)</InterfaceMember>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/DocAttribute.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/DocAttribute.xml
@@ -23,7 +23,7 @@
     <Member MemberName=".ctor">
       <MemberSignature Language="C#" Value="public DocAttribute (string docs);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string docs) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value=" DocAttribute(winrt::hstring const &amp; docs);" />
+      <MemberSignature Language="C++ WINRT" Value=" DocAttribute(winrt::hstring const&amp; docs);" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/DocValueType.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/DocValueType.xml
@@ -22,7 +22,7 @@
     <Member MemberName="M">
       <MemberSignature Language="C#" Value="public void M (int i);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const&amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/DocValueType.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/DocValueType.xml
@@ -22,7 +22,7 @@
     <Member MemberName="M">
       <MemberSignature Language="C#" Value="public void M (int i);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/UseLists.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/UseLists.xml
@@ -142,7 +142,7 @@
     <Member MemberName="UseHelper&lt;T,U,V&gt;">
       <MemberSignature Language="C#" Value="public void UseHelper&lt;T,U,V&gt; (Mono.DocTest.Generic.MyList&lt;T&gt;.Helper&lt;U,V&gt; helper);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void UseHelper&lt;T, U, V&gt;(class Mono.DocTest.Generic.MyList`1/Helper`2&lt;!!T, !!U, !!V&gt; helper) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T, typename U, typename V&gt;&#xA; void UseHelper(Mono::DocTest::Generic::MyList&lt;T&gt;::Helper&lt;U, V&gt; const &amp; helper);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T, typename U, typename V&gt;&#xA; void UseHelper(Mono::DocTest::Generic::MyList&lt;T&gt;::Helper&lt;U, V&gt; const&amp; helper);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget+NestedClass.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget+NestedClass.xml
@@ -31,7 +31,7 @@
     <Member MemberName="M">
       <MemberSignature Language="C#" Value="public void M (int i);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget+NestedClass.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget+NestedClass.xml
@@ -31,7 +31,7 @@
     <Member MemberName="M">
       <MemberSignature Language="C#" Value="public void M (int i);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const&amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget+NestedClass`1.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget+NestedClass`1.xml
@@ -35,7 +35,7 @@
     <Member MemberName="M">
       <MemberSignature Language="C#" Value="public void M (int i);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget+NestedClass`1.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget+NestedClass`1.xml
@@ -35,7 +35,7 @@
     <Member MemberName="M">
       <MemberSignature Language="C#" Value="public void M (int i);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M(int32 i) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const&amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget.xml
@@ -163,7 +163,7 @@
     <Member MemberName="Default">
       <MemberSignature Language="C#" Value="public void Default (int a = 1, int b = 2);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Default(int32 a, int32 b) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void Default(int a = 1, int b = 2);" />
+      <MemberSignature Language="C++ WINRT" Value="void Default(int const &amp; a = 1, int const &amp; b = 2);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -185,7 +185,7 @@
     <Member MemberName="Default">
       <MemberSignature Language="C#" Value="public void Default (string a = &quot;a&quot;, char b = '\0');" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Default(string a, char b) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void Default(winrt::hstring const &amp; a = &quot;a&quot;, char b = '\0');" />
+      <MemberSignature Language="C++ WINRT" Value="void Default(winrt::hstring const &amp; a = &quot;a&quot;, char const &amp; b = '\0');" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -470,7 +470,7 @@
     <Member MemberName="M1">
       <MemberSignature Language="C#" Value="public void M1 (char c, out float f, ref Mono.DocTest.DocValueType v);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M1(char c, [out] float32&amp; f, valuetype Mono.DocTest.DocValueType&amp; v) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M1(char c, [Runtime::InteropServices::Out] float &amp; f, Mono::DocTest::DocValueType &amp; v);" />
+      <MemberSignature Language="C++ WINRT" Value="void M1(char const &amp; c, [Runtime::InteropServices::Out] float &amp; f, Mono::DocTest::DocValueType &amp; v);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/Mono.DocTest/Widget.xml
@@ -52,7 +52,7 @@
     <Member MemberName=".ctor">
       <MemberSignature Language="C#" Value="public Widget (string s);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig specialname rtspecialname instance void .ctor(string s) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value=" Widget(winrt::hstring const &amp; s);" />
+      <MemberSignature Language="C++ WINRT" Value=" Widget(winrt::hstring const&amp; s);" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -131,7 +131,7 @@
     <Member MemberName="array2">
       <MemberSignature Language="C#" Value="public Mono.DocTest.Widget[,] array2;" />
       <MemberSignature Language="ILAsm" Value=".field public class Mono.DocTest.Widget[,] array2" />
-      <MemberSignature Language="C++ WINRT" Value="std::Array &lt;Mono::DocTest::Widget const &amp;, 2&gt; array2;" />
+      <MemberSignature Language="C++ WINRT" Value="std::Array &lt;Mono::DocTest::Widget const&amp;, 2&gt; array2;" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -147,7 +147,7 @@
     <Member MemberName="classCtorError">
       <MemberSignature Language="C#" Value="public static readonly string[] classCtorError;" />
       <MemberSignature Language="ILAsm" Value=".field public static initonly string[] classCtorError" />
-      <MemberSignature Language="C++ WINRT" Value="static initonly std::Array &lt;winrt::hstring const &amp;&gt; classCtorError;" />
+      <MemberSignature Language="C++ WINRT" Value="static initonly std::Array &lt;winrt::hstring const&amp;&gt; classCtorError;" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -163,7 +163,7 @@
     <Member MemberName="Default">
       <MemberSignature Language="C#" Value="public void Default (int a = 1, int b = 2);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Default(int32 a, int32 b) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void Default(int const &amp; a = 1, int const &amp; b = 2);" />
+      <MemberSignature Language="C++ WINRT" Value="void Default(int const&amp; a = 1, int const&amp; b = 2);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -185,7 +185,7 @@
     <Member MemberName="Default">
       <MemberSignature Language="C#" Value="public void Default (string a = &quot;a&quot;, char b = '\0');" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void Default(string a, char b) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void Default(winrt::hstring const &amp; a = &quot;a&quot;, char const &amp; b = '\0');" />
+      <MemberSignature Language="C++ WINRT" Value="void Default(winrt::hstring const&amp; a = &quot;a&quot;, char const&amp; b = '\0');" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -223,7 +223,7 @@
     <Member MemberName="Dynamic0">
       <MemberSignature Language="C#" Value="public dynamic Dynamic0 (dynamic a, dynamic b);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance object Dynamic0(object a, object b) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IInspectable Dynamic0(winrt::Windows::Foundation::IInspectable const &amp; a, winrt::Windows::Foundation::IInspectable const &amp; b);" />
+      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IInspectable Dynamic0(winrt::Windows::Foundation::IInspectable const&amp; a, winrt::Windows::Foundation::IInspectable const&amp; b);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -359,7 +359,7 @@
     <Member MemberName="DynamicP">
       <MemberSignature Language="C#" Value="public Func&lt;Func&lt;string,dynamic,string&gt;,Func&lt;dynamic,Func&lt;dynamic&gt;,string&gt;&gt; DynamicP { get; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class System.Func`2&lt;class System.Func`3&lt;string, object, string&gt;, class System.Func`3&lt;object, class System.Func`1&lt;object&gt;, string&gt;&gt; DynamicP" />
-      <MemberSignature Language="C++ WINRT" Value="Func&lt;Func&lt;winrt::hstring, winrt::Windows::Foundation::IInspectable const &amp;, winrt::hstring const &amp;&gt;, Func&lt;winrt::Windows::Foundation::IInspectable, Func&lt;winrt::Windows::Foundation::IInspectable&gt; const &amp;, winrt::hstring const &amp;&gt; const &amp;&gt; DynamicP();" />
+      <MemberSignature Language="C++ WINRT" Value="Func&lt;Func&lt;winrt::hstring, winrt::Windows::Foundation::IInspectable const&amp;, winrt::hstring const&amp;&gt;, Func&lt;winrt::Windows::Foundation::IInspectable, Func&lt;winrt::Windows::Foundation::IInspectable&gt; const&amp;, winrt::hstring const&amp;&gt; const&amp;&gt; DynamicP();" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -470,7 +470,7 @@
     <Member MemberName="M1">
       <MemberSignature Language="C#" Value="public void M1 (char c, out float f, ref Mono.DocTest.DocValueType v);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M1(char c, [out] float32&amp; f, valuetype Mono.DocTest.DocValueType&amp; v) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M1(char const &amp; c, [Runtime::InteropServices::Out] float &amp; f, Mono::DocTest::DocValueType &amp; v);" />
+      <MemberSignature Language="C++ WINRT" Value="void M1(char const&amp; c, [Runtime::InteropServices::Out] float &amp; f, Mono::DocTest::DocValueType &amp; v);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -527,7 +527,7 @@
     <Member MemberName="M2">
       <MemberSignature Language="C#" Value="public void M2 (short[] x1, int[,] x2, long[][] x3);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M2(int16[] x1, int32[,] x2, int64[][] x3) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M2(std::Array &lt;short&gt; const &amp; x1, std::Array &lt;int, 2&gt; const &amp; x2, std::Array &lt;std::Array &lt;long&gt; const &amp;&gt; const &amp; x3);" />
+      <MemberSignature Language="C++ WINRT" Value="void M2(std::Array &lt;short&gt; const&amp; x1, std::Array &lt;int, 2&gt; const&amp; x2, std::Array &lt;std::Array &lt;long&gt; const&amp;&gt; const&amp; x3);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -551,7 +551,7 @@
     <Member MemberName="M3">
       <MemberSignature Language="C#" Value="protected void M3 (long[][] x3, Mono.DocTest.Widget[,,][] x4);" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M3(int64[][] x3, class Mono.DocTest.Widget[,,][] x4) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M3(std::Array &lt;std::Array &lt;long&gt; const &amp;&gt; const &amp; x3, std::Array &lt;std::Array &lt;Mono::DocTest::Widget const &amp;, 3&gt; const &amp;&gt; const &amp; x4);" />
+      <MemberSignature Language="C++ WINRT" Value="void M3(std::Array &lt;std::Array &lt;long&gt; const&amp;&gt; const&amp; x3, std::Array &lt;std::Array &lt;Mono::DocTest::Widget const&amp;, 3&gt; const&amp;&gt; const&amp; x4);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -595,7 +595,7 @@
     <Member MemberName="M5">
       <MemberSignature Language="C#" Value="protected void M5 (void* pv, double*[,][] pd);" />
       <MemberSignature Language="ILAsm" Value=".method familyhidebysig instance void M5(void* pv, float64*[,][] pd) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M5(void* pv, std::Array &lt;std::Array &lt;double*, 2&gt; const &amp;&gt; const &amp; pd);" />
+      <MemberSignature Language="C++ WINRT" Value="void M5(void* pv, std::Array &lt;std::Array &lt;double*, 2&gt; const&amp;&gt; const&amp; pd);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -645,7 +645,7 @@
     <Member MemberName="M7">
       <MemberSignature Language="C#" Value="public void M7 (Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple a);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig instance void M7(class Mono.DocTest.Widget/NestedClass/Double/Triple/Quadruple a) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="void M7(Mono::DocTest::Widget::NestedClass::Double::Triple::Quadruple const &amp; a);" />
+      <MemberSignature Language="C++ WINRT" Value="void M7(Mono::DocTest::Widget::NestedClass::Double::Triple::Quadruple const&amp; a);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -697,7 +697,7 @@
     <Member MemberName="op_Addition">
       <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x1, Mono.DocTest.Widget x2);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_Addition(class Mono.DocTest.Widget x1, class Mono.DocTest.Widget x2) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value=" static Mono::DocTest::Widget operator +(Mono::DocTest::Widget const &amp; x1, Mono::DocTest::Widget const &amp; x2);" />
+      <MemberSignature Language="C++ WINRT" Value=" static Mono::DocTest::Widget operator +(Mono::DocTest::Widget const&amp; x1, Mono::DocTest::Widget const&amp; x2);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -736,7 +736,7 @@
     <Member MemberName="op_Explicit">
       <MemberSignature Language="C#" Value="public static explicit operator int (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int32 op_Explicit(class Mono.DocTest.Widget x) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value=" static explicit operator int(Mono::DocTest::Widget const &amp; x);" />
+      <MemberSignature Language="C++ WINRT" Value=" static explicit operator int(Mono::DocTest::Widget const&amp; x);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -757,7 +757,7 @@
     <Member MemberName="op_Implicit">
       <MemberSignature Language="C#" Value="public static implicit operator long (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname int64 op_Implicit(class Mono.DocTest.Widget x) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value=" static operator long(Mono::DocTest::Widget const &amp; x);" />
+      <MemberSignature Language="C++ WINRT" Value=" static operator long(Mono::DocTest::Widget const&amp; x);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -778,7 +778,7 @@
     <Member MemberName="op_UnaryPlus">
       <MemberSignature Language="C#" Value="public static Mono.DocTest.Widget operator + (Mono.DocTest.Widget x);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig specialname class Mono.DocTest.Widget op_UnaryPlus(class Mono.DocTest.Widget x) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value=" static Mono::DocTest::Widget operator +(Mono::DocTest::Widget const &amp; x);" />
+      <MemberSignature Language="C++ WINRT" Value=" static Mono::DocTest::Widget operator +(Mono::DocTest::Widget const&amp; x);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/System/Array.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/System/Array.xml
@@ -83,7 +83,7 @@
     <Member MemberName="Resize&lt;T&gt;">
       <MemberSignature Language="C#" Value="public static void Resize&lt;T&gt; (ref T[] array, int newSize);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Resize&lt;T&gt;(!!T[]&amp; array, int32 newSize) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T&gt;&#xA; static void Resize(std::Array &lt;T&gt; const &amp; &amp; array, int newSize);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T&gt;&#xA; static void Resize(std::Array &lt;T&gt; const &amp; &amp; array, int const &amp; newSize);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-cppwinrt2/System/Array.xml
+++ b/mdoc/Test/en.expected-cppwinrt2/System/Array.xml
@@ -83,7 +83,7 @@
     <Member MemberName="Resize&lt;T&gt;">
       <MemberSignature Language="C#" Value="public static void Resize&lt;T&gt; (ref T[] array, int newSize);" />
       <MemberSignature Language="ILAsm" Value=".method public static hidebysig void Resize&lt;T&gt;(!!T[]&amp; array, int32 newSize) cil managed" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T&gt;&#xA; static void Resize(std::Array &lt;T&gt; const &amp; &amp; array, int const &amp; newSize);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T&gt;&#xA; static void Resize(std::Array &lt;T&gt; const&amp; &amp; array, int const&amp; newSize);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected-eii-implementation-ecmadoc/CustomNamespace/ClassEnumerator.xml
+++ b/mdoc/Test/en.expected-eii-implementation-ecmadoc/CustomNamespace/ClassEnumerator.xml
@@ -92,7 +92,7 @@
       <MemberSignature Language="JavaScript" Value="function main(cmdArgs)" Usage="CustomNamespace.ClassEnumerator.main(cmdArgs)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; static void Main(cli::array &lt;System::String ^&gt; ^ cmdArgs);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; static void Main(Platform::Array &lt;Platform::String ^&gt; ^ cmdArgs);" />
-      <MemberSignature Language="C++ WINRT" Value=" static void Main(std::Array &lt;winrt::hstring const &amp;&gt; const &amp; cmdArgs);" />
+      <MemberSignature Language="C++ WINRT" Value=" static void Main(std::Array &lt;winrt::hstring const&amp;&gt; const&amp; cmdArgs);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.65535.65535</AssemblyVersion>

--- a/mdoc/Test/en.expected-eii-implementation-slashdoc/CustomNamespace/ClassEnumerator.xml
+++ b/mdoc/Test/en.expected-eii-implementation-slashdoc/CustomNamespace/ClassEnumerator.xml
@@ -96,7 +96,7 @@
       <MemberSignature Language="JavaScript" Value="function main(cmdArgs)" Usage="CustomNamespace.ClassEnumerator.main(cmdArgs)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; static void Main(cli::array &lt;System::String ^&gt; ^ cmdArgs);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; static void Main(Platform::Array &lt;Platform::String ^&gt; ^ cmdArgs);" />
-      <MemberSignature Language="C++ WINRT" Value=" static void Main(std::Array &lt;winrt::hstring const &amp;&gt; const &amp; cmdArgs);" />
+      <MemberSignature Language="C++ WINRT" Value=" static void Main(std::Array &lt;winrt::hstring const&amp;&gt; const&amp; cmdArgs);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.65535.65535</AssemblyVersion>

--- a/mdoc/Test/en.expected-eii-implementation/CustomNamespace/ClassEnumerator.xml
+++ b/mdoc/Test/en.expected-eii-implementation/CustomNamespace/ClassEnumerator.xml
@@ -92,7 +92,7 @@
       <MemberSignature Language="JavaScript" Value="function main(cmdArgs)" Usage="CustomNamespace.ClassEnumerator.main(cmdArgs)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; static void Main(cli::array &lt;System::String ^&gt; ^ cmdArgs);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; static void Main(Platform::Array &lt;Platform::String ^&gt; ^ cmdArgs);" />
-      <MemberSignature Language="C++ WINRT" Value=" static void Main(std::Array &lt;winrt::hstring const &amp;&gt; const &amp; cmdArgs);" />
+      <MemberSignature Language="C++ WINRT" Value=" static void Main(std::Array &lt;winrt::hstring const&amp;&gt; const&amp; cmdArgs);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.65535.65535</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/GenericBase`1.xml
@@ -49,7 +49,7 @@
       <MemberSignature Language="F#" Value="member this.BaseMethod : 'S -&gt; 'U" Usage="genericBase.BaseMethod genericParameter" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename S&gt;&#xA; U BaseMethod(S genericParameter);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA;generic &lt;typename S&gt;&#xA; U BaseMethod(S genericParameter);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename S&gt;&#xA; U BaseMethod(S const &amp; genericParameter);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename S&gt;&#xA; U BaseMethod(S const&amp; genericParameter);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -107,7 +107,7 @@
       <MemberSignature Language="VB.NET" Value="Public Custom Event ItemChanged As Action(Of MyList(Of U), MyList(Of U).Helper(Of U, U)) " />
       <MemberSignature Language="F#" Value="member this.ItemChanged : Action&lt;Mono.DocTest.Generic.MyList&lt;'U&gt;, Mono.DocTest.Generic.MyList&lt;'U&gt;.Helper&lt;'U, 'U&gt;&gt; " Usage="member this.ItemChanged : System.Action&lt;Mono.DocTest.Generic.MyList&lt;'U&gt;, Mono.DocTest.Generic.MyList&lt;'U&gt;.Helper&lt;'U, 'U&gt;&gt; " />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; event Action&lt;Mono::DocTest::Generic::MyList&lt;U&gt; ^, Mono::DocTest::Generic::MyList&lt;U&gt;::Helper&lt;U, U&gt; ^&gt; ^ ItemChanged;" />
-      <MemberSignature Language="C++ WINRT" Value="// Register&#xA;event_token ItemChanged(Action&lt;Mono::DocTest::Generic::MyList&lt;U&gt;, Mono::DocTest::Generic::MyList&lt;U&gt;::Helper&lt;U, U&gt; const &amp;&gt; const&amp; handler) const;&#xA;&#xA;// Revoke with event_token&#xA;void ItemChanged(event_token const* cookie) const;&#xA;&#xA;// Revoke with event_revoker&#xA;ItemChanged_revoker ItemChanged(auto_revoke_t, Action&lt;Mono::DocTest::Generic::MyList&lt;U&gt;, Mono::DocTest::Generic::MyList&lt;U&gt;::Helper&lt;U, U&gt; const &amp;&gt; const&amp; handler) const;" />
+      <MemberSignature Language="C++ WINRT" Value="// Register&#xA;event_token ItemChanged(Action&lt;Mono::DocTest::Generic::MyList&lt;U&gt;, Mono::DocTest::Generic::MyList&lt;U&gt;::Helper&lt;U, U&gt; const&amp;&gt; const&amp; handler) const;&#xA;&#xA;// Revoke with event_token&#xA;void ItemChanged(event_token const* cookie) const;&#xA;&#xA;// Revoke with event_revoker&#xA;ItemChanged_revoker ItemChanged(auto_revoke_t, Action&lt;Mono::DocTest::Generic::MyList&lt;U&gt;, Mono::DocTest::Generic::MyList&lt;U&gt;::Helper&lt;U, U&gt; const&amp;&gt; const&amp; handler) const;" />
       <MemberType>Event</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -147,7 +147,7 @@
       <MemberSignature Language="VB.NET" Value="Public Shared Narrowing Operator CType (list As GenericBase(Of U)) As U" />
       <MemberSignature Language="F#" Value="static member op_Explicit : Mono.DocTest.Generic.GenericBase&lt;'U&gt; -&gt; 'U" Usage="Mono.DocTest.Generic.GenericBase&lt;'U&gt;.op_Explicit list" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; static explicit operator U(Mono::DocTest::Generic::GenericBase&lt;U&gt; ^ list);" />
-      <MemberSignature Language="C++ WINRT" Value=" static explicit operator U(Mono::DocTest::Generic::GenericBase&lt;U&gt; const &amp; list);" />
+      <MemberSignature Language="C++ WINRT" Value=" static explicit operator U(Mono::DocTest::Generic::GenericBase&lt;U&gt; const&amp; list);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/GenericBase`1.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/GenericBase`1.xml
@@ -49,7 +49,7 @@
       <MemberSignature Language="F#" Value="member this.BaseMethod : 'S -&gt; 'U" Usage="genericBase.BaseMethod genericParameter" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename S&gt;&#xA; U BaseMethod(S genericParameter);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA;generic &lt;typename S&gt;&#xA; U BaseMethod(S genericParameter);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename S&gt;&#xA; U BaseMethod(S genericParameter);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename S&gt;&#xA; U BaseMethod(S const &amp; genericParameter);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/IFoo`1.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/IFoo`1.xml
@@ -29,7 +29,7 @@
       <MemberSignature Language="F#" Value="abstract member Method : 'T * 'U -&gt; 'T" Usage="iFoo.Method (t, u)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename U&gt;&#xA; T Method(T t, U u);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA;generic &lt;typename U&gt;&#xA; T Method(T t, U u);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; T Method(T const &amp; t, U const &amp; u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; T Method(T const&amp; t, U const&amp; u);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/IFoo`1.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/IFoo`1.xml
@@ -29,7 +29,7 @@
       <MemberSignature Language="F#" Value="abstract member Method : 'T * 'U -&gt; 'T" Usage="iFoo.Method (t, u)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename U&gt;&#xA; T Method(T t, U u);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA;generic &lt;typename U&gt;&#xA; T Method(T t, U u);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; T Method(T t, U u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; T Method(T const &amp; t, U const &amp; u);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1+Helper`2.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1+Helper`2.xml
@@ -52,7 +52,7 @@
       <MemberSignature Language="F#" Value="member this.UseT : 'T * 'U * 'V -&gt; unit" Usage="helper.UseT (a, b, c)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void UseT(T a, U b, V c);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void UseT(T a, U b, V c);" />
-      <MemberSignature Language="C++ WINRT" Value="void UseT(T a, U b, V c);" />
+      <MemberSignature Language="C++ WINRT" Value="void UseT(T const &amp; a, U const &amp; b, V const &amp; c);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1+Helper`2.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1+Helper`2.xml
@@ -52,7 +52,7 @@
       <MemberSignature Language="F#" Value="member this.UseT : 'T * 'U * 'V -&gt; unit" Usage="helper.UseT (a, b, c)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void UseT(T a, U b, V c);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void UseT(T a, U b, V c);" />
-      <MemberSignature Language="C++ WINRT" Value="void UseT(T const &amp; a, U const &amp; b, V const &amp; c);" />
+      <MemberSignature Language="C++ WINRT" Value="void UseT(T const&amp; a, U const&amp; b, V const&amp; c);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1.xml
@@ -118,7 +118,7 @@
       <MemberSignature Language="F#" Value="member this.Method : 'T * 'U -&gt; unit" Usage="myList.Method (t, u)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename U&gt;&#xA; void Method(T t, U u);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA;generic &lt;typename U&gt;&#xA; void Method(T t, U u);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void Method(T t, U u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void Method(T const &amp; t, U const &amp; u);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -149,7 +149,7 @@
       <MemberSignature Language="F#" Value="member this.RefMethod : 'T * 'U -&gt; unit" Usage="myList.RefMethod (t, u)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename U&gt;&#xA; void RefMethod(T % t, U % u);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA;generic &lt;typename U&gt;&#xA; void RefMethod(T &amp;  t, U &amp;  u);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void RefMethod(T &amp; t, U &amp; u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void RefMethod(T &amp; const &amp; t, U &amp; const &amp; u);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -204,7 +204,7 @@
       <MemberSignature Language="F#" Value="member this.Test : 'T -&gt; unit" Usage="myList.Test t" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void Test(T t);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void Test(T t);" />
-      <MemberSignature Language="C++ WINRT" Value="void Test(T t);" />
+      <MemberSignature Language="C++ WINRT" Value="void Test(T const &amp; t);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1.xml
@@ -118,7 +118,7 @@
       <MemberSignature Language="F#" Value="member this.Method : 'T * 'U -&gt; unit" Usage="myList.Method (t, u)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename U&gt;&#xA; void Method(T t, U u);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA;generic &lt;typename U&gt;&#xA; void Method(T t, U u);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void Method(T const &amp; t, U const &amp; u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void Method(T const&amp; t, U const&amp; u);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -204,7 +204,7 @@
       <MemberSignature Language="F#" Value="member this.Test : 'T -&gt; unit" Usage="myList.Test t" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void Test(T t);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void Test(T t);" />
-      <MemberSignature Language="C++ WINRT" Value="void Test(T const &amp; t);" />
+      <MemberSignature Language="C++ WINRT" Value="void Test(T const&amp; t);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -228,7 +228,7 @@
       <MemberSignature Language="VB.NET" Value="Public Sub UseHelper(Of U, V) (helper As MyList(Of T).Helper(Of U, V))" />
       <MemberSignature Language="F#" Value="member this.UseHelper : Mono.DocTest.Generic.MyList&lt;'T&gt;.Helper&lt;'U, 'V&gt; -&gt; unit" Usage="myList.UseHelper helper" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename U, typename V&gt;&#xA; void UseHelper(Mono::DocTest::Generic::MyList&lt;T&gt;::Helper&lt;U, V&gt; ^ helper);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U, typename V&gt;&#xA; void UseHelper(Mono::DocTest::Generic::MyList&lt;T&gt;::Helper&lt;U, V&gt; const &amp; helper);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U, typename V&gt;&#xA; void UseHelper(Mono::DocTest::Generic::MyList&lt;T&gt;::Helper&lt;U, V&gt; const&amp; helper);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`1.xml
@@ -149,7 +149,7 @@
       <MemberSignature Language="F#" Value="member this.RefMethod : 'T * 'U -&gt; unit" Usage="myList.RefMethod (t, u)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename U&gt;&#xA; void RefMethod(T % t, U % u);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA;generic &lt;typename U&gt;&#xA; void RefMethod(T &amp;  t, U &amp;  u);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void RefMethod(T &amp; const &amp; t, U &amp; const &amp; u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; void RefMethod(T &amp; t, U &amp; u);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`2.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`2.xml
@@ -89,7 +89,7 @@
       <MemberSignature Language="F#" Value="abstract member CopyTo : 'A[] * int -&gt; unit&#xA;override this.CopyTo : 'A[] * int -&gt; unit" Usage="myList.CopyTo (array, arrayIndex)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; virtual void CopyTo(cli::array &lt;A&gt; ^ array, int arrayIndex);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void CopyTo(Platform::Array &lt;A&gt; ^ array, int arrayIndex);" />
-      <MemberSignature Language="C++ WINRT" Value="void CopyTo(std::Array &lt;A&gt; const &amp; array, int const &amp; arrayIndex);" />
+      <MemberSignature Language="C++ WINRT" Value="void CopyTo(std::Array &lt;A&gt; const&amp; array, int const&amp; arrayIndex);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.CopyTo(`0[],System.Int32)</InterfaceMember>
@@ -236,7 +236,7 @@
       <MemberSignature Language="F#" Value="abstract member Mono.DocTest.Generic.IFoo&lt;A&gt;.Method : 'A * 'U -&gt; 'A&#xA;override this.Mono.DocTest.Generic.IFoo&lt;A&gt;.Method : 'A * 'U -&gt; 'A" Usage="myList.Mono.DocTest.Generic.IFoo&lt;A&gt;.Method (a, u)" />
       <MemberSignature Language="C++ CLI" Value="generic &lt;typename U&gt;&#xA; virtual A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A a, U u) = Mono::DocTest::Generic::IFoo&lt;A&gt;::Method;" />
       <MemberSignature Language="C++ CX" Value="generic &lt;typename U&gt;&#xA; virtual A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A a, U u) = Mono::DocTest::Generic::IFoo&lt;A&gt;::Method;" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A const &amp; a, U const &amp; u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A const&amp; a, U const&amp; u);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0)</InterfaceMember>
@@ -322,7 +322,7 @@
       <MemberSignature Language="F#" Value="abstract member System.Collections.Generic.ICollection&lt;A&gt;.Add : 'A -&gt; unit&#xA;override this.System.Collections.Generic.ICollection&lt;A&gt;.Add : 'A -&gt; unit" Usage="myList.System.Collections.Generic.ICollection&lt;A&gt;.Add item" />
       <MemberSignature Language="C++ CLI" Value=" virtual void System.Collections.Generic.ICollection&lt;A&gt;.Add(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Add;" />
       <MemberSignature Language="C++ CX" Value=" virtual void System.Collections.Generic.ICollection&lt;A&gt;.Add(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Add;" />
-      <MemberSignature Language="C++ WINRT" Value="void System.Collections.Generic.ICollection&lt;A&gt;.Add(A const &amp; item);" />
+      <MemberSignature Language="C++ WINRT" Value="void System.Collections.Generic.ICollection&lt;A&gt;.Add(A const&amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Add(`0)</InterfaceMember>
@@ -375,7 +375,7 @@
       <MemberSignature Language="F#" Value="abstract member System.Collections.Generic.ICollection&lt;A&gt;.Contains : 'A -&gt; bool&#xA;override this.System.Collections.Generic.ICollection&lt;A&gt;.Contains : 'A -&gt; bool" Usage="myList.System.Collections.Generic.ICollection&lt;A&gt;.Contains item" />
       <MemberSignature Language="C++ CLI" Value=" virtual bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Contains;" />
       <MemberSignature Language="C++ CX" Value=" virtual bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Contains;" />
-      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A const &amp; item);" />
+      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A const&amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Contains(`0)</InterfaceMember>
@@ -429,7 +429,7 @@
       <MemberSignature Language="F#" Value="abstract member System.Collections.Generic.ICollection&lt;A&gt;.Remove : 'A -&gt; bool&#xA;override this.System.Collections.Generic.ICollection&lt;A&gt;.Remove : 'A -&gt; bool" Usage="myList.System.Collections.Generic.ICollection&lt;A&gt;.Remove item" />
       <MemberSignature Language="C++ CLI" Value=" virtual bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Remove;" />
       <MemberSignature Language="C++ CX" Value=" virtual bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Remove;" />
-      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A const &amp; item);" />
+      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A const&amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Remove(`0)</InterfaceMember>

--- a/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`2.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest.Generic/MyList`2.xml
@@ -89,7 +89,7 @@
       <MemberSignature Language="F#" Value="abstract member CopyTo : 'A[] * int -&gt; unit&#xA;override this.CopyTo : 'A[] * int -&gt; unit" Usage="myList.CopyTo (array, arrayIndex)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; virtual void CopyTo(cli::array &lt;A&gt; ^ array, int arrayIndex);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void CopyTo(Platform::Array &lt;A&gt; ^ array, int arrayIndex);" />
-      <MemberSignature Language="C++ WINRT" Value="void CopyTo(std::Array &lt;A&gt; const &amp; array, int arrayIndex);" />
+      <MemberSignature Language="C++ WINRT" Value="void CopyTo(std::Array &lt;A&gt; const &amp; array, int const &amp; arrayIndex);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.CopyTo(`0[],System.Int32)</InterfaceMember>
@@ -236,7 +236,7 @@
       <MemberSignature Language="F#" Value="abstract member Mono.DocTest.Generic.IFoo&lt;A&gt;.Method : 'A * 'U -&gt; 'A&#xA;override this.Mono.DocTest.Generic.IFoo&lt;A&gt;.Method : 'A * 'U -&gt; 'A" Usage="myList.Mono.DocTest.Generic.IFoo&lt;A&gt;.Method (a, u)" />
       <MemberSignature Language="C++ CLI" Value="generic &lt;typename U&gt;&#xA; virtual A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A a, U u) = Mono::DocTest::Generic::IFoo&lt;A&gt;::Method;" />
       <MemberSignature Language="C++ CX" Value="generic &lt;typename U&gt;&#xA; virtual A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A a, U u) = Mono::DocTest::Generic::IFoo&lt;A&gt;::Method;" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A a, U u);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename U&gt;&#xA; A Mono.DocTest.Generic.IFoo&lt;A&gt;.Method(A const &amp; a, U const &amp; u);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:Mono.DocTest.Generic.IFoo`1.Method``1(`0,``0)</InterfaceMember>
@@ -322,7 +322,7 @@
       <MemberSignature Language="F#" Value="abstract member System.Collections.Generic.ICollection&lt;A&gt;.Add : 'A -&gt; unit&#xA;override this.System.Collections.Generic.ICollection&lt;A&gt;.Add : 'A -&gt; unit" Usage="myList.System.Collections.Generic.ICollection&lt;A&gt;.Add item" />
       <MemberSignature Language="C++ CLI" Value=" virtual void System.Collections.Generic.ICollection&lt;A&gt;.Add(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Add;" />
       <MemberSignature Language="C++ CX" Value=" virtual void System.Collections.Generic.ICollection&lt;A&gt;.Add(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Add;" />
-      <MemberSignature Language="C++ WINRT" Value="void System.Collections.Generic.ICollection&lt;A&gt;.Add(A item);" />
+      <MemberSignature Language="C++ WINRT" Value="void System.Collections.Generic.ICollection&lt;A&gt;.Add(A const &amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Add(`0)</InterfaceMember>
@@ -375,7 +375,7 @@
       <MemberSignature Language="F#" Value="abstract member System.Collections.Generic.ICollection&lt;A&gt;.Contains : 'A -&gt; bool&#xA;override this.System.Collections.Generic.ICollection&lt;A&gt;.Contains : 'A -&gt; bool" Usage="myList.System.Collections.Generic.ICollection&lt;A&gt;.Contains item" />
       <MemberSignature Language="C++ CLI" Value=" virtual bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Contains;" />
       <MemberSignature Language="C++ CX" Value=" virtual bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Contains;" />
-      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A item);" />
+      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Contains(A const &amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Contains(`0)</InterfaceMember>
@@ -429,7 +429,7 @@
       <MemberSignature Language="F#" Value="abstract member System.Collections.Generic.ICollection&lt;A&gt;.Remove : 'A -&gt; bool&#xA;override this.System.Collections.Generic.ICollection&lt;A&gt;.Remove : 'A -&gt; bool" Usage="myList.System.Collections.Generic.ICollection&lt;A&gt;.Remove item" />
       <MemberSignature Language="C++ CLI" Value=" virtual bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Remove;" />
       <MemberSignature Language="C++ CX" Value=" virtual bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A item) = System::Collections::Generic::ICollection&lt;A&gt;::Remove;" />
-      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A item);" />
+      <MemberSignature Language="C++ WINRT" Value="bool System.Collections.Generic.ICollection&lt;A&gt;.Remove(A const &amp; item);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:System.Collections.Generic.ICollection`1.Remove(`0)</InterfaceMember>

--- a/mdoc/Test/en.expected/Mono.DocTest/DocAttribute.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/DocAttribute.xml
@@ -35,7 +35,7 @@
       <MemberSignature Language="JavaScript" Value="function DocAttribute(docs)" Usage="var docAttribute = new DocAttribute(docs);" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; DocAttribute(System::String ^ docs);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; DocAttribute(Platform::String ^ docs);" />
-      <MemberSignature Language="C++ WINRT" Value=" DocAttribute(winrt::hstring const &amp; docs);" />
+      <MemberSignature Language="C++ WINRT" Value=" DocAttribute(winrt::hstring const&amp; docs);" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest/DocValueType.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/DocValueType.xml
@@ -34,7 +34,7 @@
       <MemberSignature Language="JavaScript" Value="function m(i)" Usage="docValueType.m(i)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void M(int i);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void M(int i);" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const&amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest/DocValueType.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/DocValueType.xml
@@ -34,7 +34,7 @@
       <MemberSignature Language="JavaScript" Value="function m(i)" Usage="docValueType.m(i)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void M(int i);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void M(int i);" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest/UseLists.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/UseLists.xml
@@ -179,7 +179,7 @@
       <MemberSignature Language="VB.NET" Value="Public Sub UseHelper(Of T, U, V) (helper As MyList(Of T).Helper(Of U, V))" />
       <MemberSignature Language="F#" Value="member this.UseHelper : Mono.DocTest.Generic.MyList&lt;'T&gt;.Helper&lt;'U, 'V&gt; -&gt; unit" Usage="useLists.UseHelper helper" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename T, typename U, typename V&gt;&#xA; void UseHelper(Mono::DocTest::Generic::MyList&lt;T&gt;::Helper&lt;U, V&gt; ^ helper);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T, typename U, typename V&gt;&#xA; void UseHelper(Mono::DocTest::Generic::MyList&lt;T&gt;::Helper&lt;U, V&gt; const &amp; helper);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T, typename U, typename V&gt;&#xA; void UseHelper(Mono::DocTest::Generic::MyList&lt;T&gt;::Helper&lt;U, V&gt; const&amp; helper);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget+NestedClass.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget+NestedClass.xml
@@ -43,7 +43,7 @@
       <MemberSignature Language="F#" Value="member this.M : int -&gt; unit" Usage="nestedClass.M i" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void M(int i);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void M(int i);" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const&amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget+NestedClass.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget+NestedClass.xml
@@ -43,7 +43,7 @@
       <MemberSignature Language="F#" Value="member this.M : int -&gt; unit" Usage="nestedClass.M i" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void M(int i);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void M(int i);" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget+NestedClass`1.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget+NestedClass`1.xml
@@ -47,7 +47,7 @@
       <MemberSignature Language="F#" Value="member this.M : int -&gt; unit" Usage="nestedClass.M i" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void M(int i);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void M(int i);" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const&amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget+NestedClass`1.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget+NestedClass`1.xml
@@ -47,7 +47,7 @@
       <MemberSignature Language="F#" Value="member this.M : int -&gt; unit" Usage="nestedClass.M i" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void M(int i);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; void M(int i);" />
-      <MemberSignature Language="C++ WINRT" Value="void M(int i);" />
+      <MemberSignature Language="C++ WINRT" Value="void M(int const &amp; i);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
@@ -72,7 +72,7 @@
       <MemberSignature Language="JavaScript" Value="function Widget(s)" Usage="var widget = new Widget(s);" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; Widget(System::String ^ s);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; Widget(Platform::String ^ s);" />
-      <MemberSignature Language="C++ WINRT" Value=" Widget(winrt::hstring const &amp; s);" />
+      <MemberSignature Language="C++ WINRT" Value=" Widget(winrt::hstring const&amp; s);" />
       <MemberType>Constructor</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -173,7 +173,7 @@
       <MemberSignature Language="VB.NET" Value="Public array2 As Widget(,) " />
       <MemberSignature Language="F#" Value="val mutable array2 : Mono.DocTest.Widget[,]" Usage="Mono.DocTest.Widget.array2" />
       <MemberSignature Language="C++ CLI" Value="public: cli::array &lt;Mono::DocTest::Widget ^, 2&gt; ^ array2;" />
-      <MemberSignature Language="C++ WINRT" Value="std::Array &lt;Mono::DocTest::Widget const &amp;, 2&gt; array2;" />
+      <MemberSignature Language="C++ WINRT" Value="std::Array &lt;Mono::DocTest::Widget const&amp;, 2&gt; array2;" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -193,7 +193,7 @@
       <MemberSignature Language="VB.NET" Value="Public Shared ReadOnly classCtorError As String() " />
       <MemberSignature Language="F#" Value=" staticval mutable classCtorError : string[]" Usage="Mono.DocTest.Widget.classCtorError" />
       <MemberSignature Language="C++ CLI" Value="public: static initonly cli::array &lt;System::String ^&gt; ^ classCtorError;" />
-      <MemberSignature Language="C++ WINRT" Value="static initonly std::Array &lt;winrt::hstring const &amp;&gt; classCtorError;" />
+      <MemberSignature Language="C++ WINRT" Value="static initonly std::Array &lt;winrt::hstring const&amp;&gt; classCtorError;" />
       <MemberType>Field</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -213,7 +213,7 @@
       <MemberSignature Language="VB.NET" Value="Public Sub Default (Optional a As Integer = 1, Optional b As Integer = 2)" />
       <MemberSignature Language="F#" Value="member this.Default : int * int -&gt; unit" Usage="widget.Default (a, b)" />
       <MemberSignature Language="JavaScript" Value="function default(a, b)" Usage="widget.default(a, b)" />
-      <MemberSignature Language="C++ WINRT" Value="void Default(int const &amp; a = 1, int const &amp; b = 2);" />
+      <MemberSignature Language="C++ WINRT" Value="void Default(int const&amp; a = 1, int const&amp; b = 2);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -239,7 +239,7 @@
       <MemberSignature Language="VB.NET" Value="Public Sub Default (Optional a As String = &quot;a&quot;, Optional b As Char = '\0')" />
       <MemberSignature Language="F#" Value="member this.Default : string * char -&gt; unit" Usage="widget.Default (a, b)" />
       <MemberSignature Language="JavaScript" Value="function default(a, b)" Usage="widget.default(a, b)" />
-      <MemberSignature Language="C++ WINRT" Value="void Default(winrt::hstring const &amp; a = &quot;a&quot;, char const &amp; b = '\0');" />
+      <MemberSignature Language="C++ WINRT" Value="void Default(winrt::hstring const&amp; a = &quot;a&quot;, char const&amp; b = '\0');" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -288,7 +288,7 @@
       <MemberSignature Language="JavaScript" Value="function dynamic0(a, b)" Usage="var object = widget.dynamic0(a, b)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; System::Object ^ Dynamic0(System::Object ^ a, System::Object ^ b);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA; Platform::Object ^ Dynamic0(Platform::Object ^ a, Platform::Object ^ b);" />
-      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IInspectable Dynamic0(winrt::Windows::Foundation::IInspectable const &amp; a, winrt::Windows::Foundation::IInspectable const &amp; b);" />
+      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IInspectable Dynamic0(winrt::Windows::Foundation::IInspectable const&amp; a, winrt::Windows::Foundation::IInspectable const&amp; b);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -459,7 +459,7 @@
       <MemberSignature Language="F#" Value="member this.DynamicP : Func&lt;Func&lt;string, obj, string&gt;, Func&lt;obj, Func&lt;obj&gt;, string&gt;&gt;" Usage="Mono.DocTest.Widget.DynamicP" />
       <MemberSignature Language="JavaScript" Usage="var func = widget.dynamicP;" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; property Func&lt;Func&lt;System::String ^, System::Object ^, System::String ^&gt; ^, Func&lt;System::Object ^, Func&lt;System::Object ^&gt; ^, System::String ^&gt; ^&gt; ^ DynamicP { Func&lt;Func&lt;System::String ^, System::Object ^, System::String ^&gt; ^, Func&lt;System::Object ^, Func&lt;System::Object ^&gt; ^, System::String ^&gt; ^&gt; ^ get(); };" />
-      <MemberSignature Language="C++ WINRT" Value="Func&lt;Func&lt;winrt::hstring, winrt::Windows::Foundation::IInspectable const &amp;, winrt::hstring const &amp;&gt;, Func&lt;winrt::Windows::Foundation::IInspectable, Func&lt;winrt::Windows::Foundation::IInspectable&gt; const &amp;, winrt::hstring const &amp;&gt; const &amp;&gt; DynamicP();" />
+      <MemberSignature Language="C++ WINRT" Value="Func&lt;Func&lt;winrt::hstring, winrt::Windows::Foundation::IInspectable const&amp;, winrt::hstring const&amp;&gt;, Func&lt;winrt::Windows::Foundation::IInspectable, Func&lt;winrt::Windows::Foundation::IInspectable&gt; const&amp;, winrt::hstring const&amp;&gt; const&amp;&gt; DynamicP();" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -596,7 +596,7 @@
       <MemberSignature Language="VB.NET" Value="Public Sub M1 (c As Char, ByRef f As Single, ByRef v As DocValueType)" />
       <MemberSignature Language="F#" Value="member this.M1 : char * single * DocValueType -&gt; unit" Usage="widget.M1 (c, f, v)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void M1(char c, [Runtime::InteropServices::Out] float % f, Mono::DocTest::DocValueType % v);" />
-      <MemberSignature Language="C++ WINRT" Value="void M1(char const &amp; c, [Runtime::InteropServices::Out] float &amp; f, Mono::DocTest::DocValueType &amp; v);" />
+      <MemberSignature Language="C++ WINRT" Value="void M1(char const&amp; c, [Runtime::InteropServices::Out] float &amp; f, Mono::DocTest::DocValueType &amp; v);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -663,7 +663,7 @@
       <MemberSignature Language="F#" Value="member this.M2 : int16[] * int[,] * int64[][] -&gt; unit" Usage="widget.M2 (x1, x2, x3)" />
       <MemberSignature Language="JavaScript" Value="function m2(x1, x2, x3)" Usage="widget.m2(x1, x2, x3)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void M2(cli::array &lt;short&gt; ^ x1, cli::array &lt;int, 2&gt; ^ x2, cli::array &lt;cli::array &lt;long&gt; ^&gt; ^ x3);" />
-      <MemberSignature Language="C++ WINRT" Value="void M2(std::Array &lt;short&gt; const &amp; x1, std::Array &lt;int, 2&gt; const &amp; x2, std::Array &lt;std::Array &lt;long&gt; const &amp;&gt; const &amp; x3);" />
+      <MemberSignature Language="C++ WINRT" Value="void M2(std::Array &lt;short&gt; const&amp; x1, std::Array &lt;int, 2&gt; const&amp; x2, std::Array &lt;std::Array &lt;long&gt; const&amp;&gt; const&amp; x3);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -692,7 +692,7 @@
       <MemberSignature Language="F#" Value="member this.M3 : int64[][] * Mono.DocTest.Widget[,,][] -&gt; unit" Usage="widget.M3 (x3, x4)" />
       <MemberSignature Language="JavaScript" Value="function m3(x3, x4)" Usage="widget.m3(x3, x4)" />
       <MemberSignature Language="C++ CLI" Value="protected:&#xA; void M3(cli::array &lt;cli::array &lt;long&gt; ^&gt; ^ x3, cli::array &lt;cli::array &lt;Mono::DocTest::Widget ^, 3&gt; ^&gt; ^ x4);" />
-      <MemberSignature Language="C++ WINRT" Value="void M3(std::Array &lt;std::Array &lt;long&gt; const &amp;&gt; const &amp; x3, std::Array &lt;std::Array &lt;Mono::DocTest::Widget const &amp;, 3&gt; const &amp;&gt; const &amp; x4);" />
+      <MemberSignature Language="C++ WINRT" Value="void M3(std::Array &lt;std::Array &lt;long&gt; const&amp;&gt; const&amp; x3, std::Array &lt;std::Array &lt;Mono::DocTest::Widget const&amp;, 3&gt; const&amp;&gt; const&amp; x4);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -744,7 +744,7 @@
       <MemberSignature Language="F#" Value="member this.M5 : nativeptr&lt;unit&gt; * nativeptr&lt;double&gt;[,][] -&gt; unit" Usage="widget.M5 (pv, pd)" />
       <MemberSignature Language="JavaScript" Value="function m5(pv, pd)" Usage="widget.m5(pv, pd)" />
       <MemberSignature Language="C++ CLI" Value="protected:&#xA; void M5(void* pv, cli::array &lt;cli::array &lt;double*, 2&gt; ^&gt; ^ pd);" />
-      <MemberSignature Language="C++ WINRT" Value="void M5(void* pv, std::Array &lt;std::Array &lt;double*, 2&gt; const &amp;&gt; const &amp; pd);" />
+      <MemberSignature Language="C++ WINRT" Value="void M5(void* pv, std::Array &lt;std::Array &lt;double*, 2&gt; const&amp;&gt; const&amp; pd);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -805,7 +805,7 @@
       <MemberSignature Language="F#" Value="member this.M7 : Mono.DocTest.Widget.NestedClass.Double.Triple.Quadruple -&gt; unit" Usage="widget.M7 a" />
       <MemberSignature Language="JavaScript" Value="function m7(a)" Usage="widget.m7(a)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void M7(Mono::DocTest::Widget::NestedClass::Double::Triple::Quadruple ^ a);" />
-      <MemberSignature Language="C++ WINRT" Value="void M7(Mono::DocTest::Widget::NestedClass::Double::Triple::Quadruple const &amp; a);" />
+      <MemberSignature Language="C++ WINRT" Value="void M7(Mono::DocTest::Widget::NestedClass::Double::Triple::Quadruple const&amp; a);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -870,7 +870,7 @@
       <MemberSignature Language="VB.NET" Value="Public Shared Operator + (x1 As Widget, x2 As Widget) As Widget" />
       <MemberSignature Language="F#" Value="static member ( + ) : Mono.DocTest.Widget * Mono.DocTest.Widget -&gt; Mono.DocTest.Widget" Usage="x1 + x2" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; static Mono::DocTest::Widget ^ operator +(Mono::DocTest::Widget ^ x1, Mono::DocTest::Widget ^ x2);" />
-      <MemberSignature Language="C++ WINRT" Value=" static Mono::DocTest::Widget operator +(Mono::DocTest::Widget const &amp; x1, Mono::DocTest::Widget const &amp; x2);" />
+      <MemberSignature Language="C++ WINRT" Value=" static Mono::DocTest::Widget operator +(Mono::DocTest::Widget const&amp; x1, Mono::DocTest::Widget const&amp; x2);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -917,7 +917,7 @@
       <MemberSignature Language="VB.NET" Value="Public Shared Narrowing Operator CType (x As Widget) As Integer" />
       <MemberSignature Language="F#" Value="static member op_Explicit : Mono.DocTest.Widget -&gt; int" Usage="Mono.DocTest.Widget.op_Explicit x" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; static explicit operator int(Mono::DocTest::Widget ^ x);" />
-      <MemberSignature Language="C++ WINRT" Value=" static explicit operator int(Mono::DocTest::Widget const &amp; x);" />
+      <MemberSignature Language="C++ WINRT" Value=" static explicit operator int(Mono::DocTest::Widget const&amp; x);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -942,7 +942,7 @@
       <MemberSignature Language="VB.NET" Value="Public Shared Widening Operator CType (x As Widget) As Long" />
       <MemberSignature Language="F#" Value="static member op_Implicit : Mono.DocTest.Widget -&gt; int64" Usage="Mono.DocTest.Widget.op_Implicit x" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; static operator long(Mono::DocTest::Widget ^ x);" />
-      <MemberSignature Language="C++ WINRT" Value=" static operator long(Mono::DocTest::Widget const &amp; x);" />
+      <MemberSignature Language="C++ WINRT" Value=" static operator long(Mono::DocTest::Widget const&amp; x);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -967,7 +967,7 @@
       <MemberSignature Language="VB.NET" Value="Public Shared Operator + (x As Widget) As Widget" />
       <MemberSignature Language="F#" Value="static member ( ~+ ) : Mono.DocTest.Widget -&gt; Mono.DocTest.Widget" Usage="+ x" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; static Mono::DocTest::Widget ^ operator +(Mono::DocTest::Widget ^ x);" />
-      <MemberSignature Language="C++ WINRT" Value=" static Mono::DocTest::Widget operator +(Mono::DocTest::Widget const &amp; x);" />
+      <MemberSignature Language="C++ WINRT" Value=" static Mono::DocTest::Widget operator +(Mono::DocTest::Widget const&amp; x);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
@@ -718,7 +718,7 @@
       <MemberSignature Language="F#" Value="member this.M4 : nativeptr&lt;char&gt; * nativeptr&lt;nativeptr&lt;Mono.DocTest.Color&gt;&gt; -&gt; unit" Usage="widget.M4 (pc, ppf)" />
       <MemberSignature Language="JavaScript" Value="function m4(pc, ppf)" Usage="widget.m4(pc, ppf)" />
       <MemberSignature Language="C++ CLI" Value="protected:&#xA; void M4(char* pc, Mono::DocTest::Color** ppf);" />
-      <MemberSignature Language="C++ WINRT" Value="void M4(char* const &amp; pc, Mono::DocTest::Color** const &amp; ppf);" />
+      <MemberSignature Language="C++ WINRT" Value="void M4(char* pc, Mono::DocTest::Color** ppf);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -744,7 +744,7 @@
       <MemberSignature Language="F#" Value="member this.M5 : nativeptr&lt;unit&gt; * nativeptr&lt;double&gt;[,][] -&gt; unit" Usage="widget.M5 (pv, pd)" />
       <MemberSignature Language="JavaScript" Value="function m5(pv, pd)" Usage="widget.m5(pv, pd)" />
       <MemberSignature Language="C++ CLI" Value="protected:&#xA; void M5(void* pv, cli::array &lt;cli::array &lt;double*, 2&gt; ^&gt; ^ pd);" />
-      <MemberSignature Language="C++ WINRT" Value="void M5(void* const &amp; pv, std::Array &lt;std::Array &lt;double*, 2&gt; const &amp;&gt; const &amp; pd);" />
+      <MemberSignature Language="C++ WINRT" Value="void M5(void* pv, std::Array &lt;std::Array &lt;double*, 2&gt; const &amp;&gt; const &amp; pd);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
+++ b/mdoc/Test/en.expected/Mono.DocTest/Widget.xml
@@ -213,7 +213,7 @@
       <MemberSignature Language="VB.NET" Value="Public Sub Default (Optional a As Integer = 1, Optional b As Integer = 2)" />
       <MemberSignature Language="F#" Value="member this.Default : int * int -&gt; unit" Usage="widget.Default (a, b)" />
       <MemberSignature Language="JavaScript" Value="function default(a, b)" Usage="widget.default(a, b)" />
-      <MemberSignature Language="C++ WINRT" Value="void Default(int a = 1, int b = 2);" />
+      <MemberSignature Language="C++ WINRT" Value="void Default(int const &amp; a = 1, int const &amp; b = 2);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -239,7 +239,7 @@
       <MemberSignature Language="VB.NET" Value="Public Sub Default (Optional a As String = &quot;a&quot;, Optional b As Char = '\0')" />
       <MemberSignature Language="F#" Value="member this.Default : string * char -&gt; unit" Usage="widget.Default (a, b)" />
       <MemberSignature Language="JavaScript" Value="function default(a, b)" Usage="widget.default(a, b)" />
-      <MemberSignature Language="C++ WINRT" Value="void Default(winrt::hstring const &amp; a = &quot;a&quot;, char b = '\0');" />
+      <MemberSignature Language="C++ WINRT" Value="void Default(winrt::hstring const &amp; a = &quot;a&quot;, char const &amp; b = '\0');" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -596,7 +596,7 @@
       <MemberSignature Language="VB.NET" Value="Public Sub M1 (c As Char, ByRef f As Single, ByRef v As DocValueType)" />
       <MemberSignature Language="F#" Value="member this.M1 : char * single * DocValueType -&gt; unit" Usage="widget.M1 (c, f, v)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA; void M1(char c, [Runtime::InteropServices::Out] float % f, Mono::DocTest::DocValueType % v);" />
-      <MemberSignature Language="C++ WINRT" Value="void M1(char c, [Runtime::InteropServices::Out] float &amp; f, Mono::DocTest::DocValueType &amp; v);" />
+      <MemberSignature Language="C++ WINRT" Value="void M1(char const &amp; c, [Runtime::InteropServices::Out] float &amp; f, Mono::DocTest::DocValueType &amp; v);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -718,7 +718,7 @@
       <MemberSignature Language="F#" Value="member this.M4 : nativeptr&lt;char&gt; * nativeptr&lt;nativeptr&lt;Mono.DocTest.Color&gt;&gt; -&gt; unit" Usage="widget.M4 (pc, ppf)" />
       <MemberSignature Language="JavaScript" Value="function m4(pc, ppf)" Usage="widget.m4(pc, ppf)" />
       <MemberSignature Language="C++ CLI" Value="protected:&#xA; void M4(char* pc, Mono::DocTest::Color** ppf);" />
-      <MemberSignature Language="C++ WINRT" Value="void M4(char* pc, Mono::DocTest::Color** ppf);" />
+      <MemberSignature Language="C++ WINRT" Value="void M4(char* const &amp; pc, Mono::DocTest::Color** const &amp; ppf);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>
@@ -744,7 +744,7 @@
       <MemberSignature Language="F#" Value="member this.M5 : nativeptr&lt;unit&gt; * nativeptr&lt;double&gt;[,][] -&gt; unit" Usage="widget.M5 (pv, pd)" />
       <MemberSignature Language="JavaScript" Value="function m5(pv, pd)" Usage="widget.m5(pv, pd)" />
       <MemberSignature Language="C++ CLI" Value="protected:&#xA; void M5(void* pv, cli::array &lt;cli::array &lt;double*, 2&gt; ^&gt; ^ pd);" />
-      <MemberSignature Language="C++ WINRT" Value="void M5(void* pv, std::Array &lt;std::Array &lt;double*, 2&gt; const &amp;&gt; const &amp; pd);" />
+      <MemberSignature Language="C++ WINRT" Value="void M5(void* const &amp; pv, std::Array &lt;std::Array &lt;double*, 2&gt; const &amp;&gt; const &amp; pd);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/System/Array.xml
+++ b/mdoc/Test/en.expected/System/Array.xml
@@ -106,7 +106,7 @@
       <MemberSignature Language="F#" Value="static member Resize : T[] * int -&gt; unit" Usage="System.Array.Resize (array, newSize)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename T&gt;&#xA; static void Resize(cli::array &lt;T&gt; ^ % array, int newSize);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA;generic &lt;typename T&gt;&#xA; static void Resize(Platform::Array &lt;T&gt; ^ &amp;  array, int newSize);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T&gt;&#xA; static void Resize(std::Array &lt;T&gt; const &amp; &amp; array, int const &amp; newSize);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T&gt;&#xA; static void Resize(std::Array &lt;T&gt; const&amp; &amp; array, int const&amp; newSize);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/en.expected/System/Array.xml
+++ b/mdoc/Test/en.expected/System/Array.xml
@@ -106,7 +106,7 @@
       <MemberSignature Language="F#" Value="static member Resize : T[] * int -&gt; unit" Usage="System.Array.Resize (array, newSize)" />
       <MemberSignature Language="C++ CLI" Value="public:&#xA;generic &lt;typename T&gt;&#xA; static void Resize(cli::array &lt;T&gt; ^ % array, int newSize);" />
       <MemberSignature Language="C++ CX" Value="public:&#xA;generic &lt;typename T&gt;&#xA; static void Resize(Platform::Array &lt;T&gt; ^ &amp;  array, int newSize);" />
-      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T&gt;&#xA; static void Resize(std::Array &lt;T&gt; const &amp; &amp; array, int newSize);" />
+      <MemberSignature Language="C++ WINRT" Value="template &lt;typename T&gt;&#xA; static void Resize(std::Array &lt;T&gt; const &amp; &amp; array, int const &amp; newSize);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>0.0.0.0</AssemblyVersion>

--- a/mdoc/Test/ex.expected-cppwinrtuwp/Namespace2/Class3.xml
+++ b/mdoc/Test/ex.expected-cppwinrtuwp/Namespace2/Class3.xml
@@ -36,7 +36,7 @@
     <Member MemberName="ArrayOfTypeProperty">
       <MemberSignature Language="C#" Value="public Type[] ArrayOfTypeProperty { get; set; }" />
       <MemberSignature Language="ILAsm" Value=".property instance class System.Type[] ArrayOfTypeProperty" />
-      <MemberSignature Language="C++ WINRT" Value="std::Array &lt;Type const &amp;&gt; ArrayOfTypeProperty();&#xA;&#xA;void ArrayOfTypeProperty(std::Array &lt;Type const &amp;&gt; __set_formal);" />
+      <MemberSignature Language="C++ WINRT" Value="std::Array &lt;Type const&amp;&gt; ArrayOfTypeProperty();&#xA;&#xA;void ArrayOfTypeProperty(std::Array &lt;Type const&amp;&gt; __set_formal);" />
       <MemberType>Property</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>255.255.255.255</AssemblyVersion>

--- a/mdoc/Test/ex.expected-cppwinrtuwp/Namespace222/App.xml
+++ b/mdoc/Test/ex.expected-cppwinrtuwp/Namespace222/App.xml
@@ -60,7 +60,7 @@
     <Member MemberName="Initialize">
       <MemberSignature Language="C#" Value="public void Initialize (Windows.ApplicationModel.Core.CoreApplicationView applicationView);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Initialize([in]class Windows.ApplicationModel.Core.CoreApplicationView applicationView) runtime managed" />
-      <MemberSignature Language="C++ WINRT" Value="void Initialize(winrt::Windows::ApplicationModel::Core::CoreApplicationView const &amp; applicationView);" />
+      <MemberSignature Language="C++ WINRT" Value="void Initialize(winrt::Windows::ApplicationModel::Core::CoreApplicationView const&amp; applicationView);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:Windows.ApplicationModel.Core.IFrameworkView.Initialize(Windows.ApplicationModel.Core.CoreApplicationView)</InterfaceMember>
@@ -83,7 +83,7 @@
     <Member MemberName="Load">
       <MemberSignature Language="C#" Value="public void Load (string entryPoint);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void Load([in]string entryPoint) runtime managed" />
-      <MemberSignature Language="C++ WINRT" Value="void Load(winrt::hstring const &amp; entryPoint);" />
+      <MemberSignature Language="C++ WINRT" Value="void Load(winrt::hstring const&amp; entryPoint);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:Windows.ApplicationModel.Core.IFrameworkView.Load(System.String)</InterfaceMember>
@@ -160,7 +160,7 @@
     <Member MemberName="SetWindow">
       <MemberSignature Language="C#" Value="public void SetWindow (Windows.UI.Core.CoreWindow window);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SetWindow([in]class Windows.UI.Core.CoreWindow window) runtime managed" />
-      <MemberSignature Language="C++ WINRT" Value="void SetWindow(winrt::Windows::UI::Core::CoreWindow const &amp; window);" />
+      <MemberSignature Language="C++ WINRT" Value="void SetWindow(winrt::Windows::UI::Core::CoreWindow const&amp; window);" />
       <MemberType>Method</MemberType>
       <Implements>
         <InterfaceMember>M:Windows.ApplicationModel.Core.IFrameworkView.SetWindow(Windows.UI.Core.CoreWindow)</InterfaceMember>
@@ -183,7 +183,7 @@
     <Member MemberName="SetWindow1">
       <MemberSignature Language="C#" Value="public void SetWindow1 (Windows.UI.Core.CoreWindow window);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance void SetWindow1([in]class Windows.UI.Core.CoreWindow window) runtime managed" />
-      <MemberSignature Language="C++ WINRT" Value="void SetWindow1(winrt::Windows::UI::Core::CoreWindow const &amp; window);" />
+      <MemberSignature Language="C++ WINRT" Value="void SetWindow1(winrt::Windows::UI::Core::CoreWindow const&amp; window);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>255.255.255.255</AssemblyVersion>

--- a/mdoc/Test/ex.expected-cppwinrtuwp/UwpTestWinRtComponentCpp/Class1.xml
+++ b/mdoc/Test/ex.expected-cppwinrtuwp/UwpTestWinRtComponentCpp/Class1.xml
@@ -56,7 +56,7 @@
     <Member MemberName="ComputeResult">
       <MemberSignature Language="C#" Value="public Windows.Foundation.Collections.IVector&lt;double&gt; ComputeResult (double input);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Windows.Foundation.Collections.IVector`1&lt;float64&gt; ComputeResult([in]float64 input) runtime managed" />
-      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::Collections::IVector&lt;double&gt; ComputeResult(double input);" />
+      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::Collections::IVector&lt;double&gt; ComputeResult(double const &amp; input);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>255.255.255.255</AssemblyVersion>
@@ -77,7 +77,7 @@
     <Member MemberName="GetPrimesOrdered">
       <MemberSignature Language="C#" Value="public Windows.Foundation.IAsyncOperationWithProgress&lt;Windows.Foundation.Collections.IVector&lt;int&gt;,double&gt; GetPrimesOrdered (int first, int last);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Windows.Foundation.IAsyncOperationWithProgress`2&lt;class Windows.Foundation.Collections.IVector`1&lt;int32&gt;, float64&gt; GetPrimesOrdered([in]int32 first, [in]int32 last) runtime managed" />
-      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IAsyncOperationWithProgress&lt;winrt::Windows::Foundation::Collections::IVector&lt;int&gt;, double&gt; GetPrimesOrdered(int first, int last);" />
+      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IAsyncOperationWithProgress&lt;winrt::Windows::Foundation::Collections::IVector&lt;int&gt;, double&gt; GetPrimesOrdered(int const &amp; first, int const &amp; last);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>255.255.255.255</AssemblyVersion>
@@ -100,7 +100,7 @@
     <Member MemberName="GetPrimesUnordered">
       <MemberSignature Language="C#" Value="public Windows.Foundation.IAsyncActionWithProgress&lt;double&gt; GetPrimesUnordered (int first, int last);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Windows.Foundation.IAsyncActionWithProgress`1&lt;float64&gt; GetPrimesUnordered([in]int32 first, [in]int32 last) runtime managed" />
-      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IAsyncActionWithProgress&lt;double&gt; GetPrimesUnordered(int first, int last);" />
+      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IAsyncActionWithProgress&lt;double&gt; GetPrimesUnordered(int const &amp; first, int const &amp; last);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>255.255.255.255</AssemblyVersion>

--- a/mdoc/Test/ex.expected-cppwinrtuwp/UwpTestWinRtComponentCpp/Class1.xml
+++ b/mdoc/Test/ex.expected-cppwinrtuwp/UwpTestWinRtComponentCpp/Class1.xml
@@ -56,7 +56,7 @@
     <Member MemberName="ComputeResult">
       <MemberSignature Language="C#" Value="public Windows.Foundation.Collections.IVector&lt;double&gt; ComputeResult (double input);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Windows.Foundation.Collections.IVector`1&lt;float64&gt; ComputeResult([in]float64 input) runtime managed" />
-      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::Collections::IVector&lt;double&gt; ComputeResult(double const &amp; input);" />
+      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::Collections::IVector&lt;double&gt; ComputeResult(double const&amp; input);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>255.255.255.255</AssemblyVersion>
@@ -77,7 +77,7 @@
     <Member MemberName="GetPrimesOrdered">
       <MemberSignature Language="C#" Value="public Windows.Foundation.IAsyncOperationWithProgress&lt;Windows.Foundation.Collections.IVector&lt;int&gt;,double&gt; GetPrimesOrdered (int first, int last);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Windows.Foundation.IAsyncOperationWithProgress`2&lt;class Windows.Foundation.Collections.IVector`1&lt;int32&gt;, float64&gt; GetPrimesOrdered([in]int32 first, [in]int32 last) runtime managed" />
-      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IAsyncOperationWithProgress&lt;winrt::Windows::Foundation::Collections::IVector&lt;int&gt;, double&gt; GetPrimesOrdered(int const &amp; first, int const &amp; last);" />
+      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IAsyncOperationWithProgress&lt;winrt::Windows::Foundation::Collections::IVector&lt;int&gt;, double&gt; GetPrimesOrdered(int const&amp; first, int const&amp; last);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>255.255.255.255</AssemblyVersion>
@@ -100,7 +100,7 @@
     <Member MemberName="GetPrimesUnordered">
       <MemberSignature Language="C#" Value="public Windows.Foundation.IAsyncActionWithProgress&lt;double&gt; GetPrimesUnordered (int first, int last);" />
       <MemberSignature Language="ILAsm" Value=".method public hidebysig newslot virtual instance class Windows.Foundation.IAsyncActionWithProgress`1&lt;float64&gt; GetPrimesUnordered([in]int32 first, [in]int32 last) runtime managed" />
-      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IAsyncActionWithProgress&lt;double&gt; GetPrimesUnordered(int const &amp; first, int const &amp; last);" />
+      <MemberSignature Language="C++ WINRT" Value="winrt::Windows::Foundation::IAsyncActionWithProgress&lt;double&gt; GetPrimesUnordered(int const&amp; first, int const&amp; last);" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>255.255.255.255</AssemblyVersion>

--- a/mdoc/mdoc.Test/CppWinRtMembersTests.cs
+++ b/mdoc/mdoc.Test/CppWinRtMembersTests.cs
@@ -19,7 +19,7 @@ namespace mdoc.Test
         public void Method_ComputeResult()
         {
             TestMethodSignature(CppCxTestLibName, "UwpTestWinRtComponentCpp.Class1", "ComputeResult",
-                @"winrt::Windows::Foundation::Collections::IVector<double> ComputeResult(double input);");
+                @"winrt::Windows::Foundation::Collections::IVector<double> ComputeResult(double const & input);");
         }
 
         [Test]
@@ -27,7 +27,7 @@ namespace mdoc.Test
         public void Method_GetPrimesOrdered()
         {
             TestMethodSignature(CppCxTestLibName, "UwpTestWinRtComponentCpp.Class1", "GetPrimesOrdered",
-                @"winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Windows::Foundation::Collections::IVector<int>, double> GetPrimesOrdered(int first, int last);");
+                @"winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Windows::Foundation::Collections::IVector<int>, double> GetPrimesOrdered(int const & first, int const & last);");
 
         }
 
@@ -36,7 +36,7 @@ namespace mdoc.Test
         public void Method_GetPrimesUnordered()
         {
             TestMethodSignature(CppCxTestLibName, "UwpTestWinRtComponentCpp.Class1", "GetPrimesUnordered",
-                @"winrt::Windows::Foundation::IAsyncActionWithProgress<double> GetPrimesUnordered(int first, int last);");
+                @"winrt::Windows::Foundation::IAsyncActionWithProgress<double> GetPrimesUnordered(int const & first, int const & last);");
         }
 
         [Test]

--- a/mdoc/mdoc.Test/CppWinRtMembersTests.cs
+++ b/mdoc/mdoc.Test/CppWinRtMembersTests.cs
@@ -19,7 +19,7 @@ namespace mdoc.Test
         public void Method_ComputeResult()
         {
             TestMethodSignature(CppCxTestLibName, "UwpTestWinRtComponentCpp.Class1", "ComputeResult",
-                @"winrt::Windows::Foundation::Collections::IVector<double> ComputeResult(double const & input);");
+                @"winrt::Windows::Foundation::Collections::IVector<double> ComputeResult(double const& input);");
         }
 
         [Test]
@@ -27,7 +27,7 @@ namespace mdoc.Test
         public void Method_GetPrimesOrdered()
         {
             TestMethodSignature(CppCxTestLibName, "UwpTestWinRtComponentCpp.Class1", "GetPrimesOrdered",
-                @"winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Windows::Foundation::Collections::IVector<int>, double> GetPrimesOrdered(int const & first, int const & last);");
+                @"winrt::Windows::Foundation::IAsyncOperationWithProgress<winrt::Windows::Foundation::Collections::IVector<int>, double> GetPrimesOrdered(int const& first, int const& last);");
 
         }
 
@@ -36,7 +36,7 @@ namespace mdoc.Test
         public void Method_GetPrimesUnordered()
         {
             TestMethodSignature(CppCxTestLibName, "UwpTestWinRtComponentCpp.Class1", "GetPrimesUnordered",
-                @"winrt::Windows::Foundation::IAsyncActionWithProgress<double> GetPrimesUnordered(int const & first, int const & last);");
+                @"winrt::Windows::Foundation::IAsyncActionWithProgress<double> GetPrimesUnordered(int const& first, int const& last);");
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace mdoc.Test
         public void Method_DefaultParameters()
         {
             TestMethodSignature(CSharpTestLib, "Mono.DocTest.Widget", "Default",
-                @"void Default(int const & a = 1, int const & b = 2);");
+                @"void Default(int const& a = 1, int const& b = 2);");
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace mdoc.Test
         public void Method_RefType()
         {
             TestMethodSignature(CppCxTestLibName, "Namespace222.App", "SetWindow1",
-                @"void SetWindow1(winrt::Windows::UI::Core::CoreWindow const & window);");
+                @"void SetWindow1(winrt::Windows::UI::Core::CoreWindow const& window);");
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace mdoc.Test
         public void Method_WinRtTypeInterfaceImplementation()
         {
             TestMethodSignature(CppCxTestLibName, "Namespace222.App", "SetWindow",
-                @"void SetWindow(winrt::Windows::UI::Core::CoreWindow const & window);");
+                @"void SetWindow(winrt::Windows::UI::Core::CoreWindow const& window);");
         }
 
         [Test]

--- a/mdoc/mdoc.Test/CppWinRtMembersTests.cs
+++ b/mdoc/mdoc.Test/CppWinRtMembersTests.cs
@@ -44,7 +44,7 @@ namespace mdoc.Test
         public void Method_DefaultParameters()
         {
             TestMethodSignature(CSharpTestLib, "Mono.DocTest.Widget", "Default",
-                @"void Default(int a = 1, int b = 2);");
+                @"void Default(int const & a = 1, int const & b = 2);");
         }
 
         [Test]


### PR DESCRIPTION
Link to work item: https://dev.azure.com/ceapex/Engineering/_workitems/edit/86667
This change will add '&' for out parameters and 'const &' for in parameters for all Cpp/WinRt parameter syntax.