### PR TITLE
Fix 662735: Members with user edited docs will not be deleted

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
     public static class Consts
     {
-        public static string MonoVersion = "5.8.9.2";
+        public static string MonoVersion = "5.9.0";
         public const string DocId = "DocId";
         public const string CppCli = "C++ CLI";
         public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1550,7 +1550,7 @@ namespace Mono.Documentation
                 bool isprivateeii = !IsMemberNotPrivateEII(oldmember2);
                 if (oldmember2 == null || isprivateeii)
                 {
-                    if (!string.IsNullOrWhiteSpace (FrameworksPath) && !isprivateeii) // only do this check if fx mode AND it's not a private EII. If it's a private EII, we just want to delete it
+                    if (!string.IsNullOrWhiteSpace (FrameworksPath)) // only do this check if fx mode
                     {
                         // verify that this member wasn't seen in another framework and is indeed valid
                         var sigFromXml = oldmember
@@ -1939,11 +1939,9 @@ namespace Mono.Documentation
                     signature);
 
             // Identify all of the different states that could affect our decision to delete the member
-            bool duplicated = reason.Contains("Duplicate Member");
             bool shouldPreserve = !string.IsNullOrWhiteSpace (PreserveTag);
             bool hasContent = MemberDocsHaveUserContent (member);
-            //When the member is NOT PRESERVED, the member has NO CONTENT or  is DUPLICATED, then it should be deleted
-            bool shouldDelete = !shouldPreserve && (delete && (!hasContent || duplicated));
+            bool shouldDelete = !shouldPreserve && (delete || !hasContent);
 
             bool unifiedRun = HasDroppedNamespace (type);
 

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.8.9.2</version>
+    <version>5.9.0</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
revert https://github.com/mono/api-doc-tools/commit/eb7fec62c3ec4759ae178bd601564aa4f4d66ed6 and delete existing EII only if it is private in all the frameworks.