### PR TITLE
[MDocUpdater] Fix assembly info duplication

### DIFF
--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -988,7 +988,7 @@ namespace Mono.Documentation
             AssemblyNameDefinition name = assembly.Name;
             if (name.HasPublicKey)
             {
-                XmlElement pubkey = parent.OwnerDocument.CreateElement ("AssemblyPublicKey");
+                XmlElement pubkey = WriteElement (index_assembly, "AssemblyPublicKey");
                 var key = new StringBuilder (name.PublicKey.Length * 3 + 2);
                 key.Append ("[");
                 foreach (byte b in name.PublicKey)
@@ -1000,7 +1000,7 @@ namespace Mono.Documentation
 
             if (!string.IsNullOrEmpty (name.Culture))
             {
-                XmlElement culture = parent.OwnerDocument.CreateElement ("AssemblyCulture");
+                XmlElement culture = WriteElement (index_assembly, "AssemblyCulture");
                 culture.InnerText = name.Culture;
                 index_assembly.AppendChild (culture);
             }


### PR DESCRIPTION
The `AssemblyPublicKey` and `AssemblyCulture` elements will be added to
to a docs `index.xml` file every time the tool runs, even if the element
already exists.  Fix this by using `MDocUpdater.WriteElement` to write
these elements, as it will first check for an existing element rather
than always creating a new one.