### PR TITLE
feat#550375: Support ref struct and readonly ref struct syntaxes

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -38,12 +38,15 @@ namespace Mono.Documentation
         public const string VoidFullName = "System.Void";
         public const string RefTypeObsoleteString = "Types with embedded references are not supported in this version of your compiler.";
         public const string FrameworksIndexFolderName = "FrameworksIndex";
-        public const string CompilerGeneratedAttribute = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
-        public const string CompilationMappingAttribute = "Microsoft.FSharp.Core.CompilationMappingAttribute";
         public const string FrameworksIndex = "FrameworksIndex";
         public const string FrameworkAlternate = "FrameworkAlternate";
         public const string Index = "Index";
 
         public static bool CollapseInheritedInterfaces = true;
+
+        public const string CompilationMappingAttribute = "Microsoft.FSharp.Core.CompilationMappingAttribute";
+        public const string CompilerGeneratedAttribute = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
+        public const string IsByRefLikeAttribute = "System.Runtime.CompilerServices.IsByRefLikeAttribute";
+        public const string IsReadOnlyAttribute = "System.Runtime.CompilerServices.IsReadOnlyAttribute";
     }
 }

--- a/mdoc/Mono.Documentation/Updater/DocUtils.cs
+++ b/mdoc/Mono.Documentation/Updater/DocUtils.cs
@@ -946,7 +946,7 @@ namespace Mono.Documentation.Updater
             return type;
         }
 
-        public static bool HasReadOnlyAttribute(ICustomAttributeProvider customAttrProvider)
+        public static bool HasCustomAttribute(ICustomAttributeProvider customAttrProvider, string attributeName)
         {
             if (customAttrProvider == null)
             {
@@ -955,7 +955,7 @@ namespace Mono.Documentation.Updater
             else
             {
                 return customAttrProvider.HasCustomAttributes
-                    && customAttrProvider.CustomAttributes.Any(attr => attr.AttributeType.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute");
+                    && customAttrProvider.CustomAttributes.Any(attr => attr.AttributeType.FullName == attributeName);
             }
         }
     }

--- a/mdoc/Mono.Documentation/Updater/DocUtils.cs
+++ b/mdoc/Mono.Documentation/Updater/DocUtils.cs
@@ -945,5 +945,18 @@ namespace Mono.Documentation.Updater
 
             return type;
         }
+
+        public static bool HasReadOnlyAttribute(ICustomAttributeProvider customAttrProvider)
+        {
+            if (customAttrProvider == null)
+            {
+                return false;
+            }
+            else
+            {
+                return customAttrProvider.HasCustomAttributes
+                    && customAttrProvider.CustomAttributes.Any(attr => attr.AttributeType.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute");
+            }
+        }
     }
 }

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -238,7 +238,19 @@ namespace Mono.Documentation.Updater.Formatters
             if (t.IsEnum)
                 return "enum";
             if (t.IsValueType)
-                return "struct";
+            {
+                StringBuilder buf = new StringBuilder();
+                if (DocUtils.HasReadOnlyAttribute(t))
+                {
+                    buf.Append("readonly ");
+                }
+                if (t.CustomAttributes.Any(attr => attr.AttributeType.FullName == "System.Runtime.CompilerServices.IsByRefLikeAttribute"))
+                {
+                    buf.Append("ref ");
+                }
+                buf.Append("struct");
+                return buf.ToString();
+            }
             if (t.IsClass || t.FullName == "System.Enum")
                 return "class";
             if (t.IsInterface)
@@ -508,8 +520,7 @@ namespace Mono.Documentation.Updater.Formatters
                 modifiers += " ref";
             }
 
-            if (method.ReturnType.IsRequiredModifier
-                && method.MethodReturnType.CustomAttributes.Any(attr => attr.AttributeType.FullName == "System.Runtime.CompilerServices.IsReadOnlyAttribute"))
+            if (method.ReturnType.IsRequiredModifier && DocUtils.HasReadOnlyAttribute(method.MethodReturnType))
             {
                 modifiers += " readonly";
             }

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -240,11 +240,11 @@ namespace Mono.Documentation.Updater.Formatters
             if (t.IsValueType)
             {
                 StringBuilder buf = new StringBuilder();
-                if (DocUtils.HasReadOnlyAttribute(t))
+                if (DocUtils.HasCustomAttribute(t, Consts.IsReadOnlyAttribute))
                 {
                     buf.Append("readonly ");
                 }
-                if (t.CustomAttributes.Any(attr => attr.AttributeType.FullName == "System.Runtime.CompilerServices.IsByRefLikeAttribute"))
+                if (DocUtils.HasCustomAttribute(t, Consts.IsByRefLikeAttribute))
                 {
                     buf.Append("ref ");
                 }
@@ -520,7 +520,7 @@ namespace Mono.Documentation.Updater.Formatters
                 modifiers += " ref";
             }
 
-            if (method.ReturnType.IsRequiredModifier && DocUtils.HasReadOnlyAttribute(method.MethodReturnType))
+            if (method.ReturnType.IsRequiredModifier && DocUtils.HasCustomAttribute(method.MethodReturnType, Consts.IsReadOnlyAttribute))
             {
                 modifiers += " readonly";
             }

--- a/mdoc/mdoc.Test/DocUtilsTests.cs
+++ b/mdoc/mdoc.Test/DocUtilsTests.cs
@@ -146,7 +146,7 @@ random text
         }
 
         [Test]
-        public void HasReadOnlyAttribute()
+        public void HasCustomAttributeTest()
         {
             Assert.IsFalse(DocUtils.HasCustomAttribute(null, ""));
 

--- a/mdoc/mdoc.Test/DocUtilsTests.cs
+++ b/mdoc/mdoc.Test/DocUtilsTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using mdoc.Test.SampleClasses;
+using Mono.Documentation;
 using Mono.Documentation.Updater;
-using Mono.Documentation.Updater.Frameworks;
 using NUnit.Framework;
 using System.Xml;
 
@@ -148,13 +148,15 @@ random text
         [Test]
         public void HasReadOnlyAttribute()
         {
-            Assert.IsFalse(DocUtils.HasReadOnlyAttribute(null));
+            Assert.IsFalse(DocUtils.HasCustomAttribute(null, ""));
 
             var type = GetType(typeof(SampleClasses.RefStruct));
-            Assert.IsFalse(DocUtils.HasReadOnlyAttribute(type));
+            Assert.IsFalse(DocUtils.HasCustomAttribute(type, Consts.IsReadOnlyAttribute));
+            Assert.IsTrue(DocUtils.HasCustomAttribute(type, Consts.IsByRefLikeAttribute));
 
             type = GetType(typeof(SampleClasses.ReadOnlyRefStruct));
-            Assert.IsTrue(DocUtils.HasReadOnlyAttribute(type));
+            Assert.IsTrue(DocUtils.HasCustomAttribute(type, Consts.IsReadOnlyAttribute));
+            Assert.IsTrue(DocUtils.HasCustomAttribute(type, Consts.IsByRefLikeAttribute));
         }
     }
 }

--- a/mdoc/mdoc.Test/DocUtilsTests.cs
+++ b/mdoc/mdoc.Test/DocUtilsTests.cs
@@ -144,5 +144,17 @@ random text
             var result = DocUtils.IsEiiIgnoredMethod(member, member.Overrides[0]);
             Assert.IsTrue(result);
         }
+
+        [Test]
+        public void HasReadOnlyAttribute()
+        {
+            Assert.IsFalse(DocUtils.HasReadOnlyAttribute(null));
+
+            var type = GetType(typeof(SampleClasses.RefStruct));
+            Assert.IsFalse(DocUtils.HasReadOnlyAttribute(type));
+
+            type = GetType(typeof(SampleClasses.ReadOnlyRefStruct));
+            Assert.IsTrue(DocUtils.HasReadOnlyAttribute(type));
+        }
     }
 }

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -387,6 +387,24 @@ namespace mdoc.Test
             Assert.AreEqual(true, flag);
         }
 
+        [Test]
+        public void CSharpRefStructTest()
+        {
+            var type = GetType(typeof(SampleClasses.RefStruct));
+            var formatter = new CSharpFullMemberFormatter();
+            var typeSignature = formatter.GetDeclaration(type);
+            Assert.AreEqual("public ref struct RefStruct;", typeSignature);
+        }
+
+        [Test]
+        public void CSharpReadOnlyRefStructTest()
+        {
+            var type = GetType(typeof(SampleClasses.ReadOnlyRefStruct));
+            var formatter = new CSharpFullMemberFormatter();
+            var typeSignature = formatter.GetDeclaration(type);
+            Assert.AreEqual("public readonly ref struct ReadOnlyRefStruct;", typeSignature);
+        }
+
         #region Helper Methods
         string RealTypeName(string name){
             switch (name) {

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -391,18 +391,16 @@ namespace mdoc.Test
         public void CSharpRefStructTest()
         {
             var type = GetType(typeof(SampleClasses.RefStruct));
-            var formatter = new CSharpFullMemberFormatter();
             var typeSignature = formatter.GetDeclaration(type);
-            Assert.AreEqual("public ref struct RefStruct;", typeSignature);
+            Assert.AreEqual("public ref struct RefStruct", typeSignature);
         }
 
         [Test]
         public void CSharpReadOnlyRefStructTest()
         {
             var type = GetType(typeof(SampleClasses.ReadOnlyRefStruct));
-            var formatter = new CSharpFullMemberFormatter();
             var typeSignature = formatter.GetDeclaration(type);
-            Assert.AreEqual("public readonly ref struct ReadOnlyRefStruct;", typeSignature);
+            Assert.AreEqual("public readonly ref struct ReadOnlyRefStruct", typeSignature);
         }
 
         #region Helper Methods

--- a/mdoc/mdoc.Test/SampleClasses/ReadOnlyRefStruct.cs
+++ b/mdoc/mdoc.Test/SampleClasses/ReadOnlyRefStruct.cs
@@ -1,0 +1,7 @@
+﻿namespace mdoc.Test.SampleClasses
+{
+    public readonly ref struct ReadOnlyRefStruct
+    {
+
+    }
+}

--- a/mdoc/mdoc.Test/SampleClasses/RefStruct.cs
+++ b/mdoc/mdoc.Test/SampleClasses/RefStruct.cs
@@ -1,0 +1,7 @@
+﻿namespace mdoc.Test.SampleClasses
+{
+    public ref struct RefStruct
+    {
+
+    }
+}


### PR DESCRIPTION
https://ceapex.visualstudio.com/Engineering/_workitems/edit/550375

**ref struct**
before: https://github.com/dotnet/dotnet-api-docs/blob/main/xml/System/ArgIterator.xml
after: 
![image](https://user-images.githubusercontent.com/73150173/154010979-ef8ce183-f84c-43a9-8203-714ced1a3aec.png)

**readonly ref struct**
before: https://github.com/dotnet/dotnet-api-docs/blob/main/xml/System/Span%601.xml
after:
![image](https://user-images.githubusercontent.com/73150173/154011196-272ee38e-635a-4c42-a2e5-ec0f52cf201f.png)

**readonly struct**
before: https://github.com/dotnet/dotnet-api-docs/blob/main/xml/System.Runtime.Intrinsics/Vector64%601.xml
after:
![image](https://user-images.githubusercontent.com/73150173/154011676-b2dc648d-adce-45af-b39f-271e2809a3db.png)
