### PR TITLE
bump to 5.8.4

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
 	public static class Consts
 	{
-		public static string MonoVersion = "5.8.3";
+		public static string MonoVersion = "5.8.4";
 		public const string DocId = "DocId";
 		public const string CppCli = "C++ CLI";
 	    public const string CppCx = "C++ CX";

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.8.3</version>
+    <version>5.8.4</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
There is a similar PR https://github.com/mono/api-doc-tools/pull/562 which filed months ago. Instead of reusing Ann's branch, I checked out a new 5.8.4 release branch which includes the latest changes of develop.

Since tag mdoc-5.8.4 has already been created, so I had to create another tag [mdoc-5.8.4-0914](https://github.com/mono/api-doc-tools/releases/tag/mdoc-5.8.4-0914) to point to this release branch.

And I tried to run the CI job against this version https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=252959&view=results but failed on issue https://github.com/dotnet/dotnet-api-docs/issues/7178 
After dotnet content team merged my PR https://github.com/dotnet/dotnet-api-docs/pull/7177 we can continue to run the CI job against this version and verify the diff with version 5.8.3