### PR TITLE
Fix bug : Cross reference not found: 'System.IDisposable.Close'.

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
     public static class Consts
     {
-        public static string MonoVersion = "5.9.3.6";
+        public static string MonoVersion = "5.9.3.7";
         public const string DocId = "DocId";
         public const string CppCli = "C++ CLI";
         public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
@@ -156,12 +156,7 @@ namespace Mono.Documentation.Updater
 
         protected override string GetTypeName(TypeReference type, IAttributeParserContext context, bool appendGeneric = true, bool useTypeProjection = false, bool isTypeofOperator = false)
         {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            var typeName = _AppendTypeName(new StringBuilder(type.Name.Length), type, context, appendGeneric, false, isTypeofOperator).ToString();
-
-            return RemoveMod(typeName);
+            return base.GetTypeName(type, context, appendGeneric, false, isTypeofOperator);
         }
 
         private string GetMethodDefinitionName (MethodReference method, string name)

--- a/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
@@ -154,6 +154,16 @@ namespace Mono.Documentation.Updater
             return GetMethodDefinitionName (method, name);
         }
 
+        protected override string GetTypeName(TypeReference type, IAttributeParserContext context, bool appendGeneric = true, bool useTypeProjection = false, bool isTypeofOperator = false)
+        {
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+
+            var typeName = _AppendTypeName(new StringBuilder(type.Name.Length), type, context, appendGeneric, false, isTypeofOperator).ToString();
+
+            return RemoveMod(typeName);
+        }
+
         private string GetMethodDefinitionName (MethodReference method, string name)
         {
             StringBuilder buf = new StringBuilder ();

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.9.3.6</version>
+    <version>5.9.3.7</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
**Fix bug : Cross reference not found: 'System.IDisposable.Close'.**
WorkItem : https://ceapex.visualstudio.com/Engineering/_workitems/edit/1018526

**Before the problem was fixed**
![image](https://github.com/user-attachments/assets/faadb031-6fd9-460a-949e-d9b19d1018c8)
![image](https://github.com/user-attachments/assets/56e2eedc-7383-4fe8-881c-681aa6acaf76)


**After fixing the problem**
System.IDisposable.Close disappeared, and the rest of the xref-not-found were actually only about 40 or so, because the count was by word, and there were multiple identical words in a row.
![image](https://github.com/user-attachments/assets/eb2f7003-c2fd-4d82-b3df-b737ad85b3a8)
