### PR TITLE
Add nullable feature support to the ReturnType and Parameter element for generating XML

### DIFF
--- a/mdoc/Mono.Documentation/Updater/DocUtils.cs
+++ b/mdoc/Mono.Documentation/Updater/DocUtils.cs
@@ -945,5 +945,30 @@ namespace Mono.Documentation.Updater
 
             return type;
         }
+
+        public static string GetTypeNullableSymbol(TypeReference type, bool? isNullableType)
+        {
+            if (isNullableType.IsTrue() && !IsValueTypeOrDefineByReference(type) && !type.FullName.Equals("System.Void"))
+            {
+                return "?";
+            }
+
+            return string.Empty;
+        }
+
+        private static bool IsValueTypeOrDefineByReference(TypeReference type)
+        {
+            if (type.IsValueType)
+            {
+                return true;
+            }
+
+            if (type is ByReferenceType byRefType)
+            {
+                return byRefType.ElementType.IsValueType;
+            }
+
+            return false;
+        }
     }
 }

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -431,27 +431,7 @@ namespace Mono.Documentation.Updater.Formatters
 
         protected override string GetTypeNullableSymbol(TypeReference type, bool? isNullableType)
         {
-            if (isNullableType.IsTrue() && !IsValueTypeOrDefineByReference(type) && !type.FullName.Equals("System.Void"))
-            {
-                return "?";
-            }
-
-            return string.Empty;
-        }
-
-        private bool IsValueTypeOrDefineByReference(TypeReference type)
-        {
-            if (type.IsValueType)
-            {
-                return true;
-            }
-
-            if (type is ByReferenceType byRefType)
-            {
-                return byRefType.ElementType.IsValueType;
-            }
-
-            return false;
+            return DocUtils.GetTypeNullableSymbol(type, isNullableType);
         }
 
         protected override StringBuilder AppendGenericMethodConstraints (StringBuilder buf, MethodDefinition method)

--- a/mdoc/Mono.Documentation/Updater/Formatters/DocTypeFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/DocTypeFullMemberFormatter.cs
@@ -1,6 +1,8 @@
-﻿namespace Mono.Documentation.Updater
+﻿using Mono.Cecil;
+
+namespace Mono.Documentation.Updater
 {
-    class DocTypeFullMemberFormatter : MemberFormatter
+    public class DocTypeFullMemberFormatter : MemberFormatter
     {
         private static MemberFormatter defaultFormatter;
         public static MemberFormatter Default
@@ -19,6 +21,11 @@
         protected override string NestedTypeSeparator
         {
             get { return "+"; }
+        }
+
+        protected override string GetTypeNullableSymbol(TypeReference type, bool? isNullableType)
+        {
+            return DocUtils.GetTypeNullableSymbol(type, isNullableType);
         }
     }
 }

--- a/mdoc/Mono.Documentation/Updater/NullableReferenceTypeProvider.cs
+++ b/mdoc/Mono.Documentation/Updater/NullableReferenceTypeProvider.cs
@@ -117,6 +117,16 @@ namespace Mono.Documentation.Updater
                 return GetTypeNullableAttributes(fieldDefinition);
             }
 
+            if (provider is MethodDefinition methodDefinition)
+            {
+                return GetTypeNullableAttributes(methodDefinition);
+            }
+
+            if (provider is EventDefinition eventDefinition)
+            {
+                return GetTypeNullableAttributes(eventDefinition);
+            }
+
             throw new ArgumentException("We don't support this custom attribute provider type now.", nameof(provider));
         }
 
@@ -144,6 +154,11 @@ namespace Mono.Documentation.Updater
             };
         }
 
+        private ICollection<ICustomAttributeProvider> GetTypeNullableAttributes(EventDefinition eventDefinition)
+        {
+            return GetTypeNullableAttributes(eventDefinition.AddMethod.Parameters[0]);
+        }
+
         private ICollection<ICustomAttributeProvider> GetTypeNullableAttributes(ICustomAttributeProvider customAttributeProvider, MethodDefinition methodDefinition)
         {
             var resultList = new List<ICustomAttributeProvider> 
@@ -151,6 +166,14 @@ namespace Mono.Documentation.Updater
                 customAttributeProvider
             };
 
+            resultList.AddRange(GetTypeNullableAttributes(methodDefinition));
+
+            return resultList;
+        }
+
+        private ICollection<ICustomAttributeProvider> GetTypeNullableAttributes(MethodDefinition methodDefinition)
+        {
+            var resultList = new List<ICustomAttributeProvider>();
             if (methodDefinition != null)
             {
                 resultList.Add(methodDefinition);

--- a/mdoc/mdoc.Test/DocTypeNullableReferenceTypesTests.cs
+++ b/mdoc/mdoc.Test/DocTypeNullableReferenceTypesTests.cs
@@ -1,0 +1,78 @@
+﻿using Mono.Cecil;
+using Mono.Documentation.Updater;
+using NUnit.Framework;
+
+namespace mdoc.Test
+{
+    public class DocTypeNullableReferenceTypesTests : BasicFormatterTests<MemberFormatter>
+    {
+        private const string NullableReferenceTypesAssemblyPath = "../../../../external/Test/mdoc.Test.NullableReferenceTypes.dll";
+
+        protected override MemberFormatter formatter => DocTypeFullMemberFormatter.Default;
+
+        [TestCase("System.Int32", "ValueType")]
+        [TestCase("System.Nullable<System.Int32>", "NullableValueType")]
+        [TestCase("System.Collections.Generic.Dictionary<System.String,System.Collections.Generic.Dictionary<System.String,System.String>>", "DictionaryOfReferenceTypeKeyAndDictionaryOfReferenceTypeValue")]
+        [TestCase("System.Collections.Generic.Dictionary<System.String?,System.Collections.Generic.Dictionary<System.String?,System.String?>?>?", "NullableDictionaryOfNullableReferenceTypeKeyAndNullableDictionaryOfNullableReferenceTypeValue")]
+        public void DocTypeReturnType(string returnType, string methodName)
+        {
+            // This is a common test for the return type of method, extension method, property, field, and operator overloading.
+            // They have the same process logic that we just test once the type of them.
+            var type = GetType(NullableReferenceTypesAssemblyPath, "mdoc.Test.NullableReferenceTypes.CommonType");
+            var method = GetMethod(type, i => i.Name == methodName);
+
+            var typeName = GetDocTypeName(method.MethodReturnType, method.ReturnType);
+
+            Assert.AreEqual(returnType, typeName);
+        }
+
+        [TestCase("System.EventHandler", "EventHandler")]
+        [TestCase("System.EventHandler<System.EventArgs>?", "NullableGenericEventHandler")]
+        [TestCase("System.EventHandler<System.EventArgs?>?", "NullableGenericEventHandlerOfNullableEventArgs")]
+        public void DocTypeEventType(string returnType, string methodName)
+        {
+            var type = GetType(NullableReferenceTypesAssemblyPath, "mdoc.Test.NullableReferenceTypes.Event");
+            var @event = GetEvent(type, methodName) as EventDefinition;
+
+            var typeName = GetDocTypeName(@event, @event.EventType);
+
+            Assert.AreEqual(returnType, typeName);
+        }
+
+        [TestCase("NullableAndNonNullableValueType", "System.Int32", "System.Nullable<System.Int32>", "System.Int32")]
+        [TestCase("NullableAndNonNullableReferenceType", "System.String", "System.String?", "System.String")]
+        [TestCase("NullableAndNonNullableInterfaceOfValueType", "System.Collections.Generic.ICollection<System.Int32>", "System.Collections.Generic.ICollection<System.Int32>?", "System.Collections.Generic.ICollection<System.Int32>")]
+        [TestCase("NullableAndNonNullableInterfaceOfReferenceType", "System.Collections.Generic.ICollection<System.String>", "System.Collections.Generic.ICollection<System.String>?", "System.Collections.Generic.ICollection<System.String>")]
+        public void DocTypeParameterType(string methodName, params string[] methodParameterType)
+        {
+            // This is a common test for the parameter type of constructor, method, extension method, delegate and operator overloading.
+            // They have the same process logic that we just test once the type of them.
+            var type = GetType(NullableReferenceTypesAssemblyPath, "mdoc.Test.NullableReferenceTypes.MethodParameter");
+            var method = GetMethod(type, i => i.Name == methodName);
+
+            for (int i = 0; i < method.Parameters.Count; i++)
+            {
+                var methodParameter = method.Parameters[i];
+                var expectedParameterType = methodParameterType[i];
+
+                var typeName = GetDocTypeName(methodParameter, methodParameter.ParameterType);
+
+                Assert.AreEqual(expectedParameterType, typeName);
+            }
+        }
+
+        private string GetDocTypeName(ICustomAttributeProvider provider, TypeReference type)
+        {
+            var context = AttributeParserContext.Create(provider);
+            var isNullable = context.IsNullable();
+            var typeName = DocTypeFullMemberFormatter.Default.GetName(type, context, useTypeProjection: false);
+
+            if (isNullable)
+            {
+                typeName += DocUtils.GetTypeNullableSymbol(type, isNullable);
+            }
+
+            return typeName;
+        }
+    }
+}

--- a/mdoc/mdoc.Test/mdoc.Test.csproj
+++ b/mdoc/mdoc.Test/mdoc.Test.csproj
@@ -77,6 +77,7 @@
     <Compile Include="BasicTests.cs" />
     <Compile Include="CppWinRtMembersTests.cs" />
     <Compile Include="CppWinRtFormatterTests.cs" />
+    <Compile Include="DocTypeNullableReferenceTypesTests.cs" />
     <Compile Include="Enumeration\AttachedEntityTests.cs" />
     <Compile Include="DotnetCoreAssemblyResolver.cs" />
     <Compile Include="FrameworkIndexHelperTests.cs" />


### PR DESCRIPTION
The nullable feature supports the constructor, field, property, method, event, and operator overriding for ECMA2YAML to consume.