### PR TITLE
feat#550375: Support ref and ref readonly return

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -48,5 +48,6 @@ namespace Mono.Documentation
         public const string CompilerGeneratedAttribute = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
         public const string IsByRefLikeAttribute = "System.Runtime.CompilerServices.IsByRefLikeAttribute";
         public const string IsReadOnlyAttribute = "System.Runtime.CompilerServices.IsReadOnlyAttribute";
+        public const string InAttribute = "System.Runtime.InteropServices.InAttribute";
     }
 }

--- a/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CppFormatters/CppFullMemberFormatter.cs
@@ -776,10 +776,9 @@ namespace Mono.Documentation.Updater.Formatters.CppFormatters
             return buf;
         }
 
-        protected override StringBuilder AppendRefTypeName(StringBuilder buf, TypeReference type, IAttributeParserContext context)
+        protected override StringBuilder AppendRefTypeName(StringBuilder buf, ByReferenceType type, IAttributeParserContext context)
         {
-            TypeSpecification spec = type as TypeSpecification;
-            _AppendTypeName(buf, spec != null ? spec.ElementType : type.GetElementType(), context);
+            _AppendTypeName(buf, type.ElementType, context);
             AppendHat(buf, type);
             buf.Append(RefTypeModifier);
 

--- a/mdoc/Mono.Documentation/Updater/Formatters/FSharpFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/FSharpFormatter.cs
@@ -613,10 +613,9 @@ namespace Mono.Documentation.Updater
             return buf;
         }
 
-        protected override StringBuilder AppendRefTypeName(StringBuilder buf, TypeReference type, IAttributeParserContext context)
+        protected override StringBuilder AppendRefTypeName(StringBuilder buf, ByReferenceType type, IAttributeParserContext context)
         {
-            ByReferenceType reftype = type as ByReferenceType;
-            return AppendTypeName(buf, reftype?.ElementType, context);
+            return AppendTypeName(buf, type.ElementType, context);
         }
 
         protected override StringBuilder AppendModifiers(StringBuilder buf, MethodDefinition method)

--- a/mdoc/Mono.Documentation/Updater/Formatters/MemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/MemberFormatter.cs
@@ -143,14 +143,14 @@ namespace Mono.Documentation.Updater
 
             StringBuilder interimBuilder = new StringBuilder();
 
-            if (ShouldStripModFromTypeName && type is RequiredModifierType)
+            if (ShouldStripModFromTypeName && type is RequiredModifierType requiredModifierType)
             {
-                AppendRequiredModifierTypeName(interimBuilder, type as RequiredModifierType, context);
+                AppendRequiredModifierTypeName(interimBuilder, requiredModifierType, context);
                 return SetBuffer(buf, interimBuilder, useTypeProjection: useTypeProjection);
             }
-            if (ShouldStripModFromTypeName && type is OptionalModifierType)
+            if (ShouldStripModFromTypeName && type is OptionalModifierType optionalModifierType)
             {
-                AppendOptionalModifierTypeName(interimBuilder, type as OptionalModifierType, context);
+                AppendOptionalModifierTypeName(interimBuilder, optionalModifierType, context);
                 return SetBuffer(buf, interimBuilder, useTypeProjection: useTypeProjection);
             }
             if (type is ArrayType)
@@ -158,9 +158,9 @@ namespace Mono.Documentation.Updater
                 AppendArrayTypeName(interimBuilder, type, context);
                 return SetBuffer(buf, interimBuilder, useTypeProjection: useTypeProjection);
             }
-            if (type is ByReferenceType)
+            if (type is ByReferenceType byReferenceType)
             {
-                AppendRefTypeName (interimBuilder, type, context);
+                AppendRefTypeName (interimBuilder, byReferenceType, context);
                 return SetBuffer(buf, interimBuilder, useTypeProjection: useTypeProjection);
             }
             if (type is PointerType)
@@ -290,10 +290,9 @@ namespace Mono.Documentation.Updater
             get { return "@"; }
         }
 
-        protected virtual StringBuilder AppendRefTypeName (StringBuilder buf, TypeReference type, IAttributeParserContext context)
+        protected virtual StringBuilder AppendRefTypeName (StringBuilder buf, ByReferenceType type, IAttributeParserContext context)
         {
-            TypeSpecification spec = type as TypeSpecification;
-            return _AppendTypeName(buf, spec != null ? spec.ElementType : type.GetElementType(), context);
+            return _AppendTypeName(buf, type.ElementType, context);
         }
 
         protected virtual string PointerModifier

--- a/mdoc/Mono.Documentation/Updater/Formatters/MsxdocSlashDocMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/MsxdocSlashDocMemberFormatter.cs
@@ -7,10 +7,9 @@ namespace Mono.Documentation.Updater
     {
         public MsxdocSlashDocMemberFormatter(TypeMap map) : base(map) { }
 
-        protected override StringBuilder AppendRefTypeName(StringBuilder buf, TypeReference type, IAttributeParserContext context)
+        protected override StringBuilder AppendRefTypeName(StringBuilder buf, ByReferenceType type, IAttributeParserContext context)
         {
-            TypeSpecification spec = type as TypeSpecification;
-            return _AppendTypeName(buf, spec != null ? spec.ElementType : type.GetElementType(), context).Append(RefTypeModifier);
+            return _AppendTypeName(buf, type.ElementType, context).Append(RefTypeModifier);
         }
     }
 }

--- a/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
@@ -82,7 +82,7 @@ namespace Mono.Documentation.Updater
             return buf;
         }
 
-        protected override StringBuilder AppendRefTypeName (StringBuilder buf, TypeReference type, IAttributeParserContext context)
+        protected override StringBuilder AppendRefTypeName (StringBuilder buf, ByReferenceType type, IAttributeParserContext context)
         {
             return base.AppendRefTypeName (buf, type, context).Append (RefTypeModifier);
         }

--- a/mdoc/mdoc.Test/BasicTests.cs
+++ b/mdoc/mdoc.Test/BasicTests.cs
@@ -88,6 +88,15 @@ namespace mdoc.Test
             return GetMethod(GetType(type), i => i.Name == name);
         }
 
+        protected PropertyDefinition GetProperty(Type type, Func<PropertyDefinition, bool> query)
+        {
+            var properties = GetType(type).Properties;
+            var member = properties.FirstOrDefault(query)?.Resolve();
+            if (member == null)
+                throw new Exception("Did not find the member in the test class");
+            return member;
+        }
+
         protected Dictionary<string, List<MemberReference>> GetClassInterface(TypeDefinition type)
         {
             return DocUtils.GetImplementedMembersFingerprintLookup(type);

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -256,22 +256,28 @@ namespace mdoc.Test
             Assert.AreEqual("public void SomeMethod4 (out string a, T t, object b = default);", sig);
         }
 
-        [Test]
-        public void CSharpReadonlyRefReturn()
+        [TestCase(typeof(ReadonlyRefClass), "Ref", "public ref int Ref ();")]
+        [TestCase(typeof(ReadonlyRefClass), "ReadonlyRef", "public ref readonly int ReadonlyRef ();")]
+        [TestCase(typeof(ReadonlyRefClass), "RefInAndOutMethod", "public void RefInAndOutMethod (ref int a, in int b, out int c);")]
+        [TestCase(typeof(GenericRefClass<>), "Ref", "public ref T Ref ();")]
+        [TestCase(typeof(GenericRefClass<>), "ReadonlyRef", "public ref readonly T ReadonlyRef ();")]
+        [TestCase(typeof(GenericRefClass<>), "RefInAndOutMethod", "public void RefInAndOutMethod (ref T a, in T b, out T c);")]
+        public void CSharpRefReturnMethodTest(Type type, string methodName, string expectedSignature)
         {
-            var member = GetMethod(typeof(ReadonlyRefClass), m => m.Name == "ReadonlyRef");
-            var formatter = new CSharpFullMemberFormatter();
-            var sig = formatter.GetDeclaration(member);
-            Assert.AreEqual("public ref readonly int ReadonlyRef ();", sig);
+            var member = GetMethod(type, m => m.Name == methodName);
+            var actualSignature = formatter.GetDeclaration(member);
+            Assert.AreEqual(expectedSignature, actualSignature);
         }
 
-        [Test]
-        public void CSharpRefReturn()
+        [TestCase(typeof(ReadonlyRefClass), "RefProperty", "public ref int RefProperty { get; }")]
+        [TestCase(typeof(ReadonlyRefClass), "Item", "public ref readonly int this[int index] { get; }")]
+        [TestCase(typeof(GenericRefClass<>), "RefProperty", "public ref int RefProperty { get; }")]
+        [TestCase(typeof(GenericRefClass<>), "Item", "public ref readonly T this[int index] { get; }")]
+        public void CSharpRefReturnPropertyTest(Type type, string propertyName, string expectedSignature)
         {
-            var member = GetMethod(typeof(ReadonlyRefClass), m => m.Name == "Ref");
-            var formatter = new CSharpFullMemberFormatter();
-            var sig = formatter.GetDeclaration(member);
-            Assert.AreEqual("public ref int Ref ();", sig);
+            var member = GetProperty(type, p => p.Name == propertyName);
+            var actualSignature = formatter.GetDeclaration(member);
+            Assert.AreEqual(expectedSignature, actualSignature);
         }
 
         [Test]

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -271,7 +271,7 @@ namespace mdoc.Test
 
         [TestCase(typeof(ReadonlyRefClass), "RefProperty", "public ref int RefProperty { get; }")]
         [TestCase(typeof(ReadonlyRefClass), "Item", "public ref readonly int this[int index] { get; }")]
-        [TestCase(typeof(GenericRefClass<>), "RefProperty", "public ref int RefProperty { get; }")]
+        [TestCase(typeof(GenericRefClass<>), "RefProperty", "public ref T RefProperty { get; }")]
         [TestCase(typeof(GenericRefClass<>), "Item", "public ref readonly T this[int index] { get; }")]
         public void CSharpRefReturnPropertyTest(Type type, string propertyName, string expectedSignature)
         {

--- a/mdoc/mdoc.Test/SampleClasses/ReadonlyRefClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/ReadonlyRefClass.cs
@@ -3,8 +3,27 @@
     public class ReadonlyRefClass
     {
         int i;
-
         public ref int Ref() => ref i;
-        public ref readonly int ReadonlyRef() => ref i;       
+
+        public ref readonly int ReadonlyRef() => ref i;
+
+        public ref int RefProperty { get { return ref i; } }
+
+        public ref readonly int this[int index] => throw null;
+
+        public void RefInAndOutMethod(ref int a, in int b, out int c) => throw null;
+    }
+
+    public class GenericRefClass<T>
+    {
+        public ref T Ref() => throw null;
+
+        public ref readonly T ReadonlyRef() => throw null;
+
+        public ref T RefProperty => throw null;
+
+        public ref readonly T this[int index] => throw null;
+
+        public void RefInAndOutMethod(ref T a, in T b, out T c) => throw null;
     }
 }


### PR DESCRIPTION
Task link: https://ceapex.visualstudio.com/Engineering/_workitems/edit/167409

- Method return type (ref, ref readonly)
- Property type(ref, ref readonly)
- Parameter type(ref, in, out)

before: https://github.com/dotnet/dotnet-api-docs/blob/main/xml/System/ReadOnlySpan%601.xml
<img width="453" alt="image" src="https://user-images.githubusercontent.com/73150173/155077956-39738680-38dd-4248-93e3-9a3f7ab0b075.png">

after:
<img width="843" alt="image" src="https://user-images.githubusercontent.com/73150173/155078178-6efa0718-6611-4674-825e-6b51ea3bb840.png">
