### PR TITLE
mdoc: use //license/@expression, not //licenseUrl

### DIFF
--- a/azure-pipelines.lgtm.yml
+++ b/azure-pipelines.lgtm.yml
@@ -26,6 +26,8 @@ variables:
   value: true
 - name: buildConfiguration
   value: Release
+- name: msbuild
+  value: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe'
   
 steps:
 - task: NuGetToolInstaller@1

--- a/azure-pipelines.lgtm.yml
+++ b/azure-pipelines.lgtm.yml
@@ -26,8 +26,6 @@ variables:
   value: true
 - name: buildConfiguration
   value: Release
-- name: msbuild
-  value: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe'
   
 steps:
 - task: NuGetToolInstaller@1

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://github.com/mono/api-doc-tools</projectUrl>
-    <licenseUrl>https://github.com/mono/api-doc-tools/blob/main/LICENSE.md</licenseUrl>
+    <license type="expression">MIT</license>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>.NET API Documentation toolchain</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>


### PR DESCRIPTION
Context: https://docs.microsoft.com/en-us/nuget/reference/nuspec#licenseurl
Context: https://docs.microsoft.com/en-us/nuget/reference/nuspec#license
Context: https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#important-nuget-package-metadata
Context: https://docs.clearlydefined.io/curation-guidelines

Certain internal Microsoft tools check NuGet license information by
using [ClearlyDefined curated data][0] to determine verified license
information for packages which don't "clearly define" their license.

Unfortunately, a license URL is *not* considered "clearly defined",
likely because it isn't *really* machine readable.  (Just because the
URL contains "MIT" doesn't mean it's *actually* MIT.)

As part of this effort, [NuGet deprecated][1] the [`<licenseUrl/>`][2]
element, preferring instead the new [`<license/>`][3] element.

Replace `<licenseUrl/>` with `<license/>`, and provide a
`//license/@type` value of `expression`.  The value of the
`<license/>` element is `MIT`, which is an [SPDX identifier][4],
which is a "clearly defined" value, and thus satisfies ClearlyDefined.

[0]: https://github.com/clearlydefined/curated-data/
[1]: https://github.com/NuGet/Home/issues/7509
[2]: https://docs.microsoft.com/en-us/nuget/reference/nuspec#licenseurl
[3]: https://docs.microsoft.com/en-us/nuget/reference/nuspec#license
[4]: https://spdx.org/licenses/