### PR TITLE
C# signatures for new operators

### DIFF
--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -392,6 +392,9 @@ namespace Mono.Documentation.Updater.Formatters
                 methodName = ifaceMethod.Name;
             }
 
+            // TODO this is liable to register false positives, but that's only likely to happen
+            // in an adversarial situation. Operators have to be public static, with the
+            // specialname bit set, with the right parameters for the type of operation.
             if (methodName.StartsWith("op_", StringComparison.Ordinal))
             {
                 // this is an operator
@@ -399,6 +402,7 @@ namespace Mono.Documentation.Updater.Formatters
                 {
                     case "op_Implicit":
                     case "op_Explicit":
+                    case "op_CheckedExplicit":
                         buf.Length--; // remove the last space, which assumes a member name is coming
                         return buf;
                     case "op_Addition":
@@ -447,6 +451,22 @@ namespace Mono.Documentation.Updater.Formatters
                         return buf.Append("operator >");
                     case "op_GreaterThanOrEqual":
                         return buf.Append("operator >=");
+                    case "op_UnsignedRightShift":
+                        return buf.Append("operator >>>");
+                    case "op_CheckedIncrement":
+                        return buf.Append("operator checked ++");
+                    case "op_CheckedDecrement":
+                        return buf.Append("operator checked --");
+                    case "op_CheckedUnaryNegation":
+                        return buf.Append("operator checked -");
+                    case "op_CheckedAddition":
+                        return buf.Append("operator checked +");
+                    case "op_CheckedSubtraction":
+                        return buf.Append("operator checked -");
+                    case "op_CheckedMultiply":
+                        return buf.Append("operator checked *");
+                    case "op_CheckedDivision":
+                        return buf.Append("operator checked /");
                     default:
                         return buf.Append(methodName);
                 }
@@ -535,6 +555,9 @@ namespace Mono.Documentation.Updater.Formatters
                 modifiers += buf.Length == 0 ? "readonly" : " readonly";
             }
 
+            // TODO this is liable to register false positives, but that's only likely to happen
+            // in an adversarial situation. Operators have to be public static, with the
+            // specialname bit set, with the right parameters for the type of operation.
             switch (method.Name)
             {
                 case "op_Implicit":
@@ -542,6 +565,9 @@ namespace Mono.Documentation.Updater.Formatters
                     break;
                 case "op_Explicit":
                     modifiers += " explicit operator";
+                    break;
+                case "op_CheckedExplicit":
+                    modifiers += " explicit operator checked";
                     break;
             }
 

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -81,6 +81,26 @@ namespace mdoc.Test
             TestBinaryOp ("RightShift", ">>", secondType: "int");
 
         [Test]
+        public void CSharp_op_UnsignedRightShift () =>
+            TestBinaryOp("UnsignedRightShift", ">>>", secondType: "int");
+
+        [Test]
+        public void CSharp_op_CheckedAddition () =>
+           TestBinaryOp("CheckedAddition", "checked +");
+
+        [Test]
+        public void CSharp_op_CheckedSubtraction () =>
+           TestBinaryOp("CheckedSubtraction", "checked -");
+
+        [Test]
+        public void CSharp_op_CheckedMultiply () =>
+           TestBinaryOp("CheckedMultiply", "checked *");
+
+        [Test]
+        public void CSharp_op_CheckedDivision () =>
+           TestBinaryOp("CheckedDivision", "checked /");
+
+        [Test]
         public void CSharp_op_UnaryPlus () =>
 			TestUnaryOp ("UnaryPlus", "+");
 
@@ -111,6 +131,18 @@ namespace mdoc.Test
 		[Test]
 		public void CSharp_op_False () =>
             TestUnaryOp ("False", "false", returnType: "bool");
+
+        [Test]
+        public void CSharp_op_CheckedIncrement () =>
+           TestUnaryOp("CheckedIncrement", "checked ++");
+
+        [Test]
+        public void CSharp_op_CheckedDecrement () =>
+           TestUnaryOp("CheckedDecrement", "checked --");
+
+        [Test]
+        public void CSharp_op_CheckedUnaryNegation () =>
+           TestUnaryOp("CheckedUnaryNegation", "checked -");
 
         [Test]
         public void CSharp_op_Equality () =>
@@ -151,6 +183,14 @@ namespace mdoc.Test
         [Test]
         public void CSharp_op_Explicit_inverse () =>
             TestConversionOp ("Explicit", "explicit", "TestClass", "int");
+
+        [Test]
+        public void CSharp_op_Explicit_checked () =>
+            TestConversionOp("CheckedExplicit", "explicit", "int", "TestClass");
+
+        [Test]
+        public void CSharp_op_Explicit_checked_inverse () =>
+            TestConversionOp("CheckedExplicit", "explicit", "TestClass", "int");
 
         [Test]
         public void CSharp_modopt () =>
@@ -538,7 +578,7 @@ namespace mdoc.Test
 
         [TestCase("StaticVirtualMembers.StaticVirtualMemberInInterface`3", "StaticVirtualMethod", "public static virtual int StaticVirtualMethod (int left, int right);")]
         [TestCase("StaticVirtualMembers.StaticVirtualMemberInInterface`3", "op_Addition", "public static abstract TResult operator + (TSelf left, TOther right);")]
-        [TestCase("StaticVirtualMembers.StaticVirtualMemberInInterface`3", "op_CheckedAddition", "public static virtual TResult op_CheckedAddition (TSelf left, TOther right);")]
+        [TestCase("StaticVirtualMembers.StaticVirtualMemberInInterface`3", "op_CheckedAddition", "public static virtual TResult operator checked + (TSelf left, TOther right);")]
         [TestCase("StaticVirtualMembers.InterfaceI`1", "M", "public static abstract void M ();")]
         [TestCase("StaticVirtualMembers.InterfaceI`1", "M1", "public static virtual void M1 ();")]
         [TestCase("StaticVirtualMembers.InterfaceI`1", "op_Addition", "public static abstract T operator + (T l, T r);")]
@@ -546,7 +586,7 @@ namespace mdoc.Test
         [TestCase("StaticVirtualMembers.InterfaceI`1", "op_Inequality", "public static abstract bool operator != (T l, T r);")]
         [TestCase("StaticVirtualMembers.InterfaceI`1", "op_Implicit", "public static abstract implicit operator T (string s);")]
         [TestCase("StaticVirtualMembers.InterfaceI`1", "op_Explicit", "public static abstract explicit operator string (T t);")]
-        [TestCase("StaticVirtualMembers.InterfaceI`1", "op_CheckedAddition", "public static virtual T op_CheckedAddition (T l, T r);")]
+        [TestCase("StaticVirtualMembers.InterfaceI`1", "op_CheckedAddition", "public static virtual T operator checked + (T l, T r);")]
         public void CSharpStaticVirtualMethodTest(string typeFullName, string methodName, string expectedSignature)
         {
             var staticVirtualMemberDllPath = "../../../../external/Test/StaticVirtualMembers.dll";
@@ -612,7 +652,7 @@ namespace mdoc.Test
 
 
         void TestConversionOp (string name, string type, string leftType, string rightType) {
-            TestOp (name, $"public static {type} operator {leftType} ({rightType} c1);", argCount: 1, returnType: leftType);
+            TestOp (name, $"public static {type} operator {(name.StartsWith("Checked") ? "checked " : "")}{leftType} ({rightType} c1);", argCount: 1, returnType: leftType);
         }
 
         void TestComparisonOp (string name, string op)

--- a/mdoc/mdoc.Test/SampleClasses/TestClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/TestClass.cs
@@ -14,6 +14,9 @@ namespace mdoc.Test.SampleClasses
         public static TestClass operator ~ (TestClass c1) { return new TestClass (); }
         public static TestClass operator ++ (TestClass c1) { return new TestClass (); }
         public static TestClass operator -- (TestClass c1) { return new TestClass (); }
+        public static TestClass operator checked ++ (TestClass c1) { return new TestClass (); }
+        public static TestClass operator checked -- (TestClass c1) { return new TestClass (); }
+        public static TestClass operator checked - (TestClass c1) { return new TestClass (); }
 
         // Binary Operators
         public static TestClass operator + (TestClass c1, TestClass c2) { return new TestClass (); }
@@ -26,6 +29,11 @@ namespace mdoc.Test.SampleClasses
         public static TestClass operator ^ (TestClass c1, TestClass c2) { return new TestClass (); }
         public static TestClass operator << (TestClass c1, int c2) { return new TestClass (); }
         public static TestClass operator >> (TestClass c1, int c2) { return new TestClass (); }
+        public static TestClass operator >>> (TestClass c1, int c2) { return new TestClass(); }
+        public static TestClass operator checked * (TestClass c1, TestClass c2) { return new TestClass(); }
+        public static TestClass operator checked / (TestClass c1, TestClass c2) { return new TestClass(); }
+        public static TestClass operator checked + (TestClass c1, TestClass c2) { return new TestClass(); }
+        public static TestClass operator checked - (TestClass c1, TestClass c2) { return new TestClass(); }
 
         // Comparison Operators
         public static bool operator true (TestClass c1) { return false; }
@@ -42,6 +50,8 @@ namespace mdoc.Test.SampleClasses
         public static implicit operator TestClass (TestClassTwo c1) { return new TestClass (); }
         public static explicit operator int (TestClass c1) { return 0; }
         public static explicit operator TestClass (int c1) { return new TestClass (); }
+        public static explicit operator checked TestClass (int c1) { return new TestClass (); }
+        public static explicit operator checked int (TestClass c1) { return 0; }
 
         public void DoSomethingWithParams (params int[] values) { }
         public void RefAndOut (ref int a, out int b) { b = 1; }


### PR DESCRIPTION
Work items:

- https://ceapex.visualstudio.com/Engineering/_workitems/edit/722484
- https://ceapex.visualstudio.com/Engineering/_workitems/edit/722491

Implement correct C# method signature output for the newer operators that currently aren't implemented: unsigned right shift and all of the checked operators.

Added unit tests and tested locally against the types mentioned in the work items (BigInteger and Int128).

As with #710, I was unable to get C++ tests running, but nothing in that codepath should be affected.