### PR TITLE
keep the latest inheritdoc only

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
     public static class Consts
     {
-        public static string MonoVersion = "5.9.3";
+        public static string MonoVersion = "5.9.3.1";
         public const string DocId = "DocId";
         public const string CppCli = "C++ CLI";
         public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/Updater/MsxdocDocumentationImporter.cs
+++ b/mdoc/Mono.Documentation/Updater/MsxdocDocumentationImporter.cs
@@ -73,8 +73,10 @@ namespace Mono.Documentation.Updater
                 if (DocUtils.NeedsOverwrite(e["returns"]))
                     MDocUpdater.ClearElement(e, "returns");
             }
-            
-            
+            if (elem.SelectSingleNode("inheritdoc") != null)
+                MDocUpdater.ClearElement(e, "inheritdoc");
+
+
 
             foreach (XmlNode child in elem.ChildNodes)
             {

--- a/mdoc/Mono.Documentation/Updater/MsxdocDocumentationImporter.cs
+++ b/mdoc/Mono.Documentation/Updater/MsxdocDocumentationImporter.cs
@@ -76,8 +76,6 @@ namespace Mono.Documentation.Updater
             if (elem.SelectSingleNode("inheritdoc") != null)
                 MDocUpdater.ClearElement(e, "inheritdoc");
 
-
-
             foreach (XmlNode child in elem.ChildNodes)
             {
                 switch (child.Name)

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.9.3</version>
+    <version>5.9.3.1</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
CI Pipeline: https://ceapex.visualstudio.com/Engineering/_build/results?buildId=1695391&view=results

step 1. get Microsoft.Data.SqlClient.dll and Microsoft.Data.SqlClient.xml from package: https://apidrop.visualstudio.com/Content%20CI/_artifacts/feed/DocsReferenceCISource@Local/NuGet/Microsoft.Data.SqlClient/overview/5.2.0-build.24045.1-94b4384(https://apidrop.visualstudio.com/Content%20CI/_artifacts/feed/DocsReferenceCISource/NuGet/Microsoft.Data.SqlClient/overview/5.2.0-build.24045.1-94b4384)
the original inheritdoc in Microsoft.Data.SqlClient.xml as below.
![image](https://github.com/mono/api-doc-tools/assets/134926504/bb441039-fa66-469a-9eb8-2b96f1e294c7)

step 2. generate SqlBatch.xml, the generated inheritdoc as below.
![image](https://github.com/mono/api-doc-tools/assets/134926504/df5ffc7b-a20f-4abe-a33d-a69c63ba14df)

step 3. change inheritdoc to be like below.
![image](https://github.com/mono/api-doc-tools/assets/134926504/a8ab6fad-dd86-485d-b6e6-b429d4e989ed)

step 4. generate SqlBatch.xml, the generated inheritdoc as below.
![image](https://github.com/mono/api-doc-tools/assets/134926504/3c412d54-dc72-4af1-8be4-d0476dc9e342)

step 5. change inheritdoc again to be like below.
![image](https://github.com/mono/api-doc-tools/assets/134926504/537e0a9d-1e4f-4345-b3d8-4b61412ff61b)

step 6. generate SqlBatch.xml, the generated inheritdoc as below.
![image](https://github.com/mono/api-doc-tools/assets/134926504/ec188b0e-18da-4f40-8a72-53b7dafa4819)

the result is expected : changed inheritdoc in source xml and generated it to target xml multiple times, only the latest one can  show in target.



