### PR TITLE
Fix the in parameter modifier not be rendered.

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -572,10 +572,18 @@ namespace Mono.Documentation.Updater.Formatters
             if (parameter.ParameterType is ByReferenceType)
             {
                 if (parameter.IsOut)
+                {
                     buf.Append ("out ");
+                }
                 else
-                    buf.Append ("ref ");
+                {
+                    if (parameter.HasCustomAttributes && parameter.CustomAttributes.Any (ca => ca.AttributeType.Name == "IsReadOnlyAttribute"))
+                        buf.Append ("in ");
+                    else
+                        buf.Append ("ref ");
+                }
             }
+
             if (parameter.HasCustomAttributes)
             {
                 var isParams = parameter.CustomAttributes.Any (ca => ca.AttributeType.Name == "ParamArrayAttribute");
@@ -595,6 +603,7 @@ namespace Mono.Documentation.Updater.Formatters
                 var ReturnVal = new AttributeFormatter().MakeAttributesValueString(parameter.Constant, parameter.ParameterType);
                 buf.AppendFormat (" = {0}", ReturnVal == "null" ? "default" : ReturnVal);
             }
+
             return buf;
         }
 

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -258,6 +258,15 @@ namespace mdoc.Test
         }
 
         [Test]
+        public void CSharpInModifier()
+        {
+            var member = GetMethod(typeof(SomeClass), m => m.Name == "SomeMethodWithInParameterModifier");
+            var formatter = new CSharpFullMemberFormatter();
+            var sig = formatter.GetDeclaration(member);
+            Assert.AreEqual("public void SomeMethodWithInParameterModifier (in string s1, string s2, in string s3);", sig);
+        }
+
+        [Test]
         public void CSharpTuple()
         {
             var member = GetMethod(typeof(NullablesAndTuples), m => m.Name == "TupleReturn");

--- a/mdoc/mdoc.Test/SampleClasses/SomeClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/SomeClass.cs
@@ -46,7 +46,12 @@ namespace mdoc.Test.SampleClasses
 
         public void SomeMethodWithParameters(SomeClass someClass, int i)
         {
-            
+
+        }
+
+        public void SomeMethodWithInParameterModifier(in string s1, string s2, in string s3)
+        {
+
         }
 
         public void SomeMethod()


### PR DESCRIPTION
The compiler will apply IsReadOnlyAttribute to the parameter when the parameter with an in parameter modifier.