### PR TITLE
Remove symbols folder from frameworks.xml

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
     public static class Consts
     {
-        public static string MonoVersion = "5.9.3.2";
+        public static string MonoVersion = "5.9.3.3";
         public const string DocId = "DocId";
         public const string CppCli = "C++ CLI";
         public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/frameworksbootstrapper.cs
+++ b/mdoc/Mono.Documentation/frameworksbootstrapper.cs
@@ -40,7 +40,8 @@ namespace Mono.Documentation
 									Path = d.Substring (frameworkPath.Length + slashOffset, d.Length - frameworkPath.Length - slashOffset),
 									Name = Path.GetFileName(d)
 								})
-                                .Where (d => !d.Name.Equals ("dependencies", StringComparison.OrdinalIgnoreCase))
+                                .Where (d => !d.Name.Equals ("dependencies", StringComparison.OrdinalIgnoreCase) &&
+                                             !d.Name.Equals("symbols", StringComparison.OrdinalIgnoreCase))
                                 .OrderBy(d => d.Name)
                                 .ToArray();
 


### PR DESCRIPTION
Fix this [bug: Remove symbols folder from frameworks.xml](https://ceapex.visualstudio.com/Engineering/_workitems/edit/984993)

https://ceapex.visualstudio.com/Engineering/_build/results?buildId=1798944&view=results

before fix
![image](https://github.com/user-attachments/assets/19997290-2e95-4b6a-8102-1636cbaa8d48)

after fix
![image](https://github.com/user-attachments/assets/a1331368-ba95-4dc9-88b5-7dab0e072629)
