### PR TITLE
Fix bug [966887] : FrameworksIndex files not cleaned up

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
     public static class Consts
     {
-        public static string MonoVersion = "5.9.3.1";
+        public static string MonoVersion = "5.9.3.2";
         public const string DocId = "DocId";
         public const string CppCli = "C++ CLI";
         public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1421,15 +1421,16 @@ namespace Mono.Documentation
         {
             var assemblyNames = assemblies.ToDictionary(item => item.Name, item => item);
             var indexFolder = Path.Combine(dest, "FrameworksIndex");
-            if (Directory.Exists(indexFolder))
+            if (!Directory.Exists(indexFolder))
             {
-                var files = Directory.GetFiles(indexFolder);
-                foreach (var file in files)
+                return;
+            }
+            var files = Directory.GetFiles(indexFolder);
+            foreach (var file in files)
+            {
+                if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
                 {
-                    if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
-                    {
-                        File.Delete(file);
-                    }
+                    File.Delete(file);
                 }
             }
         }

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1102,7 +1102,8 @@ namespace Mono.Documentation
 
             SortIndexEntries (index_types);
 
-            CleanupFiles (dest, goodfiles);
+            CleanupFiles (dest, goodfiles); 
+            CleanupFrameworksIndex(dest, this.assemblies);
             CleanupIndexTypes (index_types, goodfiles);
             CleanupExtensions (index_types);
 
@@ -1412,6 +1413,19 @@ namespace Mono.Documentation
                             }
                         }
                     }
+                }
+            }
+        }
+
+        private static void CleanupFrameworksIndex(string dest, List<AssemblySet> assemblies)
+        {
+            var assemblyNames = assemblies.ToDictionary(item => item.Name, item => item);
+            var files = Directory.GetFiles(Path.Combine(dest, "FrameworksIndex"));
+            foreach (var file in files)
+            {
+                if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
+                {
+                    File.Delete(file);
                 }
             }
         }

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1420,10 +1420,10 @@ namespace Mono.Documentation
         private static void CleanupFrameworksIndex(string dest, List<AssemblySet> assemblies)
         {
             var assemblyNames = assemblies.ToDictionary(item => item.Name, item => item);
-            var indoxFolder = Path.Combine(dest, "FrameworksIndex");
-            if (Directory.Exists(indoxFolder))
+            var indexFolder = Path.Combine(dest, "FrameworksIndex");
+            if (Directory.Exists(indexFolder))
             {
-                var files = Directory.GetFiles(indoxFolder);
+                var files = Directory.GetFiles(indexFolder);
                 foreach (var file in files)
                 {
                     if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1420,12 +1420,16 @@ namespace Mono.Documentation
         private static void CleanupFrameworksIndex(string dest, List<AssemblySet> assemblies)
         {
             var assemblyNames = assemblies.ToDictionary(item => item.Name, item => item);
-            var files = Directory.GetFiles(Path.Combine(dest, "FrameworksIndex"));
-            foreach (var file in files)
+            var indoxFolder = Path.Combine(dest, "FrameworksIndex");
+            if (Directory.Exists(indoxFolder))
             {
-                if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
+                var files = Directory.GetFiles(indoxFolder);
+                foreach (var file in files)
                 {
-                    File.Delete(file);
+                    if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
+                    {
+                        File.Delete(file);
+                    }
                 }
             }
         }

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1102,8 +1102,7 @@ namespace Mono.Documentation
 
             SortIndexEntries (index_types);
 
-            CleanupFiles (dest, goodfiles); 
-            CleanupFrameworksIndex(dest, this.assemblies);
+            CleanupFiles (dest, goodfiles);
             CleanupIndexTypes (index_types, goodfiles);
             CleanupExtensions (index_types);
 
@@ -1413,24 +1412,6 @@ namespace Mono.Documentation
                             }
                         }
                     }
-                }
-            }
-        }
-
-        private static void CleanupFrameworksIndex(string dest, List<AssemblySet> assemblies)
-        {
-            var assemblyNames = assemblies.ToDictionary(item => item.Name, item => item);
-            var indexFolder = Path.Combine(dest, "FrameworksIndex");
-            if (!Directory.Exists(indexFolder))
-            {
-                return;
-            }
-            var files = Directory.GetFiles(indexFolder);
-            foreach (var file in files)
-            {
-                if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
-                {
-                    File.Delete(file);
                 }
             }
         }

--- a/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
@@ -86,12 +86,22 @@ namespace Mono.Documentation.Updater.Frameworks
 			if (string.IsNullOrWhiteSpace (this.path))
 				return;
 			
-      string outputPath = Path.Combine (path, Consts.FrameworksIndex);
+            string outputPath = Path.Combine (path, Consts.FrameworksIndex);
 
 			if (!Directory.Exists (outputPath))
 				Directory.CreateDirectory (outputPath);
 
-			foreach (var fx in this.frameworks)
+            var files = Directory.GetFiles(outputPath); 
+            var assemblyNames = frameworks.ToDictionary(item => item.Name, item => item);
+            foreach (var file in files)
+            {
+                if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
+                {
+                    File.Delete(file);
+                }
+            }
+
+            foreach (var fx in this.frameworks)
 			{
 				XElement frameworkElement = new XElement("Framework", new XAttribute("Name", fx.Name));
 				XDocument doc = new XDocument(

--- a/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
@@ -91,8 +91,6 @@ namespace Mono.Documentation.Updater.Frameworks
 			if (!Directory.Exists (outputPath))
 				Directory.CreateDirectory (outputPath);
 
-            CleanupFrameworksIndex(outputPath);
-
             foreach (var fx in this.frameworks)
 			{
 				XElement frameworkElement = new XElement("Framework", new XAttribute("Name", fx.Name));
@@ -141,15 +139,16 @@ namespace Mono.Documentation.Updater.Frameworks
 					doc.WriteTo (writer);
 				}
 			}
-		}
+            CleanupFrameworksIndex(outputPath);
+        }
 
         private void CleanupFrameworksIndex(string outputPath)
         {
             var files = Directory.GetFiles(outputPath); 
-            var assemblyNames = frameworks.ToDictionary(item => item.Name, item => item);
+            var frameworkNames = frameworks.ToDictionary(item => item.Name, item => item);
             foreach (var file in files)
             {
-                if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
+                if (!frameworkNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
                 {
                     File.Delete(file);
                 }

--- a/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
+++ b/mdoc/Mono.Documentation/Updater/Frameworks/FrameworkIndex.cs
@@ -91,15 +91,7 @@ namespace Mono.Documentation.Updater.Frameworks
 			if (!Directory.Exists (outputPath))
 				Directory.CreateDirectory (outputPath);
 
-            var files = Directory.GetFiles(outputPath); 
-            var assemblyNames = frameworks.ToDictionary(item => item.Name, item => item);
-            foreach (var file in files)
-            {
-                if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
-                {
-                    File.Delete(file);
-                }
-            }
+            CleanupFrameworksIndex(outputPath);
 
             foreach (var fx in this.frameworks)
 			{
@@ -150,5 +142,18 @@ namespace Mono.Documentation.Updater.Frameworks
 				}
 			}
 		}
-	}
+
+        private void CleanupFrameworksIndex(string outputPath)
+        {
+            var files = Directory.GetFiles(outputPath); 
+            var assemblyNames = frameworks.ToDictionary(item => item.Name, item => item);
+            foreach (var file in files)
+            {
+                if (!assemblyNames.ContainsKey(Path.GetFileNameWithoutExtension(file)))
+                {
+                    File.Delete(file);
+                }
+            }
+        }
+    }
 }

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.9.3.1</version>
+    <version>5.9.3.2</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
Fix [bug [966887]](https://dev.azure.com/ceapex/Engineering/_sprints/taskboard/Reference/Engineering/2024-05-15?workitem=966887) : FrameworksIndex files not cleaned up

The pipeline api-doc-tools-Official run successfully
https://ceapex.visualstudio.com/Engineering/_build/results?buildId=1729303&view=results

Local test steps:
1.Prepare two versions of sdk as input
```
|_aspnetcore-7.0
 |-A.dependent.dll
|_aspnetcore-8.0
 |-A.dependent.dll
```   

2.use below command to run mdoc 
`fx-bootstrap -fx "C:\xxx\input"`
After running succesfully, the input folder will generate a frameworks.xml
![image](https://github.com/mono/api-doc-tools/assets/152238243/4c6bcd1c-8700-400e-864d-df2b036a4785)     
3.use below command to run mdoc
`update -o "C:\xxx\output" -fx "C:\xxx\input" -- debug -index false -lang docid -lang vb.net -lang fsharp -L "C:\Program Files (x86)\Windows Kits\8.1\References" -L "C:\Program Files (x86)\Microsoft.NET\Primary Interop Assemblies\msdatasrc.dll" -L "C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\PublicAssemblies" -L "C:\Program Files\dotnet" --delete`
After running succefully, the output folder will generate some folder and xml. FrameworksIndex folder has generated two corresponding xml files
![image](https://github.com/mono/api-doc-tools/assets/152238243/c9c43c0c-82dd-41ab-80b1-4865ede154db)

 .
At this point, our preparations are complete.    
4.Delete a folder in the input folder, here we delete aspnetcore-7.0 to test，then execute the command in step 2.    
![image](https://github.com/mono/api-doc-tools/assets/152238243/0167ca39-2897-41ed-b0fa-700cac95828c)
5.  Execute the command in step 3,  aspnetcore-7.0.xml of output/framworksIndex was deleted.
![image](https://github.com/mono/api-doc-tools/assets/152238243/e81e0abf-9881-461a-adca-3b51447555d9)


