### PR TITLE
Bug 388663: output nullable (?) in type name

### DIFF
--- a/mdoc/Mono.Documentation/Updater/AttributeParserContext.cs
+++ b/mdoc/Mono.Documentation/Updater/AttributeParserContext.cs
@@ -73,6 +73,14 @@ namespace Mono.Documentation.Updater
             return false;
         }
 
+        public bool HasNullableValue
+        {
+            get
+            {
+                return nullableAttributeFlags.Contains(true);
+            }
+        }
+
         private void ReadDynamicAttribute()
         {
             DynamicTypeProvider dynamicTypeProvider = new DynamicTypeProvider(provider);


### PR DESCRIPTION
Fix Bug 388663: [mdoc]Nullable in Nested Generics not Rendering
https://ceapex.visualstudio.com/Engineering/_workitems/edit/388663?src=WorkItemMention&src-action=artifact_link

Since Mdoc generate parameter node in ECMA xml is incorrect in the case just like bug said, 
so we need to update mdoc to generate correctly

![image](https://user-images.githubusercontent.com/79683539/124441697-862bd680-ddae-11eb-8ba7-f76cfb53c40c.png)