### PR TITLE
[mdoc] Multitarget net471 and net6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,10 @@
 <Project>
   <PropertyGroup>
     <NuGetVersionFSharpCore>4.3.4</NuGetVersionFSharpCore>
-    <NuGetVersionMonoCecil>0.10.0-beta5</NuGetVersionMonoCecil>
+    <NuGetVersionMonoCecil>0.10.0</NuGetVersionMonoCecil>
     <NuGetVersionNUnit>3.10.1</NuGetVersionNUnit>
-    <NuGetVersionNUnit3TestAdapter>3.13.0</NuGetVersionNUnit3TestAdapter>
+    <NuGetVersionNUnit3TestAdapter>3.17.0</NuGetVersionNUnit3TestAdapter>
+    <NuGetVersionMicrosoftNETTestSdk>16.11.0</NuGetVersionMicrosoftNETTestSdk>
     <NuGetVersionQuickIONET>2.6.2.0</NuGetVersionQuickIONET>
     <NuGetVersionSharpZipLib>1.3.3</NuGetVersionSharpZipLib>
     <NuGetVersionSystemConfigurationConfigurationManager>6.0.0</NuGetVersionSystemConfigurationConfigurationManager>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-MSBUILD = msbuild
 CONFIGURATION = Release
 BIN = bin/$(CONFIGURATION)
 MDOC = $(BIN)/mdoc.exe
@@ -9,15 +8,15 @@ all: build
 build: $(MDOC)
 
 $(MDOC):
-	$(MSBUILD) apidoctools.sln /p:Configuration=$(CONFIGURATION);
+	dotnet build -v:n apidoctools.sln /p:Configuration=$(CONFIGURATION)
 
 prepare:
 	git submodule update --init --recursive
-	nuget restore apidoctools.sln
+	dotnet restore apidoctools.sln
 	nuget install NUnit.Console -version 3.6.0 -NoCache -o packages
 
 clean:
-	#$(MSBUILD) apidoctools.sln /t:clean
+	dotnet build -v:n apidoctools.sln /t:clean /p:Configuration=$(CONFIGURATION)
 	rm -rf bin/$(CONFIGURATION)
 
 check: build check-monodoc check-mdoc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,18 +95,25 @@ stages:
     - task: NuGetToolInstaller@1
       displayName: Install NuGet Tool
 
-    - task: Bash@3
-      displayName: Run Unit and Integration Tests
-      inputs:
-        targetType: 'inline'
-        script: 'make prepare all check CONFIGURATION=$(buildConfiguration)'
-
     - task: UseDotNet@2
       displayName: 'Use .NET Core sdk'
       inputs:
         packageType: sdk
         version: 2.1.x
         installationPath: $(Agent.ToolsDirectory)/dotnet
+
+    - task: UseDotNet@2
+      displayName: 'Use .NET 6.0.x'
+      inputs:
+        packageType: sdk
+        version: 6.0.x
+        installationPath: $(Agent.ToolsDirectory)/dotnet
+
+    - task: Bash@3
+      displayName: Run Unit and Integration Tests
+      inputs:
+        targetType: 'inline'
+        script: 'make prepare all check CONFIGURATION=$(buildConfiguration)'
 
     - task: EsrpCodeSigning@1
       displayName: Sign executable and dll files

--- a/mdoc/Makefile
+++ b/mdoc/Makefile
@@ -61,6 +61,9 @@ cleanup:
 nunit: 
 	mono ../packages/NUnit.ConsoleRunner.3.6.0/tools/nunit3-console.exe mdoc.Test/bin/$(CONFIGURATION)/mdoc.Test.dll
 
+dotnet-test:
+	dotnet test mdoc.Test/bin/$(CONFIGURATION)-net6.0/mdoc.Test.dll
+
 Test/DocTest-VB-Eii.dll:
 	$(VBCOMPILE) -out:Test/DocTest-VB-Eii.dll  Test/ClassEnumerator.vb
 	
@@ -960,5 +963,5 @@ check-doc-tools-update: check-monodocer-since-update \
 	check-mdoc-export-msxdoc-update \
 	check-mdoc-validate-update 
 
-check: nunit check-doc-tools
+check: nunit dotnet-test check-doc-tools
 	@echo "mdoc Tests Complete!"

--- a/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/MDocResolver.cs
@@ -564,6 +564,10 @@ namespace Mono.Documentation.Updater.Frameworks
 
         internal AssemblyDefinition GetAssemblyInGac(AssemblyNameReference reference, ReaderParameters parameters)
         {
+#if NETCOREAPP
+            return null;
+#endif //NETCOREAPP
+
             if (reference.PublicKeyToken == null || reference.PublicKeyToken.Length == 0)
                 return null;
 

--- a/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples.xml
+++ b/mdoc/Test/en.expected-fsharp/PatternMatching/PatternMatchingExamples.xml
@@ -161,9 +161,9 @@
       </Docs>
     </Member>
     <Member MemberName="detectZeroTuple">
-      <MemberSignature Language="C#" Value="public static void detectZeroTuple (int point_0, int point_1);" />
-      <MemberSignature Language="ILAsm" Value=".method public static void detectZeroTuple(int32 point_0, int32 point_1) cil managed" />
-      <MemberSignature Language="F#" Value="PatternMatching.PatternMatchingExamples.detectZeroTuple : int * int -&gt; unit" Usage="PatternMatching.PatternMatchingExamples.detectZeroTuple (point_0, point_1)" />
+      <MemberSignature Language="C#" Value="public static void detectZeroTuple (int var1, int var2);" />
+      <MemberSignature Language="ILAsm" Value=".method public static void detectZeroTuple(int32 var1, int32 var2) cil managed" />
+      <MemberSignature Language="F#" Value="PatternMatching.PatternMatchingExamples.detectZeroTuple : int * int -&gt; unit" Usage="PatternMatching.PatternMatchingExamples.detectZeroTuple (var1, var2)" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -172,12 +172,12 @@
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
       <Parameters>
-        <Parameter Name="point_0" Type="System.Int32" />
-        <Parameter Name="point_1" Type="System.Int32" />
+        <Parameter Name="var1" Type="System.Int32" />
+        <Parameter Name="var2" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="point_0">To be added.</param>
-        <param name="point_1">To be added.</param>
+        <param name="var1">To be added.</param>
+        <param name="var2">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>
@@ -226,9 +226,9 @@
       </Docs>
     </Member>
     <Member MemberName="function1">
-      <MemberSignature Language="C#" Value="public static void function1 (int x_0, int x_1);" />
-      <MemberSignature Language="ILAsm" Value=".method public static void function1(int32 x_0, int32 x_1) cil managed" />
-      <MemberSignature Language="F#" Value="PatternMatching.PatternMatchingExamples.function1 : int * int -&gt; unit" Usage="PatternMatching.PatternMatchingExamples.function1 (x_0, x_1)" />
+      <MemberSignature Language="C#" Value="public static void function1 (int var1, int var2);" />
+      <MemberSignature Language="ILAsm" Value=".method public static void function1(int32 var1, int32 var2) cil managed" />
+      <MemberSignature Language="F#" Value="PatternMatching.PatternMatchingExamples.function1 : int * int -&gt; unit" Usage="PatternMatching.PatternMatchingExamples.function1 (var1, var2)" />
       <MemberType>Method</MemberType>
       <AssemblyInfo>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
@@ -237,12 +237,12 @@
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
       <Parameters>
-        <Parameter Name="x_0" Type="System.Int32" />
-        <Parameter Name="x_1" Type="System.Int32" />
+        <Parameter Name="var1" Type="System.Int32" />
+        <Parameter Name="var2" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="x_0">To be added.</param>
-        <param name="x_1">To be added.</param>
+        <param name="var1">To be added.</param>
+        <param name="var2">To be added.</param>
         <summary>To be added.</summary>
         <remarks>To be added.</remarks>
       </Docs>

--- a/mdoc/Test/en.expected-fsharp/index.xml
+++ b/mdoc/Test/en.expected-fsharp/index.xml
@@ -36,9 +36,6 @@
           <AttributeName>System.Reflection.AssemblyTrademark("")</AttributeName>
         </Attribute>
         <Attribute>
-          <AttributeName>System.Reflection.AssemblyVersion("1.0.0.0")</AttributeName>
-        </Attribute>
-        <Attribute>
           <AttributeName>System.Runtime.InteropServices.ComVisible(false)</AttributeName>
         </Attribute>
         <Attribute>

--- a/mdoc/mdoc.Test/CppCxFormatterMembersTests.cs
+++ b/mdoc/mdoc.Test/CppCxFormatterMembersTests.cs
@@ -1,11 +1,14 @@
 ﻿using mdoc.Test.SampleClasses;
 using Mono.Documentation.Updater.Formatters.CppFormatters;
-using Mono_DocTest;
 using NUnit.Framework;
+#if !NETCOREAPP
+using Mono_DocTest;
 using Cpp = Mono_DocTest_Generic;
+#endif // !NETCOREAPP
 
 namespace mdoc.Test
 {
+#if !NETCOREAPP
     [TestFixture]
     [Category("CppCx")]
     public class CppCxFormatterMembersTests : BasicFormatterTests<CppCxFullMemberFormatter>
@@ -194,6 +197,7 @@ namespace mdoc.Test
             TestMethodSignature(typeof(Cpp.GenericBase<>), null, "BaseMethod2");
         }
     }
+#endif //!NETCOREAPP
 
 }
 

--- a/mdoc/mdoc.Test/CppCxFormatterTypesTests.cs
+++ b/mdoc/mdoc.Test/CppCxFormatterTypesTests.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using Mono.Cecil;
 using Mono.Documentation.Updater.Formatters.CppFormatters;
+#if !NETCOREAPP
 using Mono_DocTest;
 using Mono_DocTest_Generic;
+#endif //!NETCOREAPP
 using NUnit.Framework;
 
 namespace mdoc.Test
 {
+#if !NETCOREAPP
+
     [TestFixture]
     [Category("CppCx")]
     public class CppCxFormatterTypesTests : BasicFormatterTests<CppCxMemberFormatter>
@@ -259,5 +263,8 @@ namespace mdoc.Test
             moduleCash.Clear();
         }
     }
+
+#endif //!NETCOREAPP
+
 }
 

--- a/mdoc/mdoc.Test/CppFormatterTests.cs
+++ b/mdoc/mdoc.Test/CppFormatterTests.cs
@@ -2,11 +2,14 @@
 using Mono.Cecil;
 using NUnit.Framework;
 using Mono.Documentation.Updater.Formatters.CppFormatters;
+#if !NETCOREAPP
 using Mono_DocTest_Generic;
 using Mono_DocTest;
+#endif //!NETCOREAPP
 
 namespace mdoc.Test
 {
+#if !NETCOREAPP
     public class CppFormatterTests : BasicFormatterTests<CppMemberFormatter>
     {
         #region Types
@@ -191,4 +194,6 @@ public ref class MyList1 : Mono_DocTest_Generic::GenericBase<System::Collections
         }
 
     }
+#endif //!NETCOREAPP
+
 }

--- a/mdoc/mdoc.Test/CppFullFormatterTests.cs
+++ b/mdoc/mdoc.Test/CppFullFormatterTests.cs
@@ -2,12 +2,15 @@
 using Mono.Cecil;
 using NUnit.Framework;
 using Mono.Documentation.Updater.Formatters.CppFormatters;
+#if !NETCOREAPP
 using Mono_DocTest_Generic;
 using Cpp=Mono_DocTest_Generic;
 using Mono_DocTest;
+#endif //!NETCOREAPP
 
 namespace mdoc.Test
 {
+#if !NETCOREAPP
     public class CppFullFormatterTests: BasicFormatterTests<CppFullMemberFormatter>
     {
         private static readonly CppFullMemberFormatter cppFullMemberFormatter = new CppFullMemberFormatter();
@@ -327,4 +330,6 @@ generic <typename T>
             return tref;
         }
     }
+#endif //!NETCOREAPP
+
 }

--- a/mdoc/mdoc.Test/CppWinRtFormatterTests.cs
+++ b/mdoc/mdoc.Test/CppWinRtFormatterTests.cs
@@ -1,12 +1,15 @@
 ﻿using System;
 using Mono.Cecil;
 using Mono.Documentation.Updater.Formatters.CppFormatters;
+#if !NETCOREAPP
 using Mono_DocTest;
 using Mono_DocTest_Generic;
+#endif //!NETCOREAPP
 using NUnit.Framework;
 
 namespace mdoc.Test
 {
+#if !NETCOREAPP
     [TestFixture]
     public class CppWinRtFormatterTests : BasicFormatterTests<CppWinRtMemberFormatter>
     {
@@ -208,4 +211,6 @@ class Widget : Mono_DocTest::IProcess");
             TestTypeSignature(CSharpTestLib, "Mono.DocTest.Widget/NestedClass", null);
         }
     }
+#endif //!NETCOREAPP
+
 }

--- a/mdoc/mdoc.Test/CppWinRtMembersTests.cs
+++ b/mdoc/mdoc.Test/CppWinRtMembersTests.cs
@@ -1,11 +1,14 @@
 ﻿using mdoc.Test.SampleClasses;
 using Mono.Documentation.Updater.Formatters.CppFormatters;
-using Mono_DocTest;
 using NUnit.Framework;
+#if !NETCOREAPP
+using Mono_DocTest;
 using Cpp = Mono_DocTest_Generic;
+#endif //!NETCOREAPP
 
 namespace mdoc.Test
 {
+#if !NETCOREAPP
     [TestFixture]
     public class CppWinRtMembersTests: BasicFormatterTests<CppWinRtFullMemberFormatter>
     {
@@ -181,4 +184,6 @@ void LongProperty(long __set_formal);");
                 nameof(Cpp.GenericBase<int>.ConstDecimal));
 #endregion
     }
+#endif //!NETCOREAPP
+
 }

--- a/mdoc/mdoc.Test/Enumeration/AttachedEntityTests.cs
+++ b/mdoc/mdoc.Test/Enumeration/AttachedEntityTests.cs
@@ -1,11 +1,14 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Linq;
+#if !NETCOREAPP
 using Windows.UI.Xaml;
+#endif //!NETCOREAPP
 using Mono.Documentation.Util;
 using Mono.Documentation.Updater;
 using Mono.Documentation.Updater.Formatters;
 
+#if !NETCOREAPP
 namespace mdoc.Test.Enumeration
 {
     [TestFixture]
@@ -167,3 +170,4 @@ namespace mdoc.Test.Enumeration
         }
     }
 }
+#endif //!NETCOREAPP

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -322,14 +322,20 @@ namespace mdoc.Test
             Object[] parametors1 = new Object[] { member, sig };
             mInfo1.Invoke(null, parametors1);
             sig = (string)parametors1[1];
-            Assert.AreEqual("3.1415926535897931", sig);
+            var piValue = "3.1415926535897931";
+
+#if NETCOREAPP
+            piValue = "3.141592653589793";
+#endif //NETCOREAPP
+
+            Assert.AreEqual(piValue, sig);
           
             Type type2 = typeof(ILFullMemberFormatter);
             sig = "";
             MethodInfo mInfo2 = type2.GetMethod("AppendFieldValue", flags);
             Object[] parametors2 = new Object[] { new StringBuilder(), member};
             sig = mInfo2.Invoke(null, parametors2).ToString();
-            Assert.AreEqual(" = (3.1415926535897931)", sig);
+            Assert.AreEqual($" = ({piValue})", sig);
  
             Type type3 = typeof(DocUtils);
             sig = "";                      
@@ -337,14 +343,14 @@ namespace mdoc.Test
             Object[] parametors3 = new Object[] { new StringBuilder(), member };
             mInfo3.Invoke(null, parametors3);
             sig = parametors3[0].ToString();
-            Assert.AreEqual(" = 3.1415926535897931", sig);
+            Assert.AreEqual($" = {piValue}", sig);
  
             Type type4 = typeof(CppFullMemberFormatter);
             sig = "";
             MethodInfo mInfo4 = type4.GetMethod("AppendFieldValue", flags);
             Object[] parametors4 = new Object[] { new StringBuilder(), member };
             sig = mInfo4.Invoke(null, parametors4).ToString();
-            Assert.AreEqual(" = 3.1415926535897931", sig);
+            Assert.AreEqual($" = {piValue}", sig);
         }
 
         [Test]
@@ -370,7 +376,13 @@ namespace mdoc.Test
         [Test]
         public void MissSignature()
         {
-            var member1 = GetMethod(typeof(System.IO.FileStream), m => m.FullName == "System.Void System.IO.FileStream::.ctor(System.String,System.IO.FileMode,System.Security.AccessControl.FileSystemRights,System.IO.FileShare,System.Int32,System.IO.FileOptions,System.Security.AccessControl.FileSecurity)"); ;
+            var fileStreamSig = "System.Void System.IO.FileStream::.ctor(System.String,System.IO.FileMode,System.Security.AccessControl.FileSystemRights,System.IO.FileShare,System.Int32,System.IO.FileOptions,System.Security.AccessControl.FileSecurity)";
+
+#if NETCOREAPP
+            fileStreamSig = "System.Void System.IO.FileStream::.ctor(System.String,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,System.Int32,System.IO.FileOptions)";
+#endif //NETCOREAPP
+
+            var member1 = GetMethod(typeof(System.IO.FileStream), m => m.FullName == fileStreamSig);
             var fomatter1 = new VBMemberFormatter();
             // Original return null
             var sig1 = fomatter1.GetDeclaration(member1);

--- a/mdoc/mdoc.Test/MDocUpdaterTests.cs
+++ b/mdoc/mdoc.Test/MDocUpdaterTests.cs
@@ -10,7 +10,9 @@ using Mono.Documentation.Updater;
 using Mono.Documentation.Updater.Formatters;
 using Mono.Documentation.Updater.Frameworks;
 using NUnit.Framework;
+#if !NETCOREAPP
 using Cpp = Mono_DocTest_Generic;
+#endif //!NETCOREAPP
 
 namespace mdoc.Test
 {
@@ -39,6 +41,7 @@ namespace mdoc.Test
             Assert.IsNull(GetNativeIntegerAttr(method.Parameters[2]));
         }
 
+#if !NETCOREAPP
         [Test]
         public void Test_GetDocParameterType_CppGenericParameterType_ReturnsTypeWithGenericParameters()
         {
@@ -48,6 +51,7 @@ namespace mdoc.Test
 
             Assert.AreEqual("Mono_DocTest_Generic.GenericBase<U>", parameterType);
         }
+#endif //!NETCOREAPP
 
         [TestCase("UnsafeCombine", "delegate*<T1, T2, R>")]
         [TestCase("UnsafeCombineOverload", "delegate*<System.IntPtr, System.UIntPtr, R>")]

--- a/mdoc/mdoc.Test/mdoc.Test.csproj
+++ b/mdoc/mdoc.Test/mdoc.Test.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFrameworks>net471;net6.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
     <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>bin\Release</OutputPath>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup>
     <RunPostBuildEvent>Always</RunPostBuildEvent>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
-  <ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
+    <OutputPath>bin\$(Configuration)</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net471' ">
+    <OutputPath>bin\$(Configuration)-$(TargetFramework)</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <Reference Include="mdoc.Test.Cplusplus, Version=1.0.6709.28740, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\external\Test\mdoc.Test.Cplusplus.dll</HintPath>
@@ -37,10 +37,14 @@
       <HintPath>..\..\external\Windows\Windows.Foundation.UniversalApiContract.winmd</HintPath>
     </Reference>
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="$(NuGetVersionMonoCecil)" />
     <PackageReference Include="NUnit" Version="$(NuGetVersionNUnit)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(NuGetVersionMicrosoftNETTestSdk)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="$(NuGetVersionNUnit3TestAdapter)" />
   </ItemGroup>
+
   <ItemGroup>
     <None Update="cppcli\cppcli\cppcli.h">
       <Link>SampleClasses\cppcli.h</Link>

--- a/mdoc/mdoc.csproj
+++ b/mdoc/mdoc.csproj
@@ -1,11 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFrameworks>net471;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <OutputPath>$(MSBuildThisFileDirectory)..\bin\$(Configuration)</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net471' ">
+    <OutputPath>$(MSBuildThisFileDirectory)..\bin\$(Configuration)-$(TargetFramework)</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -14,6 +14,7 @@
     <tags>mdoc documentation ecmaxml dotnet .net C# F# VB.NET</tags>
   </metadata>
   <files>
-    <file src="..\bin\Release\*.*" target="tools" />
+    <file src="..\bin\Release\*.*" target="tools\net471\" />
+    <file src="..\bin\Release-net6.0\*.*" target="tools\net6.0\" />
   </files>
 </package>


### PR DESCRIPTION
Adds `net6.0` as a target framework to mdoc.  The artifacts from the
`net6.0` build will be output to `bin/$(Configuration)-net6.0`.

Mono.Cecil has been bumped from `0.10.0-beta5` to `0.10.0`.  This update
appears to have introduced a change in behavior in F# doc generation,
and the expected output in `PatternMatchingExamples.xml` has been
updated to reflect that.

The mdoc NuGet package has been updated to include both `net471` and
`net6.0` tools.  This can be considered a breaking change, as the path
of mdoc.exe has been changed to include a folder named after its target
framework.