### PR TITLE
Fix the logic for the shouldDelete factor

### DIFF
--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -751,7 +751,7 @@ check-monodocer-attached-entities:
 
 	# now make sure it will delete a previously run/duplicated attachedproperty/property
 	cp Test/AttachedEventsAndProperties/AttachedPropertyExample.xml Test/en.actual/AttachedEventsAndProperties/
-	$(MONO) $(PROGRAM) update -o Test/en.actual Test/AttachedEventsAndProperties/bin/Release/AttachedEventsAndProperties.dll -lang docid -lang vb.net -lang fsharp -lang javascript -lang c++/cli -lang c++/cx -lang c++/winrt
+	$(MONO) $(PROGRAM) update -o Test/en.actual Test/AttachedEventsAndProperties/bin/Release/AttachedEventsAndProperties.dll --delete -lang docid -lang vb.net -lang fsharp -lang javascript -lang c++/cli -lang c++/cx -lang c++/winrt
 	$(DIFF) Test/en.expected-attached-entities Test/en.actual
 	
 Test/TestClass.dll:

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -765,7 +765,7 @@ check-monodocer-operators-work: Test/TestClass.dll
 	rm -Rf Test/en.actual
 	$(MONO) $(PROGRAM) update Test/TestClass.dll -o Test/en.actual
 	cp mdoc.Test/SampleClasses/TestClass-OldOpSig.xml Test/en.actual/mdoc.Test.SampleClasses/TestClass.xml
-	$(MONO) $(PROGRAM) update Test/TestClass.dll -o Test/en.actual
+	$(MONO) $(PROGRAM) update Test/TestClass.dll -o Test/en.actual --delete
 
 .PHONY: check-monodocer-operators
 check-monodocer-operators: check-monodocer-operators-work 

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1941,7 +1941,7 @@ namespace Mono.Documentation
             // Identify all of the different states that could affect our decision to delete the member
             bool shouldPreserve = !string.IsNullOrWhiteSpace (PreserveTag);
             bool hasContent = MemberDocsHaveUserContent (member);
-            bool shouldDelete = !shouldPreserve && (delete || !hasContent);
+            bool shouldDelete = !shouldPreserve && (delete && !hasContent);
 
             bool unifiedRun = HasDroppedNamespace (type);
 

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1939,9 +1939,11 @@ namespace Mono.Documentation
                     signature);
 
             // Identify all of the different states that could affect our decision to delete the member
+            bool duplicated = reason.Contains("Duplicate Member");
             bool shouldPreserve = !string.IsNullOrWhiteSpace (PreserveTag);
             bool hasContent = MemberDocsHaveUserContent (member);
-            bool shouldDelete = !shouldPreserve && (delete && !hasContent);
+            //When the member is NOT PRESERVED, the member has NO CONTENT or  is DUPLICATED, then it should be deleted
+            bool shouldDelete = !shouldPreserve && (delete && (!hasContent || duplicated));
 
             bool unifiedRun = HasDroppedNamespace (type);
 


### PR DESCRIPTION
The factor of this member already has content or not takes no weight in the original logic, "(delete || !hasContent);".

If it is delete allowed mode, mdoc will delete this member anyway.

Now it is changed to "(delete && !hasContent)" so that if the member has content already, it will not be deleted.