### PR TITLE
fix bug 990897 : [.NET] Exclude CollectionsExtensions class from Microsoft.Extensions.DependencyModel.dll in mdoc

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
     public static class Consts
     {
-        public static string MonoVersion = "5.9.3.3";
+        public static string MonoVersion = "5.9.3.4";
         public const string DocId = "DocId";
         public const string CppCli = "C++ CLI";
         public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -412,10 +412,9 @@ namespace Mono.Documentation
                                 foreach (var type in assembly.GetTypes().Where(t => DocUtils.IsPublic(t)))
                                 {
                                     var t = a.ProcessType(type, assembly);
+                                    // Workaround for https://dev.azure.com/ceapex/Engineering/_workitems/edit/990897
                                     if (t.Name == "System.Collections.Generic.CollectionExtensions" && assembly.MainModule.Name == "Microsoft.Extensions.DependencyModel.dll")
                                     {
-                                        // Workaround:
-                                        // Fix Bug 990897: [.NET] Exclude CollectionsExtensions class from Microsoft.Extensions.DependencyModel.dll in mdoc
                                         continue;
                                     }
                                     foreach (var member in type.GetMembers().Where(i => !DocUtils.IsIgnored(i) && IsMemberNotPrivateEII(i)))
@@ -1137,10 +1136,9 @@ namespace Mono.Documentation
                     continue;
 
                 var typeEntry = frameworkEntry.ProcessType (type, assembly);
+                // Workaround for https://dev.azure.com/ceapex/Engineering/_workitems/edit/990897
                 if (typeEntry.Name == "System.Collections.Generic.CollectionExtensions" && assembly.MainModule.Name == "Microsoft.Extensions.DependencyModel.dll")
                 {
-                    // Workaround:
-                    // Fix Bug 990897: [.NET] Exclude CollectionsExtensions class from Microsoft.Extensions.DependencyModel.dll in mdoc
                     continue;
                 }
                 string reltypepath = DoUpdateType (assemblySet, assembly, type, typeEntry, source, dest);

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -412,6 +412,12 @@ namespace Mono.Documentation
                                 foreach (var type in assembly.GetTypes().Where(t => DocUtils.IsPublic(t)))
                                 {
                                     var t = a.ProcessType(type, assembly);
+                                    if (t.Name == "System.Collections.Generic.CollectionExtensions" && assembly.MainModule.Name == "Microsoft.Extensions.DependencyModel.dll")
+                                    {
+                                        // Workaround:
+                                        // Fix Bug 990897: [.NET] Exclude CollectionsExtensions class from Microsoft.Extensions.DependencyModel.dll in mdoc
+                                        continue;
+                                    }
                                     foreach (var member in type.GetMembers().Where(i => !DocUtils.IsIgnored(i) && IsMemberNotPrivateEII(i)))
                                         t.ProcessMember(member);
                                 }
@@ -1131,7 +1137,12 @@ namespace Mono.Documentation
                     continue;
 
                 var typeEntry = frameworkEntry.ProcessType (type, assembly);
-
+                if (typeEntry.Name == "System.Collections.Generic.CollectionExtensions" && assembly.MainModule.Name == "Microsoft.Extensions.DependencyModel.dll")
+                {
+                    // Workaround:
+                    // Fix Bug 990897: [.NET] Exclude CollectionsExtensions class from Microsoft.Extensions.DependencyModel.dll in mdoc
+                    continue;
+                }
                 string reltypepath = DoUpdateType (assemblySet, assembly, type, typeEntry, source, dest);
                 if (reltypepath == null)
                     continue;

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -412,6 +412,7 @@ namespace Mono.Documentation
                                 foreach (var type in assembly.GetTypes().Where(t => DocUtils.IsPublic(t)))
                                 {
                                     var t = a.ProcessType(type, assembly);
+
                                     // Workaround for https://dev.azure.com/ceapex/Engineering/_workitems/edit/990897
                                     if (t.Name == "System.Collections.Generic.CollectionExtensions" && assembly.MainModule.Name == "Microsoft.Extensions.DependencyModel.dll")
                                     {
@@ -1136,6 +1137,7 @@ namespace Mono.Documentation
                     continue;
 
                 var typeEntry = frameworkEntry.ProcessType (type, assembly);
+
                 // Workaround for https://dev.azure.com/ceapex/Engineering/_workitems/edit/990897
                 if (typeEntry.Name == "System.Collections.Generic.CollectionExtensions" && assembly.MainModule.Name == "Microsoft.Extensions.DependencyModel.dll")
                 {

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.9.3.3</version>
+    <version>5.9.3.4</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/trigger-OneBranch-Buddy.yml
+++ b/trigger-OneBranch-Buddy.yml
@@ -1,8 +1,12 @@
 trigger: none
 
 pr:
-- main
-- develop
+  autoCancel: true
+  drafts: false
+  branches:
+    include:
+      - main
+      - develop
 
 resources:
   repositories:

--- a/trigger-OneBranch-Buddy.yml
+++ b/trigger-OneBranch-Buddy.yml
@@ -1,12 +1,8 @@
 trigger: none
 
 pr:
-  autoCancel: true
-  drafts: false
-  branches:
-    include:
-      - main
-      - develop
+- main
+- develop
 
 resources:
   repositories:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f206f56d-3a29-44dd-82a6-6e6c7b0da7d3)
![image](https://github.com/user-attachments/assets/05a37ffb-e5a6-48cf-8924-f51a296fea1f)
 Exclude CollectionsExtensions class from Microsoft.Extensions.DependencyModel.dll in mdoc as a workaround