### PR TITLE
Fix docsnode ordering (#746)

### DIFF
--- a/mdoc/Consts.cs
+++ b/mdoc/Consts.cs
@@ -3,7 +3,7 @@ namespace Mono.Documentation
 {
     public static class Consts
     {
-        public static string MonoVersion = "5.9.7";
+        public static string MonoVersion = "5.9.8";
         public const string DocId = "DocId";
         public const string CppCli = "C++ CLI";
         public const string CppCx = "C++ CX";

--- a/mdoc/Mono.Documentation/MDocUpdater.cs
+++ b/mdoc/Mono.Documentation/MDocUpdater.cs
@@ -1178,7 +1178,7 @@ namespace Mono.Documentation
                 SortXmlNodes (namespaces[i], namespaces[i].SelectNodes ("Type"), c);
         }
 
-        private static void SortXmlNodes (XmlNode parent, XmlNodeList children, XmlNodeComparer comparer)
+        internal static void SortXmlNodes (XmlNode parent, XmlNodeList children, XmlNodeComparer comparer)
         {
             MyXmlNodeList l = new MyXmlNodeList (children.Count);
             for (int i = 0; i < children.Count; ++i)
@@ -3474,15 +3474,19 @@ namespace Mono.Documentation
                     i.ImportDocumentation (info);
             }
 
+
+            SortXmlNodes(e, e.SelectNodes("altmember"), new CrefComparer());
+
             OrderDocsNodes (e, e.ChildNodes);
             NormalizeWhitespace (e);
         }
 
         static readonly string[] DocsNodeOrder = {
         "typeparam", "param", "summary", "returns", "value", "remarks",
+        "exception", "permission", "altmember", "related",
     };
 
-        private static void OrderDocsNodes (XmlNode docs, XmlNodeList children)
+        internal static void OrderDocsNodes (XmlNode docs, XmlNodeList children)
         {
             ReorderNodes (docs, children, DocsNodeOrder);
         }
@@ -3587,7 +3591,7 @@ namespace Mono.Documentation
                     paramref.SetAttribute ("name", newName);
         }
 
-        class CrefComparer : XmlNodeComparer
+        internal class CrefComparer : XmlNodeComparer
         {
 
             public override int Compare (XmlNode x, XmlNode y)

--- a/mdoc/mdoc.Test/MDocUpdaterTests.cs
+++ b/mdoc/mdoc.Test/MDocUpdaterTests.cs
@@ -253,5 +253,69 @@ namespace mdoc.Test
             Assert.IsTrue(File.Exists(Path.Combine(outputDir, "index.xml")));
             Assert.IsTrue(File.Exists(Path.Combine(outputDir, "ns-TestLibrary.xml")));
         }
+
+        // Tests for the deterministic <altmember> ordering applied in MDocUpdater.MakeDocNode:
+        // SortXmlNodes(..., new CrefComparer()) followed by OrderDocsNodes (DocsNodeOrder).
+        static XmlElement LoadDocs(string innerXml)
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml("<Docs>" + innerXml + "</Docs>");
+            return doc.DocumentElement;
+        }
+
+        static void ApplyAltMemberOrdering(XmlElement docs)
+        {
+            MDocUpdater.SortXmlNodes(docs, docs.SelectNodes("altmember"), new MDocUpdater.CrefComparer());
+            MDocUpdater.OrderDocsNodes(docs, docs.ChildNodes);
+        }
+
+        [Test]
+        public void MakeDocNode_AltMembers_AreSortedByCref()
+        {
+            var docs = LoadDocs(@"
+                <summary>s</summary>
+                <altmember cref='T:System.B' />
+                <altmember cref='T:System.A' />
+                <altmember cref='M:Other.Ns.X' />");
+
+            ApplyAltMemberOrdering(docs);
+
+            var crefs = docs.SelectNodes("altmember")
+                .Cast<XmlElement>()
+                .Select(e => e.GetAttribute("cref"))
+                .ToArray();
+
+            // CrefComparer orders by namespace first, then full cref.
+            CollectionAssert.AreEqual(
+                new[] { "M:Other.Ns.X", "T:System.A", "T:System.B" },
+                crefs);
+        }
+
+        [Test]
+        public void MakeDocNode_AltMembers_AreContiguousBetweenPermissionAndRelated()
+        {
+            var docs = LoadDocs(@"
+                <summary>s</summary>
+                <altmember cref='T:System.B' />
+                <exception cref='T:System.E1'>e1</exception>
+                <altmember cref='T:System.A' />
+                <permission cref='T:System.P'>p</permission>
+                <altmember cref='M:Other.Ns.X' />
+                <related>r</related>");
+
+            ApplyAltMemberOrdering(docs);
+
+            var names = docs.ChildNodes.Cast<XmlNode>().Select(n => n.Name).ToArray();
+            int firstAlt = System.Array.IndexOf(names, "altmember");
+            int lastAlt = System.Array.LastIndexOf(names, "altmember");
+            int lastPerm = System.Array.LastIndexOf(names, "permission");
+            int firstRel = System.Array.IndexOf(names, "related");
+
+            // All three altmembers form a single contiguous block...
+            Assert.AreEqual(3, lastAlt - firstAlt + 1, "altmembers should be contiguous");
+            // ...sitting after permission and before related per DocsNodeOrder.
+            Assert.Greater(firstAlt, lastPerm, "altmember block must come after permission");
+            Assert.Less(lastAlt, firstRel, "altmember block must come before related");
+        }
     }
 }

--- a/mdoc/mdoc.nuspec
+++ b/mdoc/mdoc.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>mdoc</id>
-    <version>5.9.7</version>
+    <version>5.9.8</version>
     <title>mdoc</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
* test: unit test cases still pass after adding change

* test: trigger pipeline

* test: trigger pipeline from local

* test: from vsc

* test: without draft

* chore: add correct docsnodeorder

* docs: remove unnecessary comments

* test: add test cases

* chore: update version to 5.9.8

* chore: update to 5.9.8