### PR TITLE
Fix the logic for shouldDelete factor

### DIFF
--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1941,7 +1941,7 @@ namespace Mono.Documentation
             // Identify all of the different states that could affect our decision to delete the member
             bool shouldPreserve = !string.IsNullOrWhiteSpace (PreserveTag);
             bool hasContent = MemberDocsHaveUserContent (member);
-            bool shouldDelete = !shouldPreserve && (delete || !hasContent);
+            bool shouldDelete = !shouldPreserve && (delete && !hasContent);
 
             bool unifiedRun = HasDroppedNamespace (type);
 


### PR DESCRIPTION
The factor of this member already has content or not takes no weight in the original logic, "(delete || !hasContent);".
If it is delete allowed mode, mdoc will delete this member anyway. 
Now it is changed to "(delete && !hasContent)" so that if the member has content already, it will not be deleted.