### PR TITLE
HtmlGenerator: Load converters lazily

### DIFF
--- a/monodoc/Monodoc/generators/html/Ecmaspec2Html.cs
+++ b/monodoc/Monodoc/generators/html/Ecmaspec2Html.cs
@@ -51,7 +51,7 @@ namespace Monodoc.Generators.Html
 				stream = assembly.GetManifestResourceStream ("ecmaspec-html-css.xsl");
 
 				XmlReader xml_reader = new XmlTextReader (stream);
-				ecma_transform.Load (xml_reader, null, null);
+				ecma_transform.Load (xml_reader, null);
 				args.AddExtensionObject ("monodoc:///extensions", new ExtObj ()); 
 			}
 		

--- a/monodoc/Monodoc/generators/html/Toc2Html.cs
+++ b/monodoc/Monodoc/generators/html/Toc2Html.cs
@@ -18,7 +18,7 @@ namespace Monodoc.Generators.Html
 			var assembly = Assembly.GetAssembly (typeof (Toc2Html));
 			var stream = assembly.GetManifestResourceStream ("toc-html.xsl");
 			XmlReader xml_reader = new XmlTextReader (stream);
-			transform.Load (xml_reader, null, null);
+			transform.Load (xml_reader, null);
 		}
 
 		public string Export (Stream input, Dictionary<string, string> extraArgs)


### PR DESCRIPTION
This is a workaround so that .NET 6 apps can use the .NET FW
build of monodoc.dll without worrying about TypeInitializationExceptions
for converters they don't use.