### PR TITLE
feat#550404: Support .NET language features: init only setter

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -50,5 +50,6 @@ namespace Mono.Documentation
         public const string IsReadOnlyAttribute = "System.Runtime.CompilerServices.IsReadOnlyAttribute";
         public const string InAttribute = "System.Runtime.InteropServices.InAttribute";
         public const string TupleElementNamesAttribute = "System.Runtime.CompilerServices.TupleElementNamesAttribute";
+        public const string IsExternalInit = "System.Runtime.CompilerServices.IsExternalInit";
     }
 }

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -725,7 +725,14 @@ namespace Mono.Documentation.Updater.Formatters
             {
                 if (set_visible != visibility)
                     buf.Append (' ').Append (set_visible);
-                buf.Append (" set;");
+                if (property.SetMethod.ReturnType is RequiredModifierType returnType && returnType.ModifierType.FullName == Consts.IsExternalInit)
+                {
+                    buf.Append(" init;");
+                }
+                else
+                {
+                    buf.Append(" set;");
+                }
             }
             buf.Append (" }");
 

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -453,6 +453,17 @@ namespace mdoc.Test
             Assert.AreEqual(expectedSignature, methodSignature);
         }
 
+        [TestCase("Property1", "public int Property1 { get; set; }")]
+        [TestCase("Property2", "public int Property2 { get; init; }")]
+        [TestCase("Property3", "public int Property3 { get; protected init; }")]
+        [TestCase("Item", "public int this[int index] { get; init; }")]
+        public void CSharpInitOnlySetterTest(string propertyName, string expectedSignature)
+        {
+            var property = GetProperty(typeof(SampleClasses.InitOnlySetter), p => p.Name == propertyName);
+            var propertySignature = formatter.GetDeclaration(property);
+            Assert.AreEqual(expectedSignature, propertySignature);
+        }
+
         #region Helper Methods
         string RealTypeName(string name){
             switch (name) {

--- a/mdoc/mdoc.Test/SampleClasses/InitOnlySetter.cs
+++ b/mdoc/mdoc.Test/SampleClasses/InitOnlySetter.cs
@@ -1,0 +1,20 @@
+﻿namespace mdoc.Test.SampleClasses
+{
+    public class InitOnlySetter
+    {
+        public int Property1 { get; set; }
+        public int Property2 { get; init; }
+        public int Property3 { get; protected init; }
+        public int this[int index]
+        {
+            get
+            {
+                throw null;
+            }
+            init
+            {
+                throw null;
+            }
+        }
+    }
+}

--- a/mdoc/mdoc.Test/SampleClasses/IsExternalInit.cs
+++ b/mdoc/mdoc.Test/SampleClasses/IsExternalInit.cs
@@ -1,0 +1,7 @@
+﻿using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal class IsExternalInit { }
+}


### PR DESCRIPTION
Feature: https://ceapex.visualstudio.com/Engineering/_workitems/edit/550404

The reason why we need to add System.Runtime.CompilerServices.IsExternalInit class.
https://stackoverflow.com/questions/62648189/testing-c-sharp-9-0-in-vs2019-cs0518-isexternalinit-is-not-defined-or-imported

diffs: https://github.com/dotnet/dotnet-api-docs/commit/3d949625d64d703a68044ec4337b6aa938a55f2a