### PR TITLE
support scoped keyword in method parameters

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -608,6 +608,13 @@ namespace Mono.Documentation.Updater.Formatters
             TypeReference parameterType = parameter.ParameterType;
             var refType = new BitArray(3);
 
+            if (parameter.HasCustomAttributes)
+            {
+                var isScoped = parameter.CustomAttributes.Any(ca => ca.AttributeType.Name == "LifetimeAnnotationAttribute");
+                if (isScoped)
+                    buf.AppendFormat("scoped ");
+            }
+
             if (parameterType is RequiredModifierType requiredModifierType)
             {
                 switch(requiredModifierType.ModifierType.FullName)

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -271,6 +271,15 @@ namespace mdoc.Test
             Assert.AreEqual(expectedSignature, actualSignature);
         }
 
+        [TestCase(typeof(SomeClass), "TestScopedKeyword", "public ref T TestScopedKeyword<T> (scoped in T p1, out T p2, scoped ref T p3);")]
+        public void CSharpScopeParamTest(Type type, string methodName, string expectedSignature)
+        {
+            var member = GetMethod(type, m => m.Name == methodName);
+            var actualSignature = formatter.GetDeclaration(member);
+            Assert.AreEqual(expectedSignature, actualSignature);
+        }
+
+
         [TestCase(typeof(ReadonlyRefClass), "RefProperty", "public ref int RefProperty { get; }")]
         [TestCase(typeof(ReadonlyRefClass), "Item", "public ref readonly int this[int index] { get; }")]
         [TestCase(typeof(GenericRefClass<>), "RefProperty", "public ref T RefProperty { get; }")]

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -271,8 +271,8 @@ namespace mdoc.Test
             Assert.AreEqual(expectedSignature, actualSignature);
         }
 
-        [TestCase(typeof(SomeClass), "TestScopedKeyword", "public ref T TestScopedKeyword<T> (scoped in T p1, out T p2, scoped ref T p3);")]
-        public void CSharpScopeParamTest(Type type, string methodName, string expectedSignature)
+        [TestCase(typeof(SomeClass), "TestScopedParams", "public ref T TestScopedParams<T> (scoped in T p1, out T p2, scoped ref T p3);")]
+        public void CSharpScopedParamsTest(Type type, string methodName, string expectedSignature)
         {
             var member = GetMethod(type, m => m.Name == methodName);
             var actualSignature = formatter.GetDeclaration(member);

--- a/mdoc/mdoc.Test/SampleClasses/SomeClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/SomeClass.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Mono.Cecil.Cil;
+using System;
 using Windows.Foundation.Metadata;
 
 namespace mdoc.Test.SampleClasses
@@ -96,6 +97,11 @@ namespace mdoc.Test.SampleClasses
 
         public void get_Method()
         {
+        }
+
+        public ref T TestScopedKeyword<T>(scoped in T p1, scoped out T p2, scoped ref T p3)
+        {
+            throw new PlatformNotSupportedException();
         }
 
         public event EventHandler<object> AppMemoryUsageIncreased;

--- a/mdoc/mdoc.Test/SampleClasses/SomeClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/SomeClass.cs
@@ -99,7 +99,7 @@ namespace mdoc.Test.SampleClasses
         {
         }
 
-        public ref T TestScopedKeyword<T>(scoped in T p1, scoped out T p2, scoped ref T p3)
+        public ref T TestScopedParams<T>(scoped in T p1, scoped out T p2, scoped ref T p3)
         {
             throw new PlatformNotSupportedException();
         }

--- a/mdoc/mdoc.Test/mdoc.Test.csproj
+++ b/mdoc/mdoc.Test/mdoc.Test.csproj
@@ -8,11 +8,11 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\Debug</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release</OutputPath>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RunPostBuildEvent>Always</RunPostBuildEvent>


### PR DESCRIPTION
"scoped" keyword can be add before "in/ref" modifier in parameter declaration of method. Details can be referred: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/declarations#scoped-ref 