### PR TITLE
bump Mdoc to 5.9.2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Debug
 /mdoc/mdoc.Test/UwpTestWinRtComponentCpp/x64/Release
 /mdoc.Test.Cplusplus/x64/Release
 /x64/Release/UwpTestWinRtComponentCpp
+/mdoc/Properties/launchSettings.json

--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
     public static class Consts
     {
-        public static string MonoVersion = "5.9.2.2";
+        public static string MonoVersion = "5.9.2.3";
         public const string DocId = "DocId";
         public const string CppCli = "C++ CLI";
         public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/Updater/DocUtils.cs
+++ b/mdoc/Mono.Documentation/Updater/DocUtils.cs
@@ -323,7 +323,7 @@ namespace Mono.Documentation.Updater
                 {
                     if (nchild == null) continue;
 
-                    if (nchild is XmlComment || nchild is XmlText || nchild is XmlCDataSection)
+                    if (nchild is XmlComment || nchild is XmlText || nchild is XmlCDataSection || nchild.Name == "include")
                     {
                         nchild.ParentNode.RemoveChild(nchild);
                         removed = true;

--- a/mdoc/mdoc.csproj
+++ b/mdoc/mdoc.csproj
@@ -7,6 +7,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.9.2.2</version>
+    <version>5.9.2.3</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
No diffs for dotnet-api-docs.
Diffs are expected for azure-docs-sdk-dotnet.
https://github.com/Azure/azure-docs-sdk-dotnet/compare/692fbc08806b6a2172a9736f078af4423511c826...0e84cfab4804fa11b3f2a997a8534592d9457dc8/