### PR TITLE
#945509 Support ref readonly parameters

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -49,6 +49,7 @@ namespace Mono.Documentation
         public const string CompilerGeneratedAttribute = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
         public const string IsByRefLikeAttribute = "System.Runtime.CompilerServices.IsByRefLikeAttribute";
         public const string IsReadOnlyAttribute = "System.Runtime.CompilerServices.IsReadOnlyAttribute";
+        public const string RequiresLocationAttribute = "System.Runtime.CompilerServices.RequiresLocationAttribute";
         public const string InAttribute = "System.Runtime.InteropServices.InAttribute";
         public const string OutAttribute = "System.Runtime.InteropServices.OutAttribute";
         public const string TupleElementNamesAttribute = "System.Runtime.CompilerServices.TupleElementNamesAttribute";

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -610,7 +610,7 @@ namespace Mono.Documentation.Updater.Formatters
         protected override StringBuilder AppendParameter(StringBuilder buf, ParameterDefinition parameter)
         {
             TypeReference parameterType = parameter.ParameterType;
-            var refType = new BitArray(3);
+            var refType = new BitArray(4);
 
             if (parameter.HasCustomAttributes)
             {
@@ -641,6 +641,10 @@ namespace Mono.Documentation.Updater.Formatters
                 {
                     refType.Set(0, true);
                 }
+                else if (parameter.IsIn && DocUtils.HasCustomAttribute(parameter, Consts.RequiresLocationAttribute))
+                {
+                    refType.Set(3, true);
+                }
                 else
                 {
                     refType.Set(2, true);
@@ -648,7 +652,7 @@ namespace Mono.Documentation.Updater.Formatters
                 parameterType = byReferenceType.ElementType;
             }
 
-            buf.Append(refType.Get(0) ? "in " : (refType.Get(1) ? "out " : (refType.Get(2) ? "ref ": "")));
+            buf.Append(refType.Get(0) ? "in " : (refType.Get(1) ? "out " : (refType.Get(2) ? "ref ": (refType.Get(3) ? "ref readonly " : ""))));
 
             if (parameter.HasCustomAttributes)
             {

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -601,6 +601,14 @@ namespace mdoc.Test
             TestEventSignature(staticVirtualMemberDllPath, typeFullName, eventName, expectedSignature);
         }
 
+        [TestCase("MethodWithRefReadonlyParam", "public void MethodWithRefReadonlyParam (ref readonly int i);")]
+        public void CSharpRefReadonlyTest(string methodName, string expectedSignature)
+        {
+            var method = GetMethod(typeof(SampleClasses.SomeClass), m => m.Name == methodName);
+            var methodSignature = formatter.GetDeclaration(method);
+            Assert.AreEqual(expectedSignature, methodSignature);
+        }
+
         #region Helper Methods
         string RealTypeName(string name){
             switch (name) {

--- a/mdoc/mdoc.Test/SampleClasses/SomeClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/SomeClass.cs
@@ -104,6 +104,10 @@ namespace mdoc.Test.SampleClasses
             throw new PlatformNotSupportedException();
         }
 
+        public void MethodWithRefReadonlyParam(ref readonly int i)
+        {
+        }
+
         public event EventHandler<object> AppMemoryUsageIncreased;
         public static event EventHandler<object> StaticEvent;
         private static event EventHandler<object> PrivateEvent;


### PR DESCRIPTION
Work item: https://ceapex.visualstudio.com/Engineering/_workitems/edit/945509

Add support for correct rendering of "ref readonly" parameter in C# method signature documentation.

Added one unit test and also verified output against the case mentioned in the work item (https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.unsafe.asref?view=net-8.0#system-runtime-compilerservices-unsafe-asref-1%28-0@%29 should render with `scoped ref readonly T source` instead of `scoped ref T source`.

I couldn't get the C++ tests running but they appear to be out of scope here.