### PR TITLE
Fix Recursion for C# Formatter for ValueTuple

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
     public static class Consts
     {
-        public static string MonoVersion = "5.9.6";
+        public static string MonoVersion = "5.9.7";
         public const string DocId = "DocId";
         public const string CppCli = "C++ CLI";
         public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -152,9 +152,8 @@ namespace Mono.Documentation.Updater.Formatters
                 var genArgTypeList = new List<string>();
                 // tuple element names should be traversed before recursion.
                 var genArgNameList = genInst.GenericArguments.Select(arg => context.GetTupleElementName()).ToList();
-                for (int index = 0; index < genInst.GenericArguments.Count; index++)
+                foreach (var item in genInst.GenericArguments)
                 {
-                    var item = genInst.GenericArguments[index];
                     var isNullableType = false;
                     if (!item.IsValueType)
                     {

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -164,6 +164,8 @@ namespace Mono.Documentation.Updater.Formatters
                     var underlyingTypeName = GetTypeName(item, context, appendGeneric, useTypeProjection) + GetTypeNullableSymbol(item, isNullableType);
                     genArgTypeList.Add(underlyingTypeName);
                 }
+
+                // System.ValueTuple with more than 7 generic arguments is represented as nested ValueTuple, with the 8th generic argument being another ValueTuple for the rest of the tuple elements.
                 const int restTupleIndex = 7;
                 var restTuple = genInst.GenericArguments.Count > restTupleIndex ? genInst.GenericArguments[restTupleIndex] as GenericInstanceType : null;
                 if (restTuple != null && restTuple.Name.StartsWith("ValueTuple`"))

--- a/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
+++ b/mdoc/Mono.Documentation/Updater/Formatters/CSharpFullMemberFormatter.cs
@@ -146,26 +146,41 @@ namespace Mono.Documentation.Updater.Formatters
                 return buf;
             }
 
-            if (genInst.Name.StartsWith ("ValueTuple`"))
+            if (genInst.Name.StartsWith("ValueTuple`"))
             {
-                buf.Append ("(");
-                var genArgTypeList = new List<string> ();
+                buf.Append("(");
+                var genArgTypeList = new List<string>();
                 // tuple element names should be traversed before recursion.
                 var genArgNameList = genInst.GenericArguments.Select(arg => context.GetTupleElementName()).ToList();
-                foreach (var item in genInst.GenericArguments)
+                for (int index = 0; index < genInst.GenericArguments.Count; index++)
                 {
+                    var item = genInst.GenericArguments[index];
                     var isNullableType = false;
                     if (!item.IsValueType)
                     {
-                        isNullableType = context.IsNullable ();
+                        isNullableType = context.IsNullable();
                     }
 
-                    var underlyingTypeName = GetTypeName (item, context, appendGeneric, useTypeProjection) + GetTypeNullableSymbol (item, isNullableType);
-                    genArgTypeList.Add (underlyingTypeName);
+                    var underlyingTypeName = GetTypeName(item, context, appendGeneric, useTypeProjection) + GetTypeNullableSymbol(item, isNullableType);
+                    genArgTypeList.Add(underlyingTypeName);
                 }
-                var genArgList = genInst.GenericArguments.Select((_, index) => string.Format("{0}{1}", genArgTypeList[index], genArgNameList[index] == null ? String.Empty : (" " + genArgNameList[index])));
-                buf.Append (string.Join (", ", genArgList));
-                buf.Append (")");
+                const int restTupleIndex = 7;
+                var restTuple = genInst.GenericArguments.Count > restTupleIndex ? genInst.GenericArguments[restTupleIndex] as GenericInstanceType : null;
+                if (restTuple != null && restTuple.Name.StartsWith("ValueTuple`"))
+                {
+                    // Build T1..T7 part, then inline the rest tuple by stripping its leading "(".
+                    // The rest tuple's trailing ")" becomes the closing paren for the outer tuple.
+                    var mainArgList = Enumerable.Range(0, restTupleIndex).Select(index => string.Format("{0}{1}", genArgTypeList[index], genArgNameList[index] == null ? String.Empty : (" " + genArgNameList[index])));
+                    buf.Append(string.Join(", ", mainArgList));
+                    buf.Append(", ");
+                    buf.Append(genArgTypeList[restTupleIndex].Substring(1));
+                }
+                else
+                {
+                    var genArgList = genInst.GenericArguments.Select((_, index) => string.Format("{0}{1}", genArgTypeList[index], genArgNameList[index] == null ? String.Empty : (" " + genArgNameList[index])));
+                    buf.Append(string.Join(", ", genArgList));
+                    buf.Append(")");
+                }
                 return buf;
             }
 

--- a/mdoc/mdoc.Test/FormatterTests.cs
+++ b/mdoc/mdoc.Test/FormatterTests.cs
@@ -473,6 +473,8 @@ namespace mdoc.Test
 
         [TestCase("TupleMethod", "public (int a, int, int b) TupleMethod ((int, int) t1, (int b, int c, int d) t2, (int, int) t3);")]
         [TestCase("RecursiveTupleMethod", "public ((int a, long b) c, int d) RecursiveTupleMethod ((((int a, long) b, string c) d, (int e, (float f, float g) h) i, int j) t);")]
+        [TestCase("EightTupleMethod", "public static (T1, T2, T3, T4, T5, T6, T7, T8) EightTupleMethod<T3,T4,T5,T6,T7,T8> (T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8);")]
+        [TestCase("SeventeenTupleMethod", "public static (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) SeventeenTupleMethod<T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17> (T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8, T9 item9, T10 item10, T11 item11, T12 item12, T13 item13, T14 item14, T15 item15, T16 item16, T17 item17);")]
         public void CSharpTupleNamesMethodTest(string methodName, string expectedSignature)
         {
             var method = GetMethod(typeof(SampleClasses.TupleNamesTestClass<,>), m => m.Name == methodName);

--- a/mdoc/mdoc.Test/SampleClasses/TupleNamesTestClass.cs
+++ b/mdoc/mdoc.Test/SampleClasses/TupleNamesTestClass.cs
@@ -12,6 +12,12 @@ namespace mdoc.Test.SampleClasses
 
         public ((int a, long b) c, int d) RecursiveTupleMethod((((int a, long) b, string c) d, (int e, (float f, float g) h) i, int j) t) => (t.d.b, t.j);
 
+        public static (T1, T2, T3, T4, T5, T6, T7, T8) EightTupleMethod<T3, T4, T5, T6, T7, T8>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8)
+            => (item1, item2, item3, item4, item5, item6, item7, item8);
+
+        public static (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) SeventeenTupleMethod<T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, T8 item8, T9 item9, T10 item10, T11 item11, T12 item12, T13 item13, T14 item14, T15 item15, T16 item16, T17 item17)
+    => (item1, item2, item3, item4, item5, item6, item7, item8, item9, item10, item11, item12, item13, item14, item15, item16, item17);
+
         public int CompareTo((T1, T2) other)
         {
             throw new NotImplementedException();

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.9.6</version>
+    <version>5.9.7</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
Resolves [#11939](https://github.com/dotnet/dotnet-api-docs/issues/11939).

Summary: 
- Fixed C# Formatter to correctly address System.ValueTuple nested ValueTuple structure, where there are more than 7 required fields, it takes the recursive structure: System.ValueTuple<T1, ..., T7, TRest>
- Added unit test cases to validate this change
- Tested this locally with System.ValueTuple.dll, comparing the generated xmls before and after the change. Change in xml file is as expected. 