### PR TITLE
Reorder children of <Docs>

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
     public static class Consts
     {
-        public static string MonoVersion = "5.9.3.6";
+        public static string MonoVersion = "5.9.3.7";
         public const string DocId = "DocId";
         public const string CppCli = "C++ CLI";
         public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -3479,7 +3479,7 @@ namespace Mono.Documentation
         }
 
         static readonly string[] DocsNodeOrder = {
-        "typeparam", "param", "summary", "returns", "value", "remarks",
+        "summary", "typeparam", "param", "returns", "value", "remarks",
     };
 
         private static void OrderDocsNodes (XmlNode docs, XmlNodeList children)

--- a/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/SlashDocMemberFormatter.cs
@@ -154,6 +154,11 @@ namespace Mono.Documentation.Updater
             return GetMethodDefinitionName (method, name);
         }
 
+        protected override string GetTypeName(TypeReference type, IAttributeParserContext context, bool appendGeneric = true, bool useTypeProjection = false, bool isTypeofOperator = false)
+        {
+            return base.GetTypeName(type, context, appendGeneric, false, isTypeofOperator);
+        }
+
         private string GetMethodDefinitionName (MethodReference method, string name)
         {
             StringBuilder buf = new StringBuilder ();

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.9.3.6</version>
+    <version>5.9.3.7</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
For https://ceapex.visualstudio.com/Engineering/_workitems/edit/654741/

Content devs would prefer <summary> to be the first child of <Docs> for ergonomic reasons.